### PR TITLE
Fix nested form rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/templates/wizard/form.ejs
+++ b/src/templates/wizard/form.ejs
@@ -3,7 +3,7 @@
     <div class="col-md-2">
       {{ ctx.wizardHeader }}
     </div>
-    <div class="col-md-3" ref="{{ ctx.wizardKey }}">
+    <div class="col-md-3">
       <div class="mb-3">
         <div class="mb-4">
           {% if (ctx.buttons.previous) { %}
@@ -21,7 +21,7 @@
             </h1>
           {% } %}
         </div>
-        <div class="components">
+        <div class="components" ref="{{ ctx.wizardKey }}">
           {{ ctx.components }}
         </div>
       </div>

--- a/standalone.html
+++ b/standalone.html
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
+    <script src="https://unpkg.com/formiojs@latest/dist/formio.full.js"></script>
     <script src="dist/formio-sfds.standalone.js"></script>
     <script>
       (() => {


### PR DESCRIPTION
I introduced a bug with nested (resource) form rendering by misplacing the `ref="{{ ctx.wizardKey }}"` bit in the "wizard" template. I haven't dug into the `formio.js` source enough to understand _why_ this was a problem, but I was able to unwind all of my changes to the original templates and work backwards from there.

@hui, you should be able to test this out with `formio-sfds@0.0.0-e783e95`.