### PR TITLE
Release 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -42,7 +42,7 @@
  * state in component templates. If we can get that, we can vary
  * the margins of these elements there.
  */
-.form-checkbox ~ .messages:not(:empty) {
+.formio-error-wrapper .form-checkbox .messages {
   margin-top: -1 * spacer(2) !important;
 }
 
@@ -88,6 +88,7 @@ label.field-required,
 // spacing tweaks AHOY
 .formio-component-address,
 .formio-component-email,
+.formio-component-file,
 .formio-component-number,
 .formio-component-radio,
 .formio-component-textfield {
@@ -103,4 +104,11 @@ label.field-required,
     margin-bottom: 0;
     padding-bottom: spacer(2);
   }
+}
+
+.fileSelector {
+  background: $grey-1;
+  border: 1px dotted $grey-3;
+  border-radius: radius(1);
+  padding: spacer(2);
 }

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -91,6 +91,7 @@ label.field-required,
 .formio-component-file,
 .formio-component-number,
 .formio-component-radio,
+.formio-component-selectboxes,
 .formio-component-textfield {
   margin-bottom: spacer(3);
 }

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -98,7 +98,7 @@ label.field-required,
 
 .formio-component-address {
   .formio-component {
-    label { @include small-text; }
+    // label { @include small-text; }
   }
 
   .formio-component-textfield {
@@ -108,8 +108,11 @@ label.field-required,
 }
 
 .fileSelector {
-  background: $grey-1;
-  border: 1px dotted $grey-3;
-  border-radius: radius(1);
+  border: border-width(1) dashed $grey-3;
   padding: spacer(2);
+
+  &.fileDragOver {
+    background-color: $blue-1;
+    border-color: $grey-4;
+  }
 }

--- a/src/scss/utilities/_borders.scss
+++ b/src/scss/utilities/_borders.scss
@@ -21,3 +21,7 @@
 @each $name, $value in $color-map {
   .border-#{"" + $name} { border-color: $value !important; }
 }
+
+.border-collapse {
+  border-collapse: collapse !important;
+}

--- a/src/templates/address/form.ejs
+++ b/src/templates/address/form.ejs
@@ -1,3 +1,3 @@
-<div ref="{{ ctx.nestedKey }}" class="round-1 bg-grey-1 pt-2 px-2">
+<div ref="{{ ctx.nestedKey }}" class="round-1 bg-blue-1 pt-2 px-2">
   {{ ctx.children }}
 </div>

--- a/src/templates/file/form.ejs
+++ b/src/templates/file/form.ejs
@@ -1,7 +1,7 @@
 {% if (!ctx.self.imageUpload) { %}
   {% if (ctx.files.length) { %}
-    <table class="align-left">
-      <thead>
+    <table class="border-collapse align-left">
+      <thead hidden>
         <tr>
           <th class="col-md-{{ ctx.self.hasTypes ? 7 : 9 }}">
             {{ ctx.t('File name') }}
@@ -21,19 +21,20 @@
       </thead>
       <tbody>
         {% ctx.files.forEach(function(file) { %}
+          {% var cellClass = 'bg-green-1 px-2 py-1' %}
           <tr>
-            <td class="pr-1">
+            <td class="{{ cellClass }}">
               {% if (ctx.component.uploadOnly) { %}
                 {{file.originalName || file.name}}
               {% } else { %}
                 <a href="{{file.url || '#'}}" target="_blank" ref="fileLink">{{file.originalName || file.name}}</a>
               {% } %}
             </td>
-            <td class="pr-1">
+            <td class="{{ cellClass }}">
               {{ ctx.fileSize(file.size) }}
             </td>
             {% if (ctx.self.hasTypes && !ctx.disabled) { %}
-              <td class="pr-1">
+              <td class="{{ cellClass }}">
                 <select class="file-type" ref="fileType">
                   {% ctx.component.fileTypes.map(function(type) { %}
                     <option value="{{ type.value }}" {% if (type.label === file.fileType) { %}selected="selected"{% } %}>{{ type.label }}</option>
@@ -42,18 +43,20 @@
               </div>
             {% } %}
             {% if (ctx.self.hasTypes && ctx.disabled) { %}
-              <td class="pr-1">{{file.fileType}}</td>
-            {% } %}
-            {% if (!ctx.disabled) { %}
-              <td>
-                <button
-                  ref="removeLink"
-                  class="p-1 bg-slate-65 fg-white d-flex flex-items-center">
-                  <span data-icon="delete" class="d-flex flex-items-center mr-1"></span>
-                  <span>{{ ctx.t('Remove') }}</span>
-                </button>
+              <td class="{{ cellClass }}">
+                {{ file.fileType }}
               </td>
             {% } %}
+            <td class="pl-1 v-align-center">
+              {% if (!ctx.disabled) { %}
+                <button
+                  ref="removeLink"
+                  aria-label="Remove"
+                  class="m-0 p-1 bg-slate-65 fg-white border-0 d-flex flex-items-center">
+                  <span data-icon="delete" class="d-flex flex-items-center"></span>
+                </button>
+              {% } %}
+            </td>
           </tr>
         {% }) %}
       </tbody>
@@ -98,27 +101,6 @@
     <button class="btn btn-primary" ref="toggleCameraMode">{{ctx.t('Switch to file upload')}}</button>
   {% } %}
 {% } %}
-{% ctx.statuses.forEach(function(status) { %}
-  <div class="file {{ctx.statuses.status === 'error' ? ' has-error' : ''}}">
-    <div class="row">
-      <div class="fileName col-form-label col-sm-10">{{status.originalName}} <i class="{{ctx.iconClass('remove')}}" ref="fileStatusRemove"></i></div>
-      <div class="fileSize col-form-label col-sm-2 text-right">{{ctx.fileSize(status.size)}}</div>
-    </div>
-    <div class="row">
-      <div class="col-sm-12">
-        {% if (status.status === 'progress') { %}
-          <div class="progress">
-            <div class="progress-bar" role="progressbar" aria-valuenow="{{status.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{status.progress}}%">
-              <span class="sr-only">{{status.progress}}% {{ctx.t('Complete')}}</span>
-            </div>
-          </div>
-        {% } else { %}
-          <div class="bg-{{status.status}}">{{ctx.t(status.message)}}</div>
-        {% } %}
-      </div>
-    </div>
-  </div>
-{% }) %}
 {% if (!ctx.component.storage || ctx.support.hasWarning) { %}
   <div class="alert alert-warning">
     {% if (!ctx.component.storage) { %}
@@ -134,4 +116,38 @@
       <p>{{ctx.t("XHR2's upload progress isn't supported.")}}</p>
     {% } %}
   </div>
+{% } %}
+
+{% if (ctx.statuses.length) { %}
+  <table>
+    {% ctx.statuses.forEach(function(status) { %}
+      {% var cellBg = ctx.statuses.status === 'error' ? 'red' : 'yellow' %}
+      {% var cellClass = `bg-${cellBg}-1 px-2 py-1` %}
+      <tr>
+        <td class="{{ cellClass }}">
+          {{ status.originalName }}
+        </td>
+        <td class="{{ cellClass }}">
+          {{ ctx.fileSize(status.size) }}
+        </td>
+        <td class="{{ cellClass }}">
+          {% if (status.status === 'progress') { %}
+            <div class="d-inline-flex bg-grey-4">
+              <div class="bg-green-4" role="progressbar" aria-valuenow="{{ status.progress }}" aria-valuemin="0" aria-valuemax="100" style="height: 1rem; width: {{ status.progress }}%;"></div>
+            </div>
+          {% } else { %}
+            {{ ctx.t(status.message) }}</div>
+          {% } %}
+        </td>
+        <td class="pl-1">
+          <button ref="fileStatusRemove">remove</button>
+        </div>
+          <div class="row">
+            <div class="col-sm-12">
+            </div>
+          </div>
+        </div>
+      </tr>
+    {% }) %}
+  </table>
 {% } %}

--- a/src/templates/file/form.ejs
+++ b/src/templates/file/form.ejs
@@ -1,67 +1,97 @@
 {% if (!ctx.self.imageUpload) { %}
-  {% if (ctx.files.length) { %}
-    <table class="border-collapse align-left">
-      <thead hidden>
+
+  <table class="border-collapse align-left">
+    <thead{% if ((ctx.files.length + ctx.statuses.length) === 0) { %} hidden{% } %}>
+      <tr>
+        <th class="col-md-{{ ctx.self.hasTypes ? 2 : 3 }}">
+          {{ ctx.t('File name') }}
+        </th>
+        <th class="col-md-2">
+          {{ ctx.t('Size') }}
+        </th>
+          <th class="col-md-1">
+            {% if (ctx.self.hasTypes) { %}
+              {{ ctx.t('Type') }}
+            {% } %}
+          </th>
+        {% if (!ctx.disabled) { %}
+          <th><!-- actions --></th>
+        {% } %}
+      </tr>
+    </thead>
+    <tbody>
+
+      {% ctx.files.forEach(function(file) { %}
+        {% var cellClass = 'bg-green-1 px-2 py-1' %}
         <tr>
-          <th class="col-md-{{ ctx.self.hasTypes ? 7 : 9 }}">
-            {{ ctx.t('File name') }}
-          </th>
-          <th class="col-md-2">
-            {{ ctx.t('Size') }}
-          </th>
-          {% if (ctx.self.hasTypes) { %}
-            <th class="col-md-2">
-              {{ ctx.t('Type') }}</strong>
-            </th>
-          {% } %}
-          {% if (!ctx.disabled) { %}
-            <th><!-- actions --></th>
-          {% } %}
-        </tr>
-      </thead>
-      <tbody>
-        {% ctx.files.forEach(function(file) { %}
-          {% var cellClass = 'bg-green-1 px-2 py-1' %}
-          <tr>
-            <td class="{{ cellClass }}">
-              {% if (ctx.component.uploadOnly) { %}
-                {{file.originalName || file.name}}
-              {% } else { %}
-                <a href="{{file.url || '#'}}" target="_blank" ref="fileLink">{{file.originalName || file.name}}</a>
-              {% } %}
-            </td>
-            <td class="{{ cellClass }}">
-              {{ ctx.fileSize(file.size) }}
-            </td>
+          <td class="{{ cellClass }}">
+            {% if (ctx.component.uploadOnly) { %}
+              {{file.originalName || file.name}}
+            {% } else { %}
+              <a href="{{file.url || '#'}}" target="_blank" ref="fileLink">{{file.originalName || file.name}}</a>
+            {% } %}
+          </td>
+          <td class="{{ cellClass }}">
+            {{ ctx.fileSize(file.size) }}
+          </td>
+          <td class="{{ cellClass }}">
             {% if (ctx.self.hasTypes && !ctx.disabled) { %}
-              <td class="{{ cellClass }}">
-                <select class="file-type" ref="fileType">
-                  {% ctx.component.fileTypes.map(function(type) { %}
-                    <option value="{{ type.value }}" {% if (type.label === file.fileType) { %}selected="selected"{% } %}>{{ type.label }}</option>
-                  {% }); %}
-                </select>
-              </div>
+              <select class="file-type" ref="fileType">
+                {% ctx.component.fileTypes.map(function(type) { %}
+                  <option value="{{ type.value }}" {% if (type.label === file.fileType) { %}selected="selected"{% } %}>{{ type.label }}</option>
+                {% }); %}
+              </select>
             {% } %}
             {% if (ctx.self.hasTypes && ctx.disabled) { %}
-              <td class="{{ cellClass }}">
-                {{ file.fileType }}
-              </td>
+              {{ file.fileType }}
             {% } %}
-            <td class="pl-1 v-align-center">
-              {% if (!ctx.disabled) { %}
-                <button
-                  ref="removeLink"
-                  aria-label="Remove"
-                  class="m-0 p-1 bg-slate-65 fg-white border-0 d-flex flex-items-center">
-                  <span data-icon="delete" class="d-flex flex-items-center"></span>
-                </button>
-              {% } %}
-            </td>
-          </tr>
-        {% }) %}
-      </tbody>
-    </table>
-  {% } %}
+          </td>
+          <td class="pl-1">
+            {% if (!ctx.disabled) { %}
+              <button
+                ref="removeLink"
+                aria-label="Remove"
+                class="m-0 p-1 bg-slate-65 fg-white border-0 d-flex flex-items-center">
+                <span data-icon="delete" class="d-flex flex-items-center"></span>
+              </button>
+            {% } %}
+          </td>
+        </tr>
+      {% }) %}
+
+      {% ctx.statuses.forEach(function(status) { %}
+        {% var cellBg = ctx.statuses.status === 'error' ? 'red' : 'yellow' %}
+        {% var cellClass = 'bg-' + cellBg + '-1 px-2 py-1' %}
+        <tr>
+          <td class="{{ cellClass }}">
+            {{ status.originalName }}
+          </td>
+          <td class="{{ cellClass }}">
+            {{ ctx.fileSize(status.size) }}
+          </td>
+          <td class="{{ cellClass }}">
+            {% if (status.status === 'progress') { %}
+              <div class="d-inline-flex bg-grey-3" style="min-width: 5rem; height: 1rem;">
+                <div class="bg-green-3" role="progressbar" aria-valuenow="{{ status.progress }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ status.progress }}%;"></div>
+              </div>
+            {% } else { %}
+              {{ ctx.t(status.message) }}
+            {% } %}
+          </td>
+          <td class="pl-1">
+            <button class="m-0" ref="fileStatusRemove">remove</button>
+          </div>
+            <div class="row">
+              <div class="col-sm-12">
+              </div>
+            </div>
+          </div>
+        </tr>
+      {% }) %}
+
+    </tbody>
+  </table>
+
 {% } else { %}
   <div>
     {% ctx.files.forEach(function(file) { %}
@@ -76,6 +106,7 @@
     {% }) %}
   </div>
 {% } %}
+
 {% if (!ctx.disabled && (ctx.component.multiple || !ctx.files.length)) { %}
   {% if (ctx.self.useWebViewCamera) { %}
     <div class="fileSelector">
@@ -116,38 +147,4 @@
       <p>{{ctx.t("XHR2's upload progress isn't supported.")}}</p>
     {% } %}
   </div>
-{% } %}
-
-{% if (ctx.statuses.length) { %}
-  <table>
-    {% ctx.statuses.forEach(function(status) { %}
-      {% var cellBg = ctx.statuses.status === 'error' ? 'red' : 'yellow' %}
-      {% var cellClass = `bg-${cellBg}-1 px-2 py-1` %}
-      <tr>
-        <td class="{{ cellClass }}">
-          {{ status.originalName }}
-        </td>
-        <td class="{{ cellClass }}">
-          {{ ctx.fileSize(status.size) }}
-        </td>
-        <td class="{{ cellClass }}">
-          {% if (status.status === 'progress') { %}
-            <div class="d-inline-flex bg-grey-4">
-              <div class="bg-green-4" role="progressbar" aria-valuenow="{{ status.progress }}" aria-valuemin="0" aria-valuemax="100" style="height: 1rem; width: {{ status.progress }}%;"></div>
-            </div>
-          {% } else { %}
-            {{ ctx.t(status.message) }}</div>
-          {% } %}
-        </td>
-        <td class="pl-1">
-          <button ref="fileStatusRemove">remove</button>
-        </div>
-          <div class="row">
-            <div class="col-sm-12">
-            </div>
-          </div>
-        </div>
-      </tr>
-    {% }) %}
-  </table>
 {% } %}

--- a/src/templates/file/form.ejs
+++ b/src/templates/file/form.ejs
@@ -1,47 +1,64 @@
 {% if (!ctx.self.imageUpload) { %}
-  <ul class="list-group list-group-striped">
-    <li class="list-group-item list-group-header hidden-xs hidden-sm">
-      <div class="row">
-        {% if (!ctx.disabled) { %}
-          <div class="col-md-1"></div>
-        {% } %}
-        <div class="col-md-{% if (ctx.self.hasTypes) { %}7{% } else { %}9{% } %}"><strong>{{ctx.t('File Name')}}</strong></div>
-        <div class="col-md-2"><strong>{{ctx.t('Size')}}</strong></div>
-        {% if (ctx.self.hasTypes) { %}
-          <div class="col-md-2"><strong>{{ctx.t('Type')}}</strong></div>
-        {% } %}
-      </div>
-    </li>
-    {% ctx.files.forEach(function(file) { %}
-      <li class="list-group-item">
-        <div class="row">
+  {% if (ctx.files.length) { %}
+    <table class="align-left">
+      <thead>
+        <tr>
+          <th class="col-md-{{ ctx.self.hasTypes ? 7 : 9 }}">
+            {{ ctx.t('File name') }}
+          </th>
+          <th class="col-md-2">
+            {{ ctx.t('Size') }}
+          </th>
+          {% if (ctx.self.hasTypes) { %}
+            <th class="col-md-2">
+              {{ ctx.t('Type') }}</strong>
+            </th>
+          {% } %}
           {% if (!ctx.disabled) { %}
-            <div class="col-md-1"><i class="{{ctx.iconClass('remove')}}" ref="removeLink"></i></div>
+            <th><!-- actions --></th>
           {% } %}
-          <div class="col-md-{% if (ctx.self.hasTypes) { %}7{% } else { %}9{% } %}">
-            {% if (ctx.component.uploadOnly) { %}
-              {{file.originalName || file.name}}
-            {% } else { %}
-              <a href="{{file.url || '#'}}" target="_blank" ref="fileLink">{{file.originalName || file.name}}</a>
+        </tr>
+      </thead>
+      <tbody>
+        {% ctx.files.forEach(function(file) { %}
+          <tr>
+            <td class="pr-1">
+              {% if (ctx.component.uploadOnly) { %}
+                {{file.originalName || file.name}}
+              {% } else { %}
+                <a href="{{file.url || '#'}}" target="_blank" ref="fileLink">{{file.originalName || file.name}}</a>
+              {% } %}
+            </td>
+            <td class="pr-1">
+              {{ ctx.fileSize(file.size) }}
+            </td>
+            {% if (ctx.self.hasTypes && !ctx.disabled) { %}
+              <td class="pr-1">
+                <select class="file-type" ref="fileType">
+                  {% ctx.component.fileTypes.map(function(type) { %}
+                    <option value="{{ type.value }}" {% if (type.label === file.fileType) { %}selected="selected"{% } %}>{{ type.label }}</option>
+                  {% }); %}
+                </select>
+              </div>
             {% } %}
-          </div>
-          <div class="col-md-2">{{ctx.fileSize(file.size)}}</div>
-          {% if (ctx.self.hasTypes && !ctx.disabled) { %}
-            <div class="col-md-2">
-              <select class="file-type" ref="fileType">
-                {% ctx.component.fileTypes.map(function(type) { %}
-                  <option class="test" value="{{ type.value }}" {% if (type.label === file.fileType) { %}selected="selected"{% } %}>{{ type.label }}</option>
-                {% }); %}
-              </select>
-            </div>
-          {% } %}
-          {% if (ctx.self.hasTypes && ctx.disabled) { %}
-          <div class="col-md-2">{{file.fileType}}</div>
-          {% } %}
-        </div>
-      </li>
-    {% }) %}
-  </ul>
+            {% if (ctx.self.hasTypes && ctx.disabled) { %}
+              <td class="pr-1">{{file.fileType}}</td>
+            {% } %}
+            {% if (!ctx.disabled) { %}
+              <td>
+                <button
+                  ref="removeLink"
+                  class="p-1 bg-slate-65 fg-white d-flex flex-items-center">
+                  <span data-icon="delete" class="d-flex flex-items-center mr-1"></span>
+                  <span>{{ ctx.t('Remove') }}</span>
+                </button>
+              </td>
+            {% } %}
+          </tr>
+        {% }) %}
+      </tbody>
+    </table>
+  {% } %}
 {% } else { %}
   <div>
     {% ctx.files.forEach(function(file) { %}
@@ -63,12 +80,15 @@
       <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> {{ctx.t('Camera')}}</button>
     </div>
   {% } else if (!ctx.self.cameraMode) { %}
-    <div class="fileSelector" ref="fileDrop">
-      <i class="{{ctx.iconClass('cloud-upload')}}"></i> {{ctx.t('Drop files to attach,')}}
-        {% if (ctx.self.imageUpload) { %}
-          <a href="#" ref="toggleCameraMode"><i class="fa fa-camera"></i> {{ctx.t('Use Camera,')}}</a>
-        {% } %}
-        {{ctx.t('or')}} <a href="#" ref="fileBrowse" class="browse">{{ctx.t('browse')}}</a>
+    <div class="my-1">
+      <div class="fileSelector" ref="fileDrop">
+        <div class="align-center">
+          {{ ctx.t('Drop files to attach, or') }}
+          <button class="p-1 ml-1 mr-0 mb-0" ref="fileBrowse">
+            {{ ctx.t('Browse')}}
+          </button>
+        </div>
+      </div>
     </div>
   {% } else { %}
     <div>

--- a/src/templates/file/form.ejs
+++ b/src/templates/file/form.ejs
@@ -3,17 +3,17 @@
   <table class="border-collapse align-left">
     <thead{% if ((ctx.files.length + ctx.statuses.length) === 0) { %} hidden{% } %}>
       <tr>
-        <th class="col-md-{{ ctx.self.hasTypes ? 2 : 3 }}">
+        <th class="col-md-{{ ctx.self.hasTypes ? 2 : 3 }} px-2">
           {{ ctx.t('File name') }}
         </th>
-        <th class="col-md-2">
+        <th class="col-md-2 px-2">
           {{ ctx.t('Size') }}
         </th>
-          <th class="col-md-1">
-            {% if (ctx.self.hasTypes) { %}
-              {{ ctx.t('Type') }}
-            {% } %}
-          </th>
+        <th class="col-md-1 px-2">
+          {% if (ctx.self.hasTypes) { %}
+            {{ ctx.t('Type') }}
+          {% } %}
+        </th>
         {% if (!ctx.disabled) { %}
           <th><!-- actions --></th>
         {% } %}

--- a/src/templates/message/form.ejs
+++ b/src/templates/message/form.ejs
@@ -1,4 +1,4 @@
-<div class="message message-{{ ctx.level }} small mb-3">
+<div class="message message-{{ ctx.level }} small my-1">
   <span class="mr-1" data-icon="{{ ctx.level }}" data-height="15"></span>
   {{ ctx.message }}
 </div>

--- a/src/templates/radio/form.ejs
+++ b/src/templates/radio/form.ejs
@@ -1,6 +1,6 @@
 <div class="form-group mt-2">
   <fieldset>
-    {% if (!ctx.component.hideLabel) { %}
+    {% if (!ctx.component.hideLabel && ctx.component.type !== 'selectboxes') { %}
       <legend>{{ ctx.t(ctx.component.label) }}</legend>
     {% } %}
     <div class="field-wrapper">

--- a/src/templates/wizardNav/form.ejs
+++ b/src/templates/wizardNav/form.ejs
@@ -4,7 +4,7 @@
     {% if (ctx.buttons.next) { %}
       <button class="{{ button_classes }} sfgov-button-primary mr-1" ref="{{ctx.wizardKey}}-next">
         <div class="d-flex flex-items-center">
-          <span>{{ ctx.t('Next')}}</span>
+          <span>{{ ctx.t(ctx.currentPage === 0 ? 'Get started' : 'Next') }}</span>
           <span data-icon="next" class="d-flex flex-items-center ml-1"></span>
         </div>
       </button>

--- a/src/templates/wizardNav/form.ejs
+++ b/src/templates/wizardNav/form.ejs
@@ -17,7 +17,7 @@
   </div>
 
   {% if (ctx.buttons.cancel) { %}
-    <div class="flex-self-end">
+    <div class="flex-self-end" hidden>
       <button class="{{ button_classes }} bg-none fg-bright-blue border-none u" ref="{{ctx.wizardKey}}-cancel">
         {{ ctx.t('Leave the form') }}
       </button>


### PR DESCRIPTION
In this release:

- A first pass on file upload styles
- Blue background for address fieldsets, per designs
- Hide double labels on "Select Boxes" components
- Change the "Next" button text to "Get started" if we're on the first page
- Hide the "Cancel" button in the wizard nav, per discussion in Figma

Note that I'm currently blocked on actually _testing_ the file uploads because we're experiencing some (general?) weirdness with form.io. But here's what they look like in their initial state:

![image](https://user-images.githubusercontent.com/113896/77595717-252d0780-6eb7-11ea-9ee7-c1fe448af588.png)

You can see this in action [here, with a test form](https://unpkg.com/formio-sfds@1.5.0-rc.bd3785c/standalone.html#res=https://sfds.form.io/shawntest1).