### PR TITLE
Component updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6783,6 +6783,26 @@
         "htmlparser2": "^3.10.0"
       }
     },
+    "postcss-import": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-12.0.1.tgz",
+      "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.1",
+        "postcss-value-parser": "^3.2.3",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
     "postcss-inline-svg": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-inline-svg/-/postcss-inline-svg-4.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.27",
     "postcss-cli": "^7.1.0",
+    "postcss-import": "^12.0.1",
     "postcss-inline-svg": "^4.1.0",
     "postcss-scss": "^2.0.0",
     "rollup": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -7,6 +7,7 @@ module.exports = {
       includePaths: ['node_modules'],
       outputStyle: NODE_ENV === 'production' ? 'compressed' : 'expanded'
     }),
+    require('postcss-import')(),
     require('postcss-inline-svg')({
       removeFill: true
     }),

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -1,0 +1,106 @@
+const { container: Container } = window.Formio.Components.components
+
+const STATES = [{ label: 'California', value: 'CA' }]
+
+const COUNTRIES = [{ label: 'United States', value: 'US' }]
+
+export default class AddressComponent extends Container {
+  static schema (rest) {
+    return Container.schema({
+      type: 'customAddress',
+      label: 'Address',
+      key: 'address',
+      hideLabel: false,
+      showCountry: false,
+      components: [
+        {
+          label: 'Address line 1',
+          tableView: false,
+          key: 'line1',
+          type: 'textfield',
+          input: true,
+          validate: { required: true }
+        },
+        {
+          label: 'Address line 2',
+          tableView: false,
+          key: 'line2',
+          type: 'textfield',
+          input: true
+        },
+        {
+          label: 'City',
+          tableView: false,
+          key: 'city',
+          type: 'textfield',
+          input: true,
+          validate: { required: true }
+        },
+        {
+          type: 'columns',
+          columns: [
+            {
+              width: 6,
+              components: [
+                {
+                  label: 'State',
+                  tableView: false,
+                  key: 'state',
+                  type: 'select',
+                  input: true,
+                  widget: 'html5',
+                  dataSrc: 'values',
+                  data: {
+                    values: STATES
+                  },
+                  validate: { required: true }
+                }
+              ]
+            },
+            {
+              width: 6,
+              components: [
+                {
+                  label: 'ZIP Code',
+                  tableView: false,
+                  key: 'zip',
+                  type: 'textfield',
+                  input: true,
+                  validate: {
+                    required: true,
+                    maxLength: 10,
+                    pattern: '([0-9]{5}(-[0-9]{4})?)?'
+                  },
+                  errors: {
+                    pattern:
+                      'Please enter a 5-digit <a href="https://en.wikipedia.org/wiki/ZIP_Code">ZIP code</a>'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          label: 'Country',
+          tableView: false,
+          key: 'country',
+          type: 'select',
+          dataSrc: 'values',
+          widget: 'html5',
+          data: { values: COUNTRIES },
+          defaultValue: 'us',
+          input: true,
+          customConditional: ({ self }) => self.parent.component.showCountry
+        }
+      ]
+    })
+  }
+
+  get defaultSchema () {
+    return AddressComponent.schema()
+  }
+
+  get templateName () {
+    return 'well'
+  }
+}

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -90,7 +90,7 @@ export default class AddressComponent extends Container {
           data: { values: COUNTRIES },
           defaultValue: 'us',
           input: true,
-          customConditional: ({ self }) => self.parent.component.showCountry
+          customConditional: ({ self }) => self.parent && self.parent.component.showCountry
         }
       ]
     })

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,5 @@
+import AddressComponent from './address'
+
+export default {
+  address: AddressComponent
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import components from './components'
 import patch from './patch'
 import templates from './templates'
 import { observeIcons } from './icons'
@@ -6,6 +7,7 @@ const framework = 'sfds'
 
 const plugin = {
   framework,
+  components,
   templates: {
     [framework]: templates
   }

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,5 +1,6 @@
 import i18n from './i18n'
 import buildHooks from './hooks'
+import { dependencies } from '../package.json'
 
 const WRAPPER_CLASS = 'formio-sfds'
 const PATCHED = `sfds-patch-${Date.now()}`
@@ -14,6 +15,9 @@ export default Formio => {
 
   util = window.FormioUtils
   patch(Formio)
+
+  const { flatpickr: flatpickrVersion } = dependencies
+  loadStylesheet(`https://unpkg.com/flatpickr@${flatpickrVersion}/dist/flatpickr.min.css`)
 
   Formio[PATCHED] = true
 }
@@ -210,4 +214,10 @@ function patchI18nMultipleKeys (Formio) {
       return bound(keys, params)
     }
   })
+}
+
+function loadStylesheet (url) {
+  const link = document.createElement('link')
+  link.rel = url
+  return document.head.appendChild(link)
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,6 +1,5 @@
 import i18n from './i18n'
 import buildHooks from './hooks'
-import { dependencies } from '../package.json'
 
 const WRAPPER_CLASS = 'formio-sfds'
 const PATCHED = `sfds-patch-${Date.now()}`
@@ -15,9 +14,6 @@ export default Formio => {
 
   util = window.FormioUtils
   patch(Formio)
-
-  const { flatpickr: flatpickrVersion } = dependencies
-  loadStylesheet(`https://unpkg.com/flatpickr@${flatpickrVersion}/dist/flatpickr.min.css`)
 
   Formio[PATCHED] = true
 }
@@ -202,10 +198,4 @@ function patchI18nMultipleKeys (Formio) {
       return bound(keys, params)
     }
   })
