### PR TITLE
Fix datetime component localization (Spanish & Chinese)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,40 +9,42 @@
   <body>
     <div class="page-node-type-form-page">
       <div class="form-page formio-sfds">
-        <h1><code>formio-sfds@<span data-package="version">0.0.0</span></code></h1>
+        <div class="px-2">
+          <h1><code>formio-sfds@<span data-package="version">0.0.0</span></code></h1>
 
-        <div class="d-flex flex-column flex-md-row">
+          <div class="d-flex flex-column flex-md-row">
 
-          <div class="pr-md-4 position-relative">
+            <div class="pr-md-4 position-relative">
 
-            <h2 class="h2 mt-2">Examples</h1>
+              <h2 class="h2 mt-2">Examples</h1>
 
-            <div style="position: sticky; top: 0;">
-              <ul id="example-links" class="list-style-none">
-                <template id="example-link">
-                  <li>
-                    <a slot="link" class="d-block py-1"></a>
-                  </li>
-                </template>
-              </ul>
+              <div style="position: sticky; top: 0;">
+                <ul id="example-links" class="list-style-none">
+                  <template id="example-link">
+                    <li>
+                      <a slot="link" class="d-block py-1"></a>
+                    </li>
+                  </template>
+                </ul>
+              </div>
             </div>
-          </div>
 
-          <div class="mt-2 pt-1">
-            <template id="form-template">
-              <section class="example">
-                <h2 class="h3" slot="title"></h2>
-                <div class="d-flex">
-                  <form class="flex-auto" slot="form"></form>
-                  <div class="ml-2">
-                    <label class="fg-grey-4">
-                      Submission data:
-                    </label>
-                    <textarea name="data" class="border-grey-4" style="width: 16em; resize: vertical;"></textarea>
+            <div class="mt-2 pt-1">
+              <template id="form-template">
+                <section class="example">
+                  <h2 class="h3" slot="title"></h2>
+                  <div class="d-flex">
+                    <form class="flex-auto" slot="form"></form>
+                    <div class="ml-2">
+                      <label class="fg-grey-4">
+                        Submission data:
+                      </label>
+                      <textarea name="data" class="border-grey-4" style="width: 16em; resize: vertical;"></textarea>
+                    </div>
                   </div>
-                </div>
-              </section>
-            </template>
+                </section>
+              </template>
+            </div>
           </div>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "choices.js": "^9.0.1",
+    "flatpickr": "^4.6.3",
     "formiojs": "^4.9.0-rc.10",
     "interpolate": "^0.1.0",
     "rollup-plugin-terser": "^5.3.0",

--- a/src/examples.js
+++ b/src/examples.js
@@ -1,3 +1,4 @@
+import { mergeObjects } from './utils'
 import examples from './examples.yml'
 import pkg from '../package.json'
 
@@ -6,8 +7,18 @@ main()
 function main () {
   const { Formio } = window
 
-  const defaults = {
-    display: 'form'
+  const defaultOptions = {
+    display: 'form',
+    // XXX this should not be required, but it is
+    language: 'en'
+  }
+
+  const { search, hash } = window.location
+  const query = search || (hash ? hash.substr(1) : null)
+  if (query) {
+    for (const [key, value] of new URLSearchParams(query).entries()) {
+      defaultOptions[key] = value
+    }
   }
 
   for (const el of document.querySelectorAll('[data-package]')) {
@@ -53,18 +64,17 @@ function main () {
   })
 
   function createForm (example, node) {
-    const { id, title } = example
+    const { id, title, form } = example
     node.id = id
     const heading = node.querySelector('[slot=title]')
     heading.innerHTML = `<a href="#${id}" class="fg-grey-4 no-u">#</a> ${title || id}`
 
     const dataField = node.querySelector('[name=data]')
 
-    // console.info('Mounting example:', example, 'to', node)
-
-    const model = Object.assign({}, defaults, example)
-    const form = node.querySelector('form')
-    return Formio.createForm(form, null, model)
+    const options = mergeObjects({}, defaultOptions, example.options)
+    console.warn('options:', options)
+    const element = node.querySelector('form')
+    return Formio.createForm(element, form, options)
       .then(formio => {
         const offset = dataField.offsetHeight - dataField.clientHeight
         formio.on('change', () => {

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -62,10 +62,12 @@
         - width: 3
           components:
             - type: textfield
+              key: a
               label: Field 1
         - width: 3
           components:
             - type: textfield
+              key: b
               label: Field 2
 
 - id: columns-3
@@ -76,15 +78,19 @@
         - width: 2
           components:
             - type: textfield
+              key: a
               label: Field 1
         - width: 2
           components:
             - type: textfield
+              key: b
               label: Field 2
         - width: 2
           components:
-            - type: textfield
+            - type: number
+              key: c
               label: Field 3
+              defaultValue: 10
 
 - id: address
   title: Address (custom component)

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -1,74 +1,81 @@
 - id: single-file
   title: Single file upload
-  components:
-    - type: file
-      storage: base64
-      label: This is the label
-      description: This is the description
+  form:
+    components:
+      - type: file
+        storage: base64
+        label: This is the label
+        description: This is the description
 
 - id: multi-file
   title: Multiple file upload
-  components:
-    - type: file
-      storage: base64
-      label: This is the label
-      description: This is the description
-      multiple: true
+  form:
+    components:
+      - type: file
+        storage: base64
+        label: This is the label
+        description: This is the description
+        multiple: true
 
 - id: checkbox
   title: Checkbox
-  components:
-    - type: checkbox
-      label: This is a long label, and it should wrap nicely alongside the checkbox with the description below it.
-      description: And this is the description
-      tooltip: And this is the tooltip
+  form:
+    components:
+      - type: checkbox
+        label: This is a long label, and it should wrap nicely alongside the checkbox with the description below it.
+        description: And this is the description
+        tooltip: And this is the tooltip
 
 - id: radio
   title: Radio
-  components:
-    - type: radio
-      label: This is the label
-      description: And this is the description
-      tooltip: And this is the tooltip
-      values:
-        - label: Option 1
-          value: 1
-        - label: Option 2 (blah)
-          value: 2
-        - label: Option 3 (this is some really long text that should wrap nicely, thanks so much)
-          value: 3
+  form:
+    components:
+      - type: radio
+        label: This is the label
+        description: And this is the description
+        tooltip: And this is the tooltip
+        values:
+          - label: Option 1
+            value: 1
+          - label: Option 2 (blah)
+            value: 2
+          - label: Option 3 (this is some really long text that should wrap nicely, thanks so much)
+            value: 3
 
 - id: us-state
   title: U.S. state select (custom component)
-  components:
-    - type: state
-      label: This is the label
-      description: This is the description
-      tooltip: And this is the tooltip
+  form:
+    components:
+      - type: state
+        label: This is the label
+        description: This is the description
+        tooltip: And this is the tooltip
 
 - id: zip-code
   title: ZIP code
-  components:
-    - type: zip
-      label: This is the label
-      description: This is the description
-      tooltip: And this is the tooltip
+  form:
+    components:
+      - type: zip
+        label: This is the label
+        description: This is the description
+        tooltip: And this is the tooltip
 
 - id: columns-2
   title: Columns (2)
-  components:
-    - type: columns
-      columns:
-        - width: 3
-          components:
-            - type: textfield
-              key: a
-              label: Field 1
-        - width: 3
-          components:
-            - type: textfield
-              key: b
-              label: Field 2
+  form:
+    components:
+      - type: columns
+        columns:
+          - width: 3
+            components:
+              - type: textfield
+                key: a
+                label: Field 1
+          - width: 3
+            components:
+              - type: textfield
+                key: b
+                label: Field 2
 
 - id: columns-3
   title: Columns (3)
@@ -94,9 +101,54 @@
 
 - id: address
   title: Address (custom component)
-  components:
-    - type: address
-      label: This is the label
-      description: This is the description
-      tooltip: And this is the tooltip
-      multiple: true
+  form:
+    components:
+      - type: address
+        label: This is the label
+        description: This is the description
+        tooltip: And this is the tooltip
+        multiple: true
+
+- id: day-default
+  title: Day (default)
+  form:
+    components:
+      - type: day
+        label: This is the label
+        description: This is the description
+
+- id: datetime-date-only
+  title: Date (no time)
+  form:
+    components:
+      - type: datetime
+        label: This is the label
+        description: This is the description
+        enableTime: false
+
+- id: datetime-default
+  title: Date & time
+  form:
+    components:
+      - type: datetime
+        label: This is the label
+        description: This is the description
+
+- id: datetime-spanish
+  title: Date & time (Spanish)
+  form:
+    components:
+      - type: datetime
+        label: This is the label
+        description: This is the description
+  options:
+    language: es
+
+- id: datetime-time-only
+  title: Time (no date)
+  form:
+    components:
+      - type: datetime
+        label: This is the label
+        description: This is the description
+        enableDate: false

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -144,6 +144,16 @@
   options:
     language: es
 
+- id: datetime-chinese
+  title: Date & time (Chinese)
+  form:
+    components:
+      - type: datetime
+        label: This is the label
+        description: This is the description
+  options:
+    language: zh
+
 - id: datetime-time-only
   title: Time (no date)
   form:

--- a/src/patch.js
+++ b/src/patch.js
@@ -174,7 +174,7 @@ function updateLanguage (form) {
 function hook (obj, methodName, wrapper) {
   const method = obj[methodName]
   obj[methodName] = function (...args) {
-    return wrapper.call(this, method, args)
+    return wrapper.call(this, method.bind(this), args)
   }
 }
 
@@ -195,18 +195,17 @@ function patchI18nMultipleKeys (Formio) {
    * <https://github.com/formio/formio.js/blob/58996eac1207803cb597b4ab7c3abc6636078c72/src/components/_classes/component/Component.js#L707-L708>
    */
   hook(Formio.Components._components.component.prototype, 't', function (t, [keys, params]) {
-    const bound = t.bind(this)
     if (Array.isArray(keys)) {
       const last = keys.length - 1
       const fallback = (key, index) => {
-        const value = bound(key, params)
+        const value = t(key, params)
         return value === key ? (index === last) ? value : '' : value
       }
       return keys.reduce((value, key, index) => {
         return value || fallback(key, index)
       }, '')
     } else {
-      return bound(keys, params)
+      return t(keys, params)
     }
   })
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -3,6 +3,9 @@ import { observe } from 'selector-observer'
 import { mergeObjects } from './utils'
 import buildHooks from './hooks'
 import loadTranslations from './i18n/load'
+import 'flatpickr/dist/l10n/es'
+// import 'flatpickr/dist/l10n/tl'
+import 'flatpickr/dist/l10n/zh'
 
 const WRAPPER_CLASS = 'formio-sfds'
 const PATCHED = `sfds-patch-${Date.now()}`
@@ -15,9 +18,10 @@ export default Formio => {
     return
   }
 
-  util = window.FormioUtils
-  patch(Formio)
+  const { FormioUtils } = window
+  util = FormioUtils
 
+  patch(Formio)
   patchDateTimeSuffix()
 
   Formio[PATCHED] = true
@@ -131,6 +135,8 @@ function patch (Formio) {
 
   patchI18nMultipleKeys(Formio)
 
+  patchDateTimeLocale(Formio)
+
   // this goes last so that if it fails it doesn't break everything else
   patchLanguageObserver()
 }
@@ -222,5 +228,13 @@ function patchDateTimeSuffix () {
         group.insertBefore(text, group.firstChild)
       }
     }
+  })
+}
+
+function patchDateTimeLocale (Formio) {
+  hook(Formio.Components.components.datetime.prototype, 'attach', function (attach, args) {
+    this.component.widget.locale = this.options.language
+    console.info('patched Datetime widget.locale:', this.component.widget)
+    return attach(...args)
   })
 }


### PR DESCRIPTION
This adds a patch to Formio's Datetime component that properly passes locale (language) information down to [flatpickr](https://flatpickr.js.org/), the library that renders Formio's date picker. This should be fixed upstream; I'm going to work on a PR to formio.js after we get this working.

This also imports the [Spanish](https://github.com/flatpickr/flatpickr/blob/master/src/l10n/es.ts) and [Chinese](https://github.com/flatpickr/flatpickr/blob/master/src/l10n/zh.ts) (Mandarin) flatpickr localizations. Unfortunately, there isn't a Tagalog [localization](https://github.com/flatpickr/flatpickr/tree/master/src/l10n).

👀 Preview the changes: [Spanish](https://unpkg.com/formio-sfds@0.0.0-0bb8b2f/index.html#datetime-spanish) and [Chinese](https://unpkg.com/formio-sfds@0.0.0-0bb8b2f/index.html#datetime-chinese)

/cc @skinnylatte 