### PR TITLE
Autocomplete styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "San Francisco Digital Services",
   "license": "MIT",
   "dependencies": {
+    "choices.js": "^9.0.1",
     "formiojs": "^4.9.0-rc.10"
   },
   "devDependencies": {

--- a/src/patch.js
+++ b/src/patch.js
@@ -76,7 +76,11 @@ function patchAddressManualMode (model) {
 function patchSelectMode (model) {
   const selects = util.searchComponents(model.components, { type: 'select' })
   for (const component of selects) {
-    if (!component.tags.includes('autocomplete')) {
+    if (component.tags.includes('autocomplete')) {
+      component.customOptions = Object.assign({
+        shouldSort: true
+      }, component.customOptions)
+    } else {
       component.widget = 'html5'
     }
   }

--- a/src/patch.js
+++ b/src/patch.js
@@ -76,7 +76,9 @@ function patchAddressManualMode (model) {
 function patchSelectMode (model) {
   const selects = util.searchComponents(model.components, { type: 'select' })
   for (const component of selects) {
-    component.widget = 'html5'
+    if (!component.tags.includes('autocomplete')) {
+      component.widget = 'html5'
+    }
   }
 }
 

--- a/src/scss/_tokens.scss
+++ b/src/scss/_tokens.scss
@@ -90,6 +90,10 @@ $breakpoint-variants: ('': null, );
   $breakpoint-variants: map-merge($breakpoint-variants, ('-#{$key}': $value, ));
 }
 
+@function color($name) {
+  @return map-get($color-map, $name);
+}
+
 @function spacer($index) {
   @return map-get($spacers, $index);
 }

--- a/src/scss/forms/_choices.scss
+++ b/src/scss/forms/_choices.scss
@@ -54,4 +54,10 @@ $select-border-width: 2px;
       box-shadow: none !important;
     }
   }
+
+  .#{$choices-selector}__item {
+    &.has-no-choices {
+      color: color(slate-65);
+    }
+  }
 }

--- a/src/scss/forms/_choices.scss
+++ b/src/scss/forms/_choices.scss
@@ -35,18 +35,14 @@ $select-border-width: 2px;
     border-color: color(bright-blue);
   }
 
-  &[aria-expanded=true] .ui {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
   .#{$choices-selector}__list--single {
     padding: 0;
   }
 
   .#{$choices-selector}__list--dropdown {
     border-width: $select-border-width;
-    border-top-width: 0;
+    border-radius: radius(1);
+    top: 0;
     margin-top: 0;
 
     .#{$choices-selector}__input {

--- a/src/scss/forms/_choices.scss
+++ b/src/scss/forms/_choices.scss
@@ -1,0 +1,57 @@
+$choices-selector: 'choices' !default;
+$choices-font-size-lg: 20px !default;
+$choices-font-size-md: 17px !default;
+$choices-font-size-sm: 14px !default;
+$choices-guttering: 20px !default;
+$choices-border-radius: radius(1) !default;
+$choices-border-radius-item: radius(1) !default;
+$choices-bg-color: color(grey-1) !default;
+$choices-bg-color-disabled: color(grey-4) !default;
+$choices-bg-color-dropdown: color(white) !default;
+$choices-text-color: color(slate) !default;
+$choices-keyline-color: color(bright-blue) !default;
+$choices-primary-color: color(bright-blue) !default;
+$choices-disabled-color: color(slate-65) !default;
+$choices-highlight-color: $choices-primary-color !default;
+$choices-button-dimension: spacer(1) !default;
+$choices-button-offset: spacer(1) !default;
+$choices-icon-cross: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEiIGhlaWdodD0iMjEiIHZpZXdCb3g9IjAgMCAyMSAyMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSIjRkZGIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxwYXRoIGQ9Ik0yLjU5Mi4wNDRsMTguMzY0IDE4LjM2NC0yLjU0OCAyLjU0OEwuMDQ0IDIuNTkyeiIvPjxwYXRoIGQ9Ik0wIDE4LjM2NEwxOC4zNjQgMGwyLjU0OCAyLjU0OEwyLjU0OCAyMC45MTJ6Ii8+PC9nPjwvc3ZnPg==) !default;
+$choices-icon-cross-inverse: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEiIGhlaWdodD0iMjEiIHZpZXdCb3g9IjAgMCAyMSAyMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSIjMDAwIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxwYXRoIGQ9Ik0yLjU5Mi4wNDRsMTguMzY0IDE4LjM2NC0yLjU0OCAyLjU0OEwuMDQ0IDIuNTkyeiIvPjxwYXRoIGQ9Ik0wIDE4LjM2NEwxOC4zNjQgMGwyLjU0OCAyLjU0OEwyLjU0OCAyMC45MTJ6Ii8+PC9nPjwvc3ZnPg==) !default;
+$choices-z-index: 1;
+
+@import "choices.js/src/styles/choices";
+
+$select-border-width: 2px;
+
+.formio-choices {
+  .ui {
+    border: $select-border-width solid color(slate);
+    border-radius: radius(1);
+    padding: spacer(1);
+  }
+
+  .ui:focus,
+  &[aria-expanded=true] .ui {
+    border-color: color(bright-blue);
+  }
+
+  &[aria-expanded=true] .ui {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .#{$choices-selector}__list--single {
+    padding: 0;
+  }
+
+  .#{$choices-selector}__list--dropdown {
+    border-width: $select-border-width;
+    border-top-width: 0;
+    margin-top: 0;
+
+    .#{$choices-selector}__input {
+      border-bottom-width: $select-border-width;
+      box-shadow: none !important;
+    }
+  }
+}

--- a/src/scss/forms/index.scss
+++ b/src/scss/forms/index.scss
@@ -1,4 +1,5 @@
 @import "./buttons";
+@import "./choices";
 @import "./inputs";
 @import "./hacks";
 

--- a/src/templates/label/form.ejs
+++ b/src/templates/label/form.ejs
@@ -1,4 +1,4 @@
-{% if (ctx.component.type !== 'radio' && ctx.component.type !== 'checkbox') { %}
+{% if (['button', 'checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
   <label class="{{ ctx.label.className }}">
     {{ ctx.t([`${ctx.component.key}_label`, ctx.component.label]) }}
     <!--


### PR DESCRIPTION
This adds explicit styles for the [choices.js](https://github.com/jshjohnson/Choices) autocomplete rendered by form.io. I've tried to limit the amount of CSS I'm adding, and I'm pretty happy with it from a code standpoint. The appearance, however, could use some work.

#### How it works
To (re-)enable autocomplete, just add the <kbd>autocomplete</kbd> tag in the form.io UI:

![image](https://user-images.githubusercontent.com/113896/79394302-fe994400-7f2b-11ea-9a8c-fc24b8ee8fc8.png)

#### How it looks
Here's the component without a value:

![image](https://user-images.githubusercontent.com/113896/79393943-32279e80-7f2b-11ea-9230-49a60e9216c3.png)

focused:

![image](https://user-images.githubusercontent.com/113896/79393670-b168a280-7f2a-11ea-932f-4adb8371b94c.png)

expanded:

![image](https://user-images.githubusercontent.com/113896/79393704-c04f5500-7f2a-11ea-8259-07e0ad97f0f6.png)

with a value selected:

![image](https://user-images.githubusercontent.com/113896/79393728-cc3b1700-7f2a-11ea-9175-4e10ddce7e71.png)

and with text that doesn't match any of the options:

![image](https://user-images.githubusercontent.com/113896/79394061-74e97680-7f2b-11ea-8195-be88ff398a70.png)
