### PR TITLE
Release 1.6.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Loading...</title>
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="https://unpkg.com/sf-design-system@latest/public/dist/css/all.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Rubik:300,400,500,700" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,500,700&amp;display=swap&amp;subset=chinese-traditional" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import svg from 'rollup-plugin-svgo'
 import postcss from 'rollup-plugin-postcss'
 import pkg from './package.json'
 
-const postcssPlugins = require('./postcss.config')
+const name = 'FormioSFDS'
 
 const commonPlugins = [
   jst({
@@ -39,7 +39,7 @@ export default [
     ],
     output: {
       format: 'umd',
-      name: 'FormioSFDS',
+      name,
       file: 'dist/formio-sfds.standalone.js'
     }
   },
@@ -47,7 +47,8 @@ export default [
     input: pkg.module,
     output: {
       format: 'umd',
-      name: 'FormioSFDS',
+      exports: 'named',
+      name,
       file: pkg.browser
     },
     plugins: [
@@ -63,6 +64,8 @@ export default [
     ],
     output: {
       format: 'cjs',
+      exports: 'named',
+      name,
       file: pkg.main
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,17 @@
-import { observe } from 'selector-observer'
 import patch from './patch'
 import templates from './templates'
 import { observeIcons } from './icons'
 
 const framework = 'sfds'
 
-export default {
+const plugin = {
   framework,
-  patch,
   templates: {
     [framework]: templates
   }
 }
 
-observeIcons()
-hideErrorListings()
+export default plugin
+export { patch }
 
-function hideErrorListings () {
-  observe('#formio > [role=alert]', {
-    add (el) {
-      el.hidden = true
-    }
-  })
-}
+observeIcons()

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,5 +1,12 @@
+const PATCHED = `sfds-patch-${Date.now()}`
+
 export default Formio => {
+  if (Formio[PATCHED]) {
+    return
+  }
+
   patchAddressSchema(Formio.Components.components.address)
+  Formio[PATCHED] = true
 }
 
 function patchAddressSchema (AddressComponent) {

--- a/src/scss/_overrides.scss
+++ b/src/scss/_overrides.scss
@@ -1,1 +1,16 @@
 [hidden] { display: none !important; }
+
+.alert {
+  border: border-width(1) solid $grey-3;
+  padding: spacer(2);
+  border-radius: radius(1);
+
+  > * { margin: 0; }
+  > * + * { margin-top: spacer(1); }
+
+  &.alert-danger {
+    color: $red-3;
+    background-color: $red-1;
+    border-color: currentColor;
+  }
+}

--- a/src/scss/_overrides.scss
+++ b/src/scss/_overrides.scss
@@ -4,6 +4,7 @@
   border: border-width(1) solid $grey-3;
   padding: spacer(2);
   border-radius: radius(1);
+  margin-bottom: spacer(2);
 
   > * { margin: 0; }
   > * + * { margin-top: spacer(1); }

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1,11 +1,10 @@
 import 'sf-design-system/public/dist/css/all.css'
 import '../dist/formio-sfds.css'
-import FormioSFDS from './index.js'
+import FormioSFDS, { patch } from './index.js'
 
-window.addEventListener('load', () => {
-  const { Formio } = window
+const { Formio } = window
 
-  FormioSFDS.patch(Formio)
+patch(Formio)
+Formio.use(FormioSFDS)
 
-  Formio.use(FormioSFDS)
-})
+window.FormioSFDS = FormioSFDS

--- a/standalone.html
+++ b/standalone.html
@@ -33,13 +33,7 @@
         const resource = params.get('res') || root.getAttribute('data-resource')
 
         Formio.createForm(root, resource, {
-          renderMode,
-          hooks: {
-            beforeSubmit: (submission, next) => {
-              document.getElementById('thanks').hidden = false
-              next(true)
-            }
-          }
+          renderMode
         }).then(form => {
           console.log('ready!', form)
 

--- a/standalone.html
+++ b/standalone.html
@@ -6,10 +6,7 @@
   </head>
   <body>
     <div class="container p-3">
-      <div id="formio" data-resource="https://sfds.form.io/oewd-workers-families"></div>
-      <div id="thanks" class="bg-green-2 round-1 p-3 my-3" hidden>
-        <h1 class="m-0">Thanks!</h1>
-      </div>
+      <div id="formio" data-resource="https://sfds.form.io/workers-families-first"></div>
     </div>
 
     <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>

--- a/standalone.html
+++ b/standalone.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Loading...</title>
+    <meta name="viewport" content="width=device-width">
   </head>
   <body>
     <div class="container p-3">

--- a/standalone.html
+++ b/standalone.html
@@ -11,33 +11,20 @@
 
     <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
     <script src="dist/formio-sfds.standalone.js"></script>
-    <script defer>
-      const root = document.getElementById('formio')
+    <script>
+      (() => {
+        const root = document.getElementById('formio')
 
-      window.addEventListener('keyup', e => {
-        const active = document.activeElement
-        if (!active || active === document.body) {
-          switch (e.key) {
-            case 'D':
-              root.classList.toggle('class-debug')
-              break
-          }
-        }
-      })
-
-      window.onload = () => {
         const params = new URLSearchParams(location.search || location.hash.substr(1))
         const renderMode = params.get('mode')
         const resource = params.get('res') || root.getAttribute('data-resource')
 
-        Formio.createForm(root, resource, {
-          renderMode
-        }).then(form => {
+        Formio.createForm(root, resource, { renderMode }).then(form => {
           console.log('ready!', form)
-
           document.title = form.schema.title
         })
-      }
+
+      })()
     </script>
   </body>
 </html>


### PR DESCRIPTION
This release tidies up how the standalone bundle initializes, and adds some basic styles for the built-in alert banner that shows up when forms fail to submit (either during page transitions or final submission). It looks like this:

![image](https://user-images.githubusercontent.com/113896/77621886-84603b80-6efa-11ea-8907-3950d1991bfa.png)

There are two related issues that I'd like to address in the next release:

1. Placing this list of errors below the submit button would be ideal (both to prevent the form content from shifting down on the page, and to keep it closer to the thing you've tapped), but I'm finding it really difficult to get a handle on the alert element so that I can move it in the DOM.

2. Tapping "Next" on smaller screens is almost always guaranteed to leave you in a weird place on the page because the form content changes but your vertical scroll position doesn't. I'd love to be able to scroll to the top of the form whenever the page advances, but the `nextPage` [event](https://github.com/formio/formio.js/wiki/Form-Renderer#events) doesn't seem to be firing?