### PR TITLE
Add formioSFDSOptOut option

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -63,6 +63,11 @@ function patch (Formio) {
 
     const rest = resourceOrOptions ? [resourceOrOptions, opts] : [opts]
     return createForm(el, ...rest).then(form => {
+      if (opts.formioSFDSOptOut === true) {
+        console.log('SFDS form opted out:', opts, el)
+        return form
+      }
+
       console.log('SFDS form created!')
 
       const { element } = form


### PR DESCRIPTION
This adds the `formioSFDSOptOut` option to disable styling of form fields on a per-form basis, as discussed [in this thread](https://github.com/SFDigitalServices/sfgov/pull/534#discussion_r432656593). /cc @jacine @aekong 

~The other half of this is adding (yet) another output bundle that _should_ work within form.io's portal. I'm going to test that out in this PR, and if it doesn't work as expected I'll just revert 3115e22 and merge this into #36 with the opt-out option.~