### PR TITLE
Fix select box styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/scss/forms/_inputs.scss
+++ b/src/scss/forms/_inputs.scss
@@ -1,6 +1,6 @@
 $input-size: 44px;
 
-.input-checkbox {
+input[type=checkbox] {
   $checkbox-size: $input-size;
 
   appearance: none;
@@ -37,7 +37,7 @@ $input-size: 44px;
   }
 }
 
-.input-radio {
+input[type=radio] {
   $radio-size: $input-size;
   $dot-inset: 8px;
 

--- a/src/templates/radio/form.ejs
+++ b/src/templates/radio/form.ejs
@@ -8,7 +8,7 @@
         <label class="d-flex flex-items-center fs-inherit my-2">
           <div class="flex-shrink-0">
             <{{ctx.input.type}}
-              class="input-radio position-relative d-block mr-2 mb-0"
+              class="input-{{ ctx.input.attr.type }} position-relative d-block mr-2 mb-0"
               ref="input"
               {% for (var attr in ctx.input.attr) { %}
               {{attr}}="{{ctx.input.attr[attr]}}"


### PR DESCRIPTION
Turns out that the "select boxes" component uses the _radio_ template, which had the `input-radio` classname hardcoded. I updated the CSS to target `[type=checkbox]` and `[type=radio]` selectors more explicitly, and made sure that the input type is substituted in the classname just in case.

Check out [the preview](https://unpkg.com/formio-sfds@0.0.0-10f074b/standalone.html#res=https://bibchaxyzkpkgra.form.io/kitchen-sink). 🎉 