### PR TITLE
Fix visual checkbox checked state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/templates/checkbox/form.ejs
+++ b/src/templates/checkbox/form.ejs
@@ -8,7 +8,7 @@
           {{attr}}="{{ctx.input.attr[attr]}}"
         {% } %}
         value="{{ ctx.value }}"
-        {% if (ctx.input.checked) { %}checked{% } %}
+        {% if (ctx.checked) { %}checked{% } %}
       >
     </div>
     <div class="flex-auto">


### PR DESCRIPTION
### Summary
Fixes a visual bug where checkboxes do not show the correct checked state when moving between pages.  The checked state does persist in javascript, just wasn't shown visually. 

### Before
![checkbox_before](https://user-images.githubusercontent.com/11635576/80190236-d1523300-85c8-11ea-9c4a-1d9d2e968ab9.gif)

### After
![checkbox_after](https://user-images.githubusercontent.com/11635576/80190257-d911d780-85c8-11ea-9071-aa7931758dae.gif)


