### PR TITLE
Merge form options deeply

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -22,8 +22,7 @@ function patch (Formio) {
   hook(Formio, 'createForm', (createForm, [el, resource, options = {}]) => {
     // get the default language from the element's (inherited) lang property
     const { lang: language } = el.lang
-    // use the translations and language as the base, and merge the provided options
-    const opts = Object.assign({ i18n, language }, options)
+    const opts = mergeObjects({ i18n, language }, options)
     return createForm(el, resource, opts).then(form => {
       console.log('SFDS form created!')
 
@@ -65,4 +64,15 @@ function patchSelectMode (model) {
 function hook (obj, methodName, wrapper) {
   const method = obj[methodName].bind(obj)
   obj[methodName] = (...args) => wrapper.call(obj, method, args)
+}
+
+function mergeObjects (a, b) {
+  for (const [key, value] of Object.entries(b)) {
+    if (a[key] instanceof Object && value instanceof Object) {
+      a[key] = mergeObjects(a[key], value)
+    } else {
+      a[key] = value
+    }
+  }
+  return a
 }

--- a/standalone.html
+++ b/standalone.html
@@ -24,7 +24,16 @@
         const renderMode = params.get('mode')
         const resource = params.get('res') || root.getAttribute('data-resource')
 
-        Formio.createForm(root, resource, { language, renderMode }).then(form => {
+        const options = { language, renderMode }
+        options.i18n = {
+          en: {
+            Submit: 'Join waitlist'
+          },
+          zh: {
+            Submit: '[join waitlist]'
+          }
+        }
+        Formio.createForm(root, resource, options).then(form => {
           console.log('ready!', form)
           document.title = form.schema.title
         })


### PR DESCRIPTION
We need to support swapping out localized strings in the form config so that we can make wording changes more nimbly than having to update the translation spreadsheet. This adds a very barebones deep merge function (the popular ones on npm completely blow up our JS bundle size!) that works for now.

I've updated `standalone.html` to demo how this works with the "Submit" string overridden to "Join waitlist". To see it in action, [visit the published version](https://unpkg.com/formio-sfds@0.0.0-b5c6394/standalone.html) and jump to the last page of the form, where you should see:

![image](https://user-images.githubusercontent.com/113896/78505513-cb370800-7728-11ea-8316-8896f37ffa55.png)

I added a placeholder Chinese string to make sure that it works in non-English translations [with `lang=zh` in the URL](https://unpkg.com/formio-sfds@0.0.0-b5c6394/standalone.html#lang=zh):

![image](https://user-images.githubusercontent.com/113896/78505540-fb7ea680-7728-11ea-88a4-6a7ae956583b.png)