-}
-
-function loadStylesheet (url) {
-  const link = document.createElement('link')
-  link.rel = url
-  return document.head.appendChild(link)
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -120,7 +120,7 @@ function patch (Formio) {
 function patchSelectMode (model) {
   const selects = util.searchComponents(model.components, { type: 'select' })
   for (const component of selects) {
-    if (component.tags.includes('autocomplete')) {
+    if (component.tags && component.tags.includes('autocomplete')) {
       component.customOptions = Object.assign({
         shouldSort: true
       }, component.customOptions)

--- a/src/patch.js
+++ b/src/patch.js
@@ -62,7 +62,6 @@ function patch (Formio) {
       // Note: we create a shallow copy of the form model so the .form setter
       // will treat it as changed. (form.io showed us this trick!)
       const model = { ...form.form }
-      patchAddressManualMode(model)
       patchSelectMode(model)
       form.form = model
 
@@ -116,17 +115,6 @@ function patch (Formio) {
 
   // this goes last so that if it fails it doesn't break everything else
   patchLanguageObserver()
-}
-
-function patchAddressManualMode (model) {
-  const addresses = util.searchComponents(model.components, { type: 'address' })
-  for (const component of addresses) {
-    // FIXME no combination of these seems to make the nested
-    // fields render...
-    component.mode = 'manual'
-    component.enableManualMode = true
-    component.manualMode = true
-  }
 }
 
 function patchSelectMode (model) {

--- a/src/scss/forms/_inputs.scss
+++ b/src/scss/forms/_inputs.scss
@@ -71,3 +71,43 @@ input[type=radio] {
     }
   }
 }
+
+.input-group {
+  display: flex;
+
+  .input-group-prepend,
+  .input-group-append {
+    background: $grey-3;
+    flex-shrink: 0;
+    padding: 0 spacer(1);
+    display: flex;
+    align-items: center;
+    border: 2px solid $slate;
+  }
+
+  .input-group-append {
+    border-top-right-radius: radius(1);
+    border-bottom-right-radius: radius(1);
+    border-left-width: 0;
+  }
+
+  .input-group-prepend {
+    border-top-left-radius: radius(1);
+    border-bottom-left-radius: radius(1);
+    border-right-width: 0;
+  }
+
+  .form-input {
+    flex: auto;
+
+    &:first-child input {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    &:last-child input {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -27,3 +27,5 @@
   @import "./utilities";
   @import "./overrides";
 }
+
+@import url(flatpickr/dist/flatpickr.min.css);

--- a/src/templates/label/form.ejs
+++ b/src/templates/label/form.ejs
@@ -1,4 +1,4 @@
-{% if (['button', 'checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
+{% if (!ctx.component.hideLabel && ['checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
   <label class="{{ ctx.label.className }}">
     {{ ctx.t([`${ctx.component.key}_label`, ctx.component.label]) }}
     <!--


### PR DESCRIPTION
Some updates for the OEWD small business grants form:

1. Input group styles to support the "prefix" and "suffix" options for currency and calendar fields

    ![image](https://user-images.githubusercontent.com/113896/79597728-a67f5080-8097-11ea-8815-35926269da93.png)

2. [Flatpickr](https://flatpickr.js.org/) CSS is loaded at runtime rather than being included in our CSS. Why? Because of [this ridiculous bit of JavaScript](https://github.com/flatpickr/flatpickr/blob/d73d399d6fd6f825a75213c832f8297aa226264d/src/index.ts#L2224) that attempts to write CSS rules to the first stylesheet on the page, which it can't when the JS is loaded from another domain. (Side note: Flatpickr is **awful** don't @ me)

3. We now have a first-class custom Address component, which I fleshed out in [this CodePen](https://codepen.io/shawnbot/pen/NWGxEWN?editors=1010). This supersedes form.io's default Google Maps-based autocomplete input, which a) works poorly for local address entry and b) doesn't work in "manual" mode out of the box anyway. AFAIK we're not using address components anywhere, so this shouldn't break existing forms.

This also fixes a bug with components that don't have tags, which was biting @skinnylatte in 4.0.1. This will release version 4.1.0.