### PR TITLE
Avoid null form options, datetime locale weirdness

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -37,8 +37,8 @@ function patch (Formio) {
     // use the translations and language as the base, and merge the provided options
     const opts = mergeObjects({ i18n: defaultTranslations, language }, options)
 
-    if (typeof options.i18n === 'string') {
-      const { i18n: translationsURL } = options
+    if (typeof opts.i18n === 'string') {
+      const { i18n: translationsURL } = opts
       console.info('loading translations form:', translationsURL)
       try {
         const i18n = await loadTranslations(translationsURL)
@@ -68,7 +68,7 @@ function patch (Formio) {
       const { element } = form
 
       element.classList.add('d-flex', 'flex-column-reverse', 'mb-4')
-      if (options.googleTranslate === false) {
+      if (opts.googleTranslate === false) {
         element.classList.add('notranslate')
       }
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -233,8 +233,9 @@ function patchDateTimeSuffix () {
 
 function patchDateTimeLocale (Formio) {
   hook(Formio.Components.components.datetime.prototype, 'attach', function (attach, args) {
-    this.component.widget.locale = this.options.language
-    console.info('patched Datetime widget.locale:', this.component.widget)
+    if (this.options.language) {
+      this.component.widget.locale = this.options.language
+    }
     return attach(...args)
   })
 }


### PR DESCRIPTION
Two things in this set of fixes for #36:

1. @brianleesfgov discovered that our patched `Formio.createForm()` bails if you don't provide form render options in Drupal. This fixes that problem by only attempting to access options from the merged object rather than the possibly null form options argument directly.
2. There appear to be some cases in which a component's `options.language` isn't set, in which case passing along the locale to flatpickr throws an error. This fixes that by only setting the locale option if there's a language set in the component.