### PR TITLE
Warn users when they leave the form.

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -27,6 +27,21 @@ function scrollToTop() {
   window.scroll(0, 0)
 }
 
+// Prevent users from navigating away and losing their entries.
+let warnBeforeLeaving = false
+function turnWarningOn() {
+  warnBeforeLeaving = true
+}
+function turnWarningOff() {
+  warnBeforeLeaving = false
+}
+window.addEventListener('beforeunload', (event) => {
+  if (warnBeforeLeaving) {
+    // Most browsers will show a default message instead of this one.
+    event.returnValue = 'Leave site? Changes you made may not be saved.'
+  }
+})
+
 function patch(Formio) {
   console.info('Patching Formio.createForm() with SFDS behaviors...')
 
@@ -67,6 +82,8 @@ function patch(Formio) {
 
       form.on('nextPage', scrollToTop)
       form.on('prevPage', scrollToTop)
+      form.on('nextPage', turnWarningOn)
+      form.on('submitDone', turnWarningOff)
 
       const { element } = form
 


### PR DESCRIPTION
We're using the next page button as a trigger to turn the warning on and the submission of a form to then disable it.

[Trello card](https://trello.com/c/JszUksHc/333-show-native-browser-alert-message)