### PR TITLE
Add spacing utility classes, output less duplicate CSS

### DIFF
--- a/src/scss/_tokens.scss
+++ b/src/scss/_tokens.scss
@@ -13,11 +13,11 @@ $CSS_CORNER_ALIAS: (
 );
 
 $breakpoint-aliases: (
-  tiny: $mq-tiny,
-  small: $mq-small,
-  narrow: $mq-narrow,
-  medium: $mq-medium,
-  wide: $mq-wide,
+  xs: $mq-tiny,
+  sm: $mq-small,
+  // narrow: $mq-narrow,
+  md: $mq-medium,
+  lg: $mq-wide,
 );
 
 $spacers: (

--- a/src/scss/_tokens.scss
+++ b/src/scss/_tokens.scss
@@ -1,0 +1,54 @@
+$CSS_EDGE_ALIAS: (
+  t: top,
+  r: right,
+  b: bottom,
+  l: left,
+);
+
+$CSS_CORNER_ALIAS: (
+  tr: top-right,
+  br: bottom-right,
+  bl: bottom-left,
+  tl: top-left,
+);
+
+$breakpoint-aliases: (
+  tiny: $mq-tiny,
+  small: $mq-small,
+  narrow: $mq-narrow,
+  medium: $mq-medium,
+  wide: $mq-wide,
+);
+
+$spacers: (
+  0: 0,
+  1: 10px,
+  2: 20px,
+  3: 40px,
+  4: 64px,
+  5: 96px,
+) !default;
+
+$breakpoint-variants: ('': null, );
+
+@each $key, $value in $breakpoint-aliases {
+  $breakpoint-variants: map-merge($breakpoint-variants, ('-#{$key}': $value, ));
+}
+
+@function spacer($index) {
+  @return map-get($spacers, $index);
+}
+
+@mixin breakpoint($name) {
+  $threshold: map-get($breakpoint-aliases, $name);
+
+  @if $threshold {
+    @media screen and (min-width: $threshold) {
+      @content;
+    }
+  }
+
+  @else {
+    @content;
+  }
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,9 +1,11 @@
 @import "sf-design-system/src/components/00-design-tokens/_variables.scss";
 @import "sf-design-system/src/components/00-design-tokens/_colors.scss";
-@import "sf-design-system/src/components/00-design-tokens/_functions.scss";
-@import "sf-design-system/src/components/00-design-tokens/_mixins.scss";
-@import "sf-design-system/src/components/00-design-tokens/_typography-mixins.scss";
-@import "sf-design-system/src/components/00-design-tokens/_base.scss";
+// @import "sf-design-system/src/components/00-design-tokens/_functions.scss";
+// @import "sf-design-system/src/components/00-design-tokens/_mixins.scss";
+// @import "sf-design-system/src/components/00-design-tokens/_typography-mixins.scss";
+// @import "sf-design-system/src/components/00-design-tokens/_base.scss";
 @import "sf-design-system/src/components/00-design-tokens/_breakpoints.scss";
-@import "sf-design-system/src/components/00-design-tokens/_typography.scss";
+// @import "sf-design-system/src/components/00-design-tokens/_typography.scss";
+@import "./tokens";
+@import "./utilities";
 @import "./debug";

--- a/src/scss/utilities/_spacing.scss
+++ b/src/scss/utilities/_spacing.scss
@@ -15,7 +15,20 @@
           .m#{$variant}#{$alias}-n#{$index} { margin-#{$edge}: -$space !important; }
         }
       }
+
+      @each $alias, $edges in (x: (left, right), y: (top, bottom)) {
+        .m#{$alias}#{$suffix} {
+          @each $edge in $edges {
+            margin-#{$edge}: $space !important;
+          }
+        }
+
+        .p#{$alias}#{$suffix} {
+          @each $edge in $edges {
+            padding-#{$edge}: $space !important;
+          }
+        }
+      }
     }
   }
 }
-

--- a/src/scss/utilities/_spacing.scss
+++ b/src/scss/utilities/_spacing.scss
@@ -1,0 +1,21 @@
+@each $index, $space in $spacers {
+  @each $variant, $threshold in $breakpoint-variants {
+    $suffix: "#{$variant}-#{$index}";
+
+    @include breakpoint($threshold) {
+      .m#{$suffix} { margin: $space !important; }
+      .p#{$suffix} { padding: $space !important; }
+
+      @each $alias, $edge in $CSS_EDGE_ALIAS {
+        .m#{$alias}#{$suffix} { margin-#{$edge}: $space !important; }
+        .p#{$alias}#{$suffix} { padding-#{$edge}: $space !important; }
+
+        @if $space != 0 {
+          // .mt-n1 { margin-top: -$spacers[1]; }, etc.
+          .m#{$variant}#{$alias}-n#{$index} { margin-#{$edge}: -$space !important; }
+        }
+      }
+    }
+  }
+}
+

--- a/src/scss/utilities/index.scss
+++ b/src/scss/utilities/index.scss
@@ -1,0 +1,1 @@
+@import "./spacing";


### PR DESCRIPTION
This introduces spacing utility classes to adjust padding and margin more granularly, without any additional CSS. The pattern is:

- `m-<n>` and `p-<n>` set uniform margin and padding, respectively, where `<n>` is a number from 0 to 5. For instance, `m-1` will set `margin: 10px !important` and `p-2` will set `padding: 20px !important`.
- `m<d>-<n>` and `p<d>-<n>` sets margin and padding, respectively, on one side (`<d>`). For instance, `mb-3` sets 3x margin on the bottom ("b") only.
- `mx-<n>`, `my-<n>`, `px-<n>` and `py-<n>` set margins and padding on both of the horizontal and vertical edges, respectively. (`x` sets `left` and `right`; `y` sets `top` and `bottom`)
- Responsive variants of each utility in the format `<what>-<size>-<n>` can be used to set any directional margin or padding at or above a given viewport width (see below). For instance, to have small-ish horizontal padding by default and then increase it on medium-sized screens, you'd specify `class="px-2 px-md-4"`.

The spacing scale is as follows, but can be easily changed:

https://github.com/SFDigitalServices/formio-sfds/blob/c472f6d5f1bd9b2ab87c52fdbfe1473f71279b9b/src/scss/_tokens.scss#L24-L29

The breakpoint names are as follows, and track somewhat closely with our `$mq-` variables:

https://github.com/SFDigitalServices/formio-sfds/blob/ba83afe5a23d2c9d980989ad6ee011385b8a2178/src/scss/_tokens.scss#L16-L20

I've also commented out all of the unused SCSS imports from `sf-design-system` for now. We can always bring them back or have consuming projects load that CSS separately if we need it.