### PR TITLE
Custom component and kitchen sink improvements

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,0 +1,122 @@
+# Development
+
+## Workflow
+
+1. [Set up your local development environment](#setup)
+2. Make some changes and push to a new branch
+3. [Open a pull request](https://github.com/SFDigitalServices/formio-sfds/compare?expand=1)
+4. Wait for status checks to pass and use the [published version](#publishing)
+   in your form on sf.gov
+5. Get your pull request reviewed and bump the package version by either:
+    - running `script/version <version|patch|minor|major>` and pushing the commit(s), or
+    - merging your pull request into a release branch
+
+## Local development
+
+### Setup
+1. Clone this repo, e.g.
+    ```sh
+    git clone https://github.com/SFDigitalServices/formio-sfds
+    ```
+2. Run `npm install` to install all of the dependencies
+3. Run `npm run watch` to build all of the browser-ready JS and CSS, and
+   rebuild whenever changes are made to the source.
+
+Running `npm run` without any additional arguments will list all of the
+available scripts, most notably:
+
+- `npm run lint` to lint the JS and SCSS source files
+- `npm run build` to do a one-time build (without watching), or
+  `NODE_ENV=production npm run build` to build minified assets
+
+### Local testing
+There are a collection of HTML documents in the repo root that you can use to
+test the theme against different form.io data and scenarios:
+
+- [index.html](../index.html) is the "kitchen sink" demo, which renders a
+  separate form for each example described in
+  [examples.yml](../src/examples.yml). The schema is an array of example
+  objects, each of which should conform to the [form.io form schema] and
+  provide an additional, unique `id` property that allows you to deep-link to
+  it on the page.
+
+- [standalone.html](../standalone.html) is for testing the "standalone" JS
+  bundle against the latest version of [formiojs] and a snapshot of CSS from
+  [sf.gov]. It respects the following query string parameters:
+
+  - `res` overrides the default resource or form URL so that you can test it
+    with live forms. E.g. `?res=https://sfds.form.io/some-other-form`
+
+  - `lang` overrides the form's language, for testing localization. E.g.
+    `?lang=zh-TW`.
+
+  - `hooks` can be used to pass [declarative hooks] that
+    modify form behavior.
+
+- [hooks.html](../hooks.html) is geared toward testing [declarative hooks], and
+  without any query string parameters renders a form that validates SF employee
+  DSW numbers using an external web service, then passes submission data via
+  the query string to the `on.submit.redirect.url`.
+
+  This page also includes a textarea containing JSON that can be copied and
+  pasted into the sf.gov form page editing UI to publish forms that follow the
+  same logic, which works well with query string parameters:
+
+  - `res` overrides the default resource or form URL so that you can test it
+    with live forms. E.g. `?res=https://sfds.form.io/some-other-form`
+
+  - `on` can be used to specify a JSON payload for
+  [declarative event listeners][declarative hooks], e.g.
+
+    ```
+    ?on={"submit":{"redirect":{"url":"javascript:alert('hi!')"}}}
+    ```
+
+  - `hooks` overrides the [declarative hooks] example with JSON, just like `on`.
+
+## Publishing
+This repo uses [primer/publish] to publish new releases of the `formio-sfds`
+npm package for every push that passes the [CI
+workflow](../.github/workflows/ci.yml). The name of the branch determines the
+"type" of release:
+
+- Merges to `master` will release new versions to the `latest` (default)
+  dist-tag if the `version` field in `package.json` has been incremented.
+- Pushes to `release-<version>` will publish npm releases to the `next`
+  dist-tag with versions in the form `<version>-rc.<sha>`, where `<sha>` is the
+  7-character commit SHA.
+- Pushes to any other branch will publish releases to the `canary` dist-tag
+  with versions in the form `0.0.0-<sha>`.
+
+You can find the release version for a given branch by navigating to either an
+open pull request or the "tree" view of that branch on github.com, and clicking
+on the status icon of the most recent commit:
+
+| Where | What it looks like |
+| :---- | :---- |
+| Commit status icon | ![image](https://user-images.githubusercontent.com/113896/80157039-33d01280-857a-11ea-83bb-d547343d4faa.png)
+| Merge box | ![image](https://user-images.githubusercontent.com/113896/80157076-46e2e280-857a-11ea-9c84-12c4438f1dfd.png)
+| Branch tree view | ![image](https://user-images.githubusercontent.com/113896/80157168-6b3ebf00-857a-11ea-9563-47e41985da39.png)
+
+### unpkg
+We use [unpkg] as our CDN. As soon as a release is published, you can access it
+on unpkg.com via the version's unique URL:
+
+```
+https://unpkg.com/formio-sfds@<version>/
+```
+
+The trailing slash allows you to browse the published package file hierarchy.
+From there you can navigate to any of the HTML files and then click the <kbd>View
+Raw</kbd> link to render the examples live.
+
+**Note:** unpkg.com will strip the query string from any URL you give it, but
+query string parameters can be passed to those URLs (one, upon loading) via the
+hash. In other words, just replace the `?` in your query string with `#`.
+
+[declarative hooks]: ../#declarative-hooks
+[form.io form schema]: https://github.com/formio/formio.js/wiki/Form-JSON-Schema
+[formiojs]: https://www.npmjs.com/package/formiojs
+[primer/publish]: https://github.com/primer/publish
+[sf.gov]: https://sf.gov
+[unpkg]: https://unpkg.com

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -111,8 +111,9 @@ From there you can navigate to any of the HTML files and then click the <kbd>Vie
 Raw</kbd> link to render the examples live.
 
 **Note:** unpkg.com will strip the query string from any URL you give it, but
-query string parameters can be passed to those URLs (one, upon loading) via the
+query string parameters can be passed to those URLs (once, on load) via the
 hash. In other words, just replace the `?` in your query string with `#`.
+Remember: You'll need to refresh the page after changing the hash!
 
 [declarative hooks]: ../#declarative-hooks
 [form.io form schema]: https://github.com/formio/formio.js/wiki/Form-JSON-Schema

--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ If you're using a CommonJS bundler like webpack, browserify, et al:
     ```
 
 ## `Formio.createForm()` improvements
-* Address components are made to enable the undocumented "manual" mode, which
-  displays a standard address form with multiple inputs.
 
 * Select components are made to always use the `html5` "widget", which is just
   an HTML `<select>` input
@@ -93,6 +91,16 @@ If you're using a CommonJS bundler like webpack, browserify, et al:
 * If `options.googleTranslate === false`, then the `notranslate` class is added
   to the form element wrapper to prevent Google Translate from touching it.
 
+## Custom components
+
+* `address` fields are rendered as multiple text and number inputs with address
+  lines (1 and 2), city, state and zip code.
+
+* Fields with type `state` render an HTML `<select>` input with the 50 U.S.
+  states.
+
+* Fields with type `zip` render a ZIP code input field that validates against a
+  5-digit number or a ZIP+4 pattern (e.g. `94110-1234`).
 
 ### Localization
 Localization of form field labels and descriptions can be implemented without

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # formio-sfds
-[Form.io] templates for the SF Design System
+This is a [Form.io] theme for the [SF Design System](https://sfdigitalservices.github.io/sf-design-system/).
+
+👉 See [DEVELOP.md](DEVELOP.md#readme) for development documentation.
 
 ## Usage
 There are a couple of different ways to use this package in your app:

--- a/data/states.json
+++ b/data/states.json
@@ -1,0 +1,202 @@
+[
+  {
+    "name": "Alabama",
+    "code": "AL"
+  },
+  {
+    "name": "Alaska",
+    "code": "AK"
+  },
+  {
+    "name": "Arizona",
+    "code": "AZ"
+  },
+  {
+    "name": "Arkansas",
+    "code": "AR"
+  },
+  {
+    "name": "California",
+    "code": "CA"
+  },
+  {
+    "name": "Colorado",
+    "code": "CO"
+  },
+  {
+    "name": "Connecticut",
+    "code": "CT"
+  },
+  {
+    "name": "Delaware",
+    "code": "DE"
+  },
+  {
+    "name": "Florida",
+    "code": "FL"
+  },
+  {
+    "name": "Georgia",
+    "code": "GA"
+  },
+  {
+    "name": "Hawaii",
+    "code": "HI"
+  },
+  {
+    "name": "Idaho",
+    "code": "ID"
+  },
+  {
+    "name": "Illinois",
+    "code": "IL"
+  },
+  {
+    "name": "Indiana",
+    "code": "IN"
+  },
+  {
+    "name": "Iowa",
+    "code": "IA"
+  },
+  {
+    "name": "Kansas",
+    "code": "KS"
+  },
+  {
+    "name": "Kentucky",
+    "code": "KY"
+  },
+  {
+    "name": "Louisiana",
+    "code": "LA"
+  },
+  {
+    "name": "Maine",
+    "code": "ME"
+  },
+  {
+    "name": "Maryland",
+    "code": "MD"
+  },
+  {
+    "name": "Massachusetts",
+    "code": "MA"
+  },
+  {
+    "name": "Michigan",
+    "code": "MI"
+  },
+  {
+    "name": "Minnesota",
+    "code": "MN"
+  },
+  {
+    "name": "Mississippi",
+    "code": "MS"
+  },
+  {
+    "name": "Missouri",
+    "code": "MO"
+  },
+  {
+    "name": "Montana",
+    "code": "MT"
+  },
+  {
+    "name": "Nebraska",
+    "code": "NE"
+  },
+  {
+    "name": "Nevada",
+    "code": "NV"
+  },
+  {
+    "name": "New Hampshire",
+    "code": "NH"
+  },
+  {
+    "name": "New Jersey",
+    "code": "NJ"
+  },
+  {
+    "name": "New Mexico",
+    "code": "NM"
+  },
+  {
+    "name": "New York",
+    "code": "NY"
+  },
+  {
+    "name": "North Carolina",
+    "code": "NC"
+  },
+  {
+    "name": "North Dakota",
+    "code": "ND"
+  },
+  {
+    "name": "Ohio",
+    "code": "OH"
+  },
+  {
+    "name": "Oklahoma",
+    "code": "OK"
+  },
+  {
+    "name": "Oregon",
+    "code": "OR"
+  },
+  {
+    "name": "Pennsylvania",
+    "code": "PA"
+  },
+  {
+    "name": "Rhode Island",
+    "code": "RI"
+  },
+  {
+    "name": "South Carolina",
+    "code": "SC"
+  },
+  {
+    "name": "South Dakota",
+    "code": "SD"
+  },
+  {
+    "name": "Tennessee",
+    "code": "TN"
+  },
+  {
+    "name": "Texas",
+    "code": "TX"
+  },
+  {
+    "name": "Utah",
+    "code": "UT"
+  },
+  {
+    "name": "Vermont",
+    "code": "VT"
+  },
+  {
+    "name": "Virginia",
+    "code": "VA"
+  },
+  {
+    "name": "Washington",
+    "code": "WA"
+  },
+  {
+    "name": "West Virginia",
+    "code": "WV"
+  },
+  {
+    "name": "Wisconsin",
+    "code": "WI"
+  },
+  {
+    "name": "Wyoming",
+    "code": "WY"
+  }
+]

--- a/hooks.html
+++ b/hooks.html
@@ -55,9 +55,8 @@
           }
         }
 
-        const options = { hooks, on, prefill: 'querystring' }
+        const options = { hooks, on, prefill: params }
         document.getElementById('json-options').innerText = JSON.stringify(options, null, 2)
-        options.prefill = params
 
         Formio.createForm(root, resource, options).then(form => {
           console.log('form ready:', form)

--- a/index.html
+++ b/index.html
@@ -8,16 +8,34 @@
   </head>
   <body>
     <div class="page-node-type-form-page">
-      <div class="form-page">
-        <div class="container p-3 formio-sfds">
-          <h1>Examples</h1>
+      <div class="form-page formio-sfds">
+        <h1><code>formio-sfds@<span data-package="version">0.0.0</span></code></h1>
 
-          <template id="form-template">
-            <section class="example">
-              <h2 class="h3" data-placeholder="title"></h2>
-              <form></form>
-            </section>
-          </template>
+        <div class="d-flex flex-column flex-md-row">
+
+          <div class="pr-md-4 position-relative">
+
+            <h2 class="h2 mt-2">Examples</h1>
+
+            <div style="position: sticky; top: 0;">
+              <ul id="example-links" class="list-style-none">
+                <template id="example-link">
+                  <li>
+                    <a slot="link" class="d-block py-1"></a>
+                  </li>
+                </template>
+              </ul>
+            </div>
+          </div>
+
+          <div class="mt-2 pt-1">
+            <template id="form-template">
+              <section class="example">
+                <h2 class="h3" slot="title"></h2>
+                <form slot="form"></form>
+              </section>
+            </template>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -34,6 +34,7 @@ export default class AddressComponent extends Container {
         },
         {
           type: 'columns',
+          key: 'stateAndZip',
           columns: [
             {
               width: 6,
@@ -52,18 +53,8 @@ export default class AddressComponent extends Container {
               components: [
                 {
                   label: 'ZIP code',
-                  tableView: false,
                   key: 'zip',
-                  type: 'textfield',
-                  input: true,
-                  validate: {
-                    required: true,
-                    maxLength: 10,
-                    pattern: '([0-9]{5}(-[0-9]{4})?)?'
-                  },
-                  errors: {
-                    pattern: 'Please enter a 5-digit <a href="https://en.wikipedia.org/wiki/ZIP_Code">ZIP code</a>'
-                  }
+                  type: 'zip'
                 }
               ]
             }

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -51,7 +51,7 @@ export default class AddressComponent extends Container {
               width: 6,
               components: [
                 {
-                  label: 'ZIP Code',
+                  label: 'ZIP code',
                   tableView: false,
                   key: 'zip',
                   type: 'textfield',
@@ -62,25 +62,12 @@ export default class AddressComponent extends Container {
                     pattern: '([0-9]{5}(-[0-9]{4})?)?'
                   },
                   errors: {
-                    pattern:
-                      'Please enter a 5-digit <a href="https://en.wikipedia.org/wiki/ZIP_Code">ZIP code</a>'
+                    pattern: 'Please enter a 5-digit <a href="https://en.wikipedia.org/wiki/ZIP_Code">ZIP code</a>'
                   }
                 }
               ]
             }
           ]
-        },
-        {
-          label: 'Country',
-          tableView: false,
-          key: 'country',
-          type: 'select',
-          dataSrc: 'values',
-          widget: 'html5',
-          data: { values: COUNTRIES },
-          defaultValue: 'us',
-          input: true,
-          customConditional: ({ self }) => self.parent && self.parent.component.showCountry
         }
       ]
     })

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -1,7 +1,7 @@
 const { container: Container } = window.Formio.Components.components
 
 export default class AddressComponent extends Container {
-  static schema (rest) {
+  static schema (...extend) {
     return Container.schema({
       type: 'customAddress',
       label: 'Address',
@@ -70,7 +70,7 @@ export default class AddressComponent extends Container {
           ]
         }
       ]
-    })
+    }, ...extend)
   }
 
   get defaultSchema () {

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -1,9 +1,5 @@
 const { container: Container } = window.Formio.Components.components
 
-const STATES = [{ label: 'California', value: 'CA' }]
-
-const COUNTRIES = [{ label: 'United States', value: 'US' }]
-
 export default class AddressComponent extends Container {
   static schema (rest) {
     return Container.schema({
@@ -46,13 +42,7 @@ export default class AddressComponent extends Container {
                   label: 'State',
                   tableView: false,
                   key: 'state',
-                  type: 'select',
-                  input: true,
-                  widget: 'html5',
-                  dataSrc: 'values',
-                  data: {
-                    values: STATES
-                  },
+                  type: 'state',
                   validate: { required: true }
                 }
               ]

--- a/src/components/columns.js
+++ b/src/components/columns.js
@@ -1,0 +1,7 @@
+const { columns: Columns } = window.Formio.Components.components
+
+export default class CustomColumns extends Columns {
+  get columnKey () {
+    return `column-${this.component.id}`
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,7 @@
-import AddressComponent from './address'
+import address from './address'
+import state from './state'
 
 export default {
-  address: AddressComponent
+  address,
+  state
 }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,11 @@
 import address from './address'
+import columns from './columns'
 import state from './state'
+import zip from './zip'
 
 export default {
   address,
-  state
+  columns,
+  state,
+  zip
 }

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -3,18 +3,16 @@ import values from '../../data/states.json'
 const { select: Select } = window.Formio.Components.components
 
 export default class StateSelect extends Select {
-  static schema (rest = {}) {
+  static schema (...extend) {
     return Select.schema({
       // these are schema fields that should be overridden
       key: 'state',
-      ...rest,
-      // and these are ones that should not be
       widget: 'html5',
       dataSrc: 'values',
       data: { values },
       valueProperty: 'code',
       template: '{{ item.name }}'
-    })
+    }, ...extend)
   }
 
   get defaultSchema () {

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -1,0 +1,23 @@
+import values from '../../data/states.json'
+
+const { select: Select } = window.Formio.Components.components
+
+export default class StateSelect extends Select {
+  static schema (rest = {}) {
+    return Select.schema({
+      // these are schema fields that should be overridden
+      key: 'state',
+      ...rest,
+      // and these are ones that should not be
+      widget: 'html5',
+      dataSrc: 'values',
+      data: { values },
+      valueProperty: 'code',
+      template: '{{ item.name }}'
+    })
+  }
+
+  get defaultSchema () {
+    return StateSelect.schema()
+  }
+}

--- a/src/components/zip.js
+++ b/src/components/zip.js
@@ -1,0 +1,22 @@
+const { textfield: TextField } = window.Formio.Components.components
+
+export default class ZIPCode extends TextField {
+  static schema (...extend) {
+    return TextField.schema({
+      // these are schema fields that should be overridden
+      key: 'zip',
+      validate: {
+        required: true,
+        maxLength: 10,
+        pattern: '([0-9]{5}(-[0-9]{4})?)?'
+      },
+      errors: {
+        pattern: 'Please enter a 5-digit <a href="https://en.wikipedia.org/wiki/ZIP_Code">ZIP code</a>'
+      }
+    }, ...extend)
+  }
+
+  get defaultSchema () {
+    return ZIPCode.schema()
+  }
+}

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -55,7 +55,7 @@
       tooltip: And this is the tooltip
 
 - id: columns-2
-  title: 2-column layout
+  title: Columns (2)
   components:
     - type: columns
       columns:
@@ -69,7 +69,7 @@
               label: Field 2
 
 - id: columns-3
-  title: 3-column layout
+  title: Columns (3)
   components:
     - type: columns
       columns:

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -38,3 +38,11 @@
           value: 2
         - label: Option 3 (this is some really long text that should wrap nicely, thanks so much)
           value: 3
+
+- id: checkbox
+  title: Checkbox
+  components:
+    - type: checkbox
+      label: This is a long label, and it should wrap nicely alongside the checkbox with the description below it.
+      description: And this is the description
+      tooltip: And this is the tooltip

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -15,14 +15,13 @@
       description: This is the description
       multiple: true
 
-- id: address
-  title: Address (custom component)
+- id: checkbox
+  title: Checkbox
   components:
-    - type: address
-      label: This is the label
-      description: This is the description
+    - type: checkbox
+      label: This is a long label, and it should wrap nicely alongside the checkbox with the description below it.
+      description: And this is the description
       tooltip: And this is the tooltip
-      multiple: true
 
 - id: radio
   title: Radio
@@ -39,10 +38,59 @@
         - label: Option 3 (this is some really long text that should wrap nicely, thanks so much)
           value: 3
 
-- id: checkbox
-  title: Checkbox
+- id: us-state
+  title: U.S. state select (custom component)
   components:
-    - type: checkbox
-      label: This is a long label, and it should wrap nicely alongside the checkbox with the description below it.
-      description: And this is the description
+    - type: state
+      label: This is the label
+      description: This is the description
       tooltip: And this is the tooltip
+
+- id: zip-code
+  title: ZIP code
+  components:
+    - type: zip
+      label: This is the label
+      description: This is the description
+      tooltip: And this is the tooltip
+
+- id: columns-2
+  title: 2-column layout
+  components:
+    - type: columns
+      columns:
+        - width: 3
+          components:
+            - type: textfield
+              label: Field 1
+        - width: 3
+          components:
+            - type: textfield
+              label: Field 2
+
+- id: columns-3
+  title: 3-column layout
+  components:
+    - type: columns
+      columns:
+        - width: 2
+          components:
+            - type: textfield
+              label: Field 1
+        - width: 2
+          components:
+            - type: textfield
+              label: Field 2
+        - width: 2
+          components:
+            - type: textfield
+              label: Field 3
+
+- id: address
+  title: Address (custom component)
+  components:
+    - type: address
+      label: This is the label
+      description: This is the description
+      tooltip: And this is the tooltip
+      multiple: true

--- a/src/kitchen-sink.js
+++ b/src/kitchen-sink.js
@@ -8,7 +8,7 @@ const defaults = {
 
 main()
 
-async function main () {
+function main () {
   const template = document.getElementById('form-template')
   const root = template.parentNode
   const forms = []
@@ -16,7 +16,7 @@ async function main () {
   for (const example of examples) {
     const node = template.content.cloneNode(true).firstElementChild
     root.appendChild(node)
-    const form = await createForm(example, node)
+    const form = createForm(example, node)
     forms.push(form)
   }
 
@@ -36,7 +36,7 @@ function createForm (example, node) {
   node.id = id
   node.querySelector('[data-placeholder=title]').innerHTML = `<a href="#${id}" class="fg-grey-4 no-u">#</a> ${title || id}`
 
-  console.warn('Mounting example:', example, 'to', node)
+  console.info('Mounting example:', example, 'to', node)
 
   const model = Object.assign({}, defaults, example)
   return Formio.createForm(node.querySelector('form'), model)

--- a/src/kitchen-sink.js
+++ b/src/kitchen-sink.js
@@ -1,4 +1,5 @@
 import examples from './examples.yml'
+import pkg from '../package.json'
 
 const { Formio } = window
 
@@ -9,13 +10,29 @@ const defaults = {
 main()
 
 function main () {
-  const template = document.getElementById('form-template')
-  const root = template.parentNode
+  for (const el of document.querySelectorAll('[data-package]')) {
+    el.textContent = pkg[el.getAttribute('data-package')]
+  }
+
+  const formTemplate = document.getElementById('form-template')
+  const linkTemplate = document.getElementById('example-link')
   const forms = []
 
+  examples.sort((a, b) => {
+    return (a.title && b.title)
+      ? a.title.localeCompare(b.title)
+      : 0
+  })
+
   for (const example of examples) {
-    const node = template.content.cloneNode(true).firstElementChild
-    root.appendChild(node)
+    const linkItem = linkTemplate.content.cloneNode(true).firstElementChild
+    const link = linkItem.querySelector('[slot=link]')
+    link.href = `#${example.id}`
+    link.textContent = example.title || example.id
+    linkTemplate.parentNode.appendChild(linkItem)
+
+    const node = formTemplate.content.cloneNode(true).firstElementChild
+    formTemplate.parentNode.appendChild(node)
     try {
       const form = createForm(example, node)
       forms.push(form)
@@ -38,7 +55,7 @@ function main () {
 function createForm (example, node) {
   const { id, title } = example
   node.id = id
-  const heading = node.querySelector('[data-placeholder=title]')
+  const heading = node.querySelector('[slot=title]')
   heading.innerHTML = `<a href="#${id}" class="fg-grey-4 no-u">#</a> ${title || id}`
 
   // console.info('Mounting example:', example, 'to', node)

--- a/src/kitchen-sink.js
+++ b/src/kitchen-sink.js
@@ -16,8 +16,12 @@ function main () {
   for (const example of examples) {
     const node = template.content.cloneNode(true).firstElementChild
     root.appendChild(node)
-    const form = createForm(example, node)
-    forms.push(form)
+    try {
+      const form = createForm(example, node)
+      forms.push(form)
+    } catch (error) {
+      node.querySelector('form').innerHTML = createError(error)
+    }
   }
 
   const { hash } = window.location
@@ -34,10 +38,19 @@ function main () {
 function createForm (example, node) {
   const { id, title } = example
   node.id = id
-  node.querySelector('[data-placeholder=title]').innerHTML = `<a href="#${id}" class="fg-grey-4 no-u">#</a> ${title || id}`
+  const heading = node.querySelector('[data-placeholder=title]')
+  heading.innerHTML = `<a href="#${id}" class="fg-grey-4 no-u">#</a> ${title || id}`
 
-  console.info('Mounting example:', example, 'to', node)
+  // console.info('Mounting example:', example, 'to', node)
 
   const model = Object.assign({}, defaults, example)
-  return Formio.createForm(node.querySelector('form'), model)
+  const form = node.querySelector('form')
+  return Formio.createForm(form, model)
+    .catch(error => {
+      form.innerHTML = createError(error)
+    })
+}
+
+function createError (error) {
+  return `<div role="alert" class="round-1 fg-red-4 bg-red-1"><pre class="p-1 m-0">${error.stack}</pre></div>`
 }

--- a/src/kitchen-sink.js
+++ b/src/kitchen-sink.js
@@ -1,15 +1,15 @@
 import examples from './examples.yml'
 import pkg from '../package.json'
 
-const { Formio } = window
-
-const defaults = {
-  display: 'form'
-}
-
 main()
 
 function main () {
+  const { Formio } = window
+
+  const defaults = {
+    display: 'form'
+  }
+
   for (const el of document.querySelectorAll('[data-package]')) {
     el.textContent = pkg[el.getAttribute('data-package')]
   }
@@ -50,24 +50,24 @@ function main () {
       window.location = hash
     }
   }
-}
 
-function createForm (example, node) {
-  const { id, title } = example
-  node.id = id
-  const heading = node.querySelector('[slot=title]')
-  heading.innerHTML = `<a href="#${id}" class="fg-grey-4 no-u">#</a> ${title || id}`
+  function createForm (example, node) {
+    const { id, title } = example
+    node.id = id
+    const heading = node.querySelector('[slot=title]')
+    heading.innerHTML = `<a href="#${id}" class="fg-grey-4 no-u">#</a> ${title || id}`
 
-  // console.info('Mounting example:', example, 'to', node)
+    // console.info('Mounting example:', example, 'to', node)
 
-  const model = Object.assign({}, defaults, example)
-  const form = node.querySelector('form')
-  return Formio.createForm(form, model)
-    .catch(error => {
-      form.innerHTML = createError(error)
-    })
-}
+    const model = Object.assign({}, defaults, example)
+    const form = node.querySelector('form')
+    return Formio.createForm(form, model)
+      .catch(error => {
+        form.innerHTML = createError(error)
+      })
+  }
 
-function createError (error) {
-  return `<div role="alert" class="round-1 fg-red-4 bg-red-1"><pre class="p-1 m-0">${error.stack}</pre></div>`
+  function createError (error) {
+    return `<div role="alert" class="round-1 fg-red-4 bg-red-1"><pre class="p-1 m-0">${error.stack}</pre></div>`
+  }
 }

--- a/src/templates/field/form.ejs
+++ b/src/templates/field/form.ejs
@@ -2,7 +2,7 @@
 
 {{ ctx.element }}
 
-{% if (ctx.component.type !== 'checkbox') { %}
+{% if (['address', 'checkbox', 'well'].indexOf(ctx.component.type) === -1) { %}
   {% var description = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
   {% if (description) { %}
     <div class="field-description">

--- a/src/templates/file/form.ejs
+++ b/src/templates/file/form.ejs
@@ -1,6 +1,6 @@
 {% if (!ctx.self.imageUpload) { %}
 
-  <table class="align-left">
+  <table class="align-left mt-0 mb-2">
     <thead{% if ((ctx.files.length + ctx.statuses.length) === 0) { %} hidden{% } %}>
       <tr>
         <th class="col-md-{{ ctx.self.hasTypes ? 2 : 3 }}">

--- a/src/templates/well/form.ejs
+++ b/src/templates/well/form.ejs
@@ -1,7 +1,7 @@
 <div ref="{{ ctx.nestedKey }}" class="formio-component formio-component-well bg-blue-1 p-2 round-1">
-  {% var desc = ctx.t([`${ctx.component.key}_tooltip`, ctx.component.tooltip]) %}
+  {% var desc = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
   {% if (desc) { %}
-    <p class="description mt-0 mb-1">{{ help }}</p>
+    <p class="description mt-0 mb-1">{{ desc }}</p>
   {% } %}
   {{ ctx.children }}
 </div>

--- a/src/templates/well/form.ejs
+++ b/src/templates/well/form.ejs
@@ -1,3 +1,7 @@
 <div ref="{{ ctx.nestedKey }}" class="formio-component formio-component-well bg-blue-1 p-2 round-1">
+  {% var desc = ctx.t([`${ctx.component.key}_tooltip`, ctx.component.tooltip]) %}
+  {% if (desc) { %}
+    <p class="description mt-0 mb-1">{{ help }}</p>
+  {% } %}
   {{ ctx.children }}
 </div>


### PR DESCRIPTION
This is a bit of a mixed bag of updates:

0. [Development docs!](https://github.com/SFDigitalServices/formio-sfds/blob/2f97ce29e8a7222469d30ffb44b1a45130e2b950/DEVELOP.md)
1. There is a new U.S. state (`state`) component that simply renders a `<select>` of the 50 U.S. states. The [list of states](https://github.com/SFDigitalServices/formio-sfds/blob/component-fixes/data/states.json) can be easily updated if, for instance, we need to include territories like Puerto Rico and/or [USMPS codes](https://en.wikipedia.org/wiki/Military_mail#U.S._Military_Postal_Service_.28MPS.29).
2. There is also a new ZIP code (`zip`) component that has built-in 5-digit and/or ZIP+4 pattern validation. We can modify this component later on to, for instance, only allow San Francisco ZIP codes for some forms.
3. There is a patched `columns` component that returns what I _think_ is the correct ref key for the column elements, based on some sleuthing in the Chrome console. Without this, the columns in the address component blow up because they're attempting to iterate over a non-existent array of refs. **This merits some follow-up with form.io folks.**
4. Address and "well" components now render the field description before the content, _inside_ the "well".
5. The [examples document](https://unpkg.com/formio-sfds@0.0.0-3850e94/index.html) now includes a sticky list of links to each one.