### PR TITLE
Register custom components with form builder

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Loading...</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="https://unpkg.com/formiojs@latest/dist/formio.builder.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/bootstrap@latest/dist/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div id="formio"></div>
+    <pre id="schema"></pre>
+
+    <script src="https://unpkg.com/formiojs@latest/dist/formio.full.js"></script>
+    <script src="dist/formio-sfds.builder.js"></script>
+    <script defer>
+      (() => {
+        const root = document.getElementById('formio')
+        const schema = document.getElementById('schema')
+        const options = {
+        }
+
+        Formio.builder(root, {}, FormioSFDS.options).then(builder => {
+          builder.on('saveComponent', () => {
+            schema.value = JSON.stringify(builder.schema, null, 2)
+          })
+        })
+
+      })()
+    </script>
+  </body>
+</html>

--- a/builder.html
+++ b/builder.html
@@ -17,10 +17,8 @@
       (() => {
         const root = document.getElementById('formio')
         const schema = document.getElementById('schema')
-        const options = {
-        }
 
-        Formio.builder(root, {}, FormioSFDS.options).then(builder => {
+        Formio.builder(root, {}, {}).then(builder => {
           builder.on('saveComponent', () => {
             schema.value = JSON.stringify(builder.schema, null, 2)
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,17 +1962,17 @@
       "dev": true
     },
     "@formio/bootstrap3": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.3.0.tgz",
-      "integrity": "sha512-mkkuvt2CCRjdetiWcMsXzSW8oUgvgfgdaH3Tgs9Ov7KQBekKwCC6ShEqml0AQhDnmrQlFMek5oH0UF0fuw9cXg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.6.1.tgz",
+      "integrity": "sha512-0P8TB+3Rx4gDaiaoG9JXASzGCG6DlLvWQ1dn6FbHiZNRSsYx2giAnvfBGnskkJfRauNJ3m41CFP0VTBz+tJqrw==",
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
       }
     },
     "@formio/semantic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.3.0.tgz",
-      "integrity": "sha512-e159R/3hqJXUNUUb1xXSxqPEuNfJ5wgDHDM7iTLX1kxYIeKqrZUwCPRZ4ril6/zDeGLbIsCdvWw+teSBfbY4Tw=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.4.1.tgz",
+      "integrity": "sha512-kvb1YPhX07hALyMrXobYNJ0vT/Ey3ylmOC7X6gJF/xAq+65Kv0ITDHfUke5fsOYXY7Omn6E1k6Sl2kl6MIolMA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -2347,9 +2347,9 @@
       "optional": true
     },
     "autocompleter": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.0.2.tgz",
-      "integrity": "sha512-euXlT7i61H1Jd43kEA9Sq2M5pX8jl0Pxy5yEwxp79Jz00DejveE58ca/hF9jGS6l9FZIeA2yTKVK/gDKHNLDOA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.0.3.tgz",
+      "integrity": "sha512-CACd1r+AzgXOrppaYuOUWtJrM84EdUNSwRVXM0cuP6UQ09kLv7QumV7PD25kxRuZ7X4kVeTX9gkloH4NkNglvg=="
     },
     "autoprefixer": {
       "version": "9.7.4",
@@ -2961,9 +2961,9 @@
       "optional": true
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.4",
@@ -3522,9 +3522,9 @@
       "dev": true
     },
     "dialog-polyfill": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.0.tgz",
-      "integrity": "sha512-fOj68T8KB6UIsDFmK7zYbmORJMLYkRmtsLM1W6wbCVUWu4Hdcud5bqbvuueTxO84JXtK9HcpCHV9vNwlWUdCIw=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.1.tgz",
+      "integrity": "sha512-1+VxuUxUz1aUpVoZZADSx/PAtMJedtvOFzLJ/HYWboXxmWwtxBPnYzK8IDgxvojcpetewaJJg30f2pIvo4zbLw=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -3592,9 +3592,9 @@
       }
     },
     "dompurify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.8.tgz",
-      "integrity": "sha512-vIOSyOXkMx81ghEalh4MLBtDHMx1bhKlaqHDMqM2yeitJ996SLOk5mGdDpI9ifJAgokred8Rmu219fX4OltqXw=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.11.tgz",
+      "integrity": "sha512-qVoGPjIW9IqxRij7klDQQ2j6nSe4UNWANBhZNLnsS7ScTtLb+3YdxkRY8brNTpkUiTtcXsCJO+jS0UCDfenLuA=="
     },
     "domutils": {
       "version": "1.7.0",
@@ -4033,9 +4033,9 @@
       "dev": true
     },
     "eventemitter2": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.0.0.tgz",
-      "integrity": "sha512-ZuNWHD7S7IoikyEmx35vPU8H1W0L+oi644+4mSTg7nwXvBQpIwQL7DPjYUF0VMB0jPkNMo3MqD07E7MYrkFmjQ=="
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.2.tgz",
+      "integrity": "sha512-r/Pwupa5RIzxIHbEKCkNXqpEQIIT4uQDxmP4G/Lug/NokVUWj0joz/WzWl3OxRpC5kDrH/WdiUJoR+IrwvXJEw=="
     },
     "execall": {
       "version": "2.0.0",
@@ -4154,9 +4154,9 @@
       }
     },
     "fetch-ponyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.0.tgz",
-      "integrity": "sha512-bLc7JCjpJZZUXVxbgwUhd72Q19MAokrCXOg/Akq+wl0uFLFLklFdBkZo5OpQ3kLI0oGqrKdx6t5Zo3QwXBRmbQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.1.tgz",
+      "integrity": "sha512-rWLgTr5A44/XhvCQPYj0X9Tc+cjUaHofSM4lcwjc9MavD5lkjIhJ+h8JQlavPlTIgDpwhuRozaIykBvX9ItaSA==",
       "requires": {
         "node-fetch": "~2.6.0"
       }
@@ -4266,34 +4266,34 @@
       "optional": true
     },
     "formiojs": {
-      "version": "4.9.0-rc.10",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.9.0-rc.10.tgz",
-      "integrity": "sha512-bp1+tw1La8qsBRi4vEcBkk7lxdbXCAMWkjjMyoR4sMy29rSE1x+ACHdbaPTWAu9KGB8kz6UeNYh394SbXsCeeA==",
+      "version": "4.9.26",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.9.26.tgz",
+      "integrity": "sha512-A/nZyZ/NZEg1GrskmxDXdsy+1nVNwZLBF7vyMQdv6m1abq/MP5m4glaVJnLcggrYFXRKZIJ0XMgBOn3Hvr9WbQ==",
       "requires": {
-        "@formio/bootstrap3": "^2.3.0",
+        "@formio/bootstrap3": "^2.4.0",
         "@formio/semantic": "^2.3.0",
-        "autocompleter": "^6.0.2",
+        "autocompleter": "^6.0.3",
         "browser-cookies": "^1.2.0",
         "choices.js": "^9.0.1",
-        "core-js": "^3.6.4",
+        "core-js": "^3.6.5",
         "custom-event-polyfill": "^1.0.7",
-        "dialog-polyfill": "^0.5.0",
-        "dompurify": "^2.0.8",
+        "dialog-polyfill": "^0.5.1",
+        "dompurify": "^2.0.10",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.2",
-        "eventemitter2": "^6.0.0",
+        "eventemitter2": "^6.3.1",
         "fast-deep-equal": "^3.1.1",
         "fast-json-patch": "^2.2.1",
         "fetch-ponyfill": "^6.1.0",
         "flatpickr": "^4.6.3",
-        "i18next": "^19.3.2",
-        "idb": "^5.0.1",
-        "ismobilejs": "^1.0.3",
+        "i18next": "^19.4.4",
+        "idb": "^5.0.2",
+        "ismobilejs": "^1.1.1",
         "json-logic-js": "^1.2.2",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^2.2.0",
         "lodash": "^4.17.15",
-        "moment": "^2.24.0",
+        "moment": "2.24.0",
         "moment-timezone": "^0.5.28",
         "native-promise-only": "^0.8.1",
         "resize-observer-polyfill": "^1.5.1",
@@ -4301,16 +4301,9 @@
         "string-hash": "^1.1.3",
         "text-mask-addons": "^3.8.0",
         "tooltip.js": "^1.3.3",
-        "uuid": "^7.0.2",
+        "uuid": "^8.0.0",
         "vanilla-picker": "^2.10.1",
         "vanilla-text-mask": "^5.1.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
-          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
-        }
       }
     },
     "fragment-cache": {
@@ -4784,9 +4777,9 @@
       }
     },
     "i18next": {
-      "version": "19.3.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.3.3.tgz",
-      "integrity": "sha512-CnuPqep5/JsltkGvQqzYN4d79eCe0TreCBRF3a8qHHi8x4SON1qqZ/pvR2X7BfNkNqpA5HXIqw0E731H+VsgSg==",
+      "version": "19.4.5",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.4.5.tgz",
+      "integrity": "sha512-aLvSsURoupi3x9IndmV6+m3IGhzLzhYv7Gw+//K3ovdliyGcFRV0I1MuddI0Bk/zR7BG1U+kJOjeHFUcUIdEgg==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -4807,9 +4800,9 @@
       "dev": true
     },
     "idb": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.1.tgz",
-      "integrity": "sha512-jdFnxTvz3JZ5AQP4nAb0x7bnisFNO5KqafsarDn/aehIn84UcVY3z96mq6WiqNe8z7OpZWZ0xG1ORbkwuBp5Mw=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.4.tgz",
+      "integrity": "sha512-g+CRa0NLB5R+VTd8UQK/J8eEPlZk82iwekJQOYA0bFJsc7TGDKyBywNmLBUdHPUyyazV1wN8DdHhSKzEX9Z9kQ=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -5305,9 +5298,9 @@
       "dev": true
     },
     "ismobilejs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.0.3.tgz",
-      "integrity": "sha512-6rTcdWK7PHIWPYlCPdTbU9eE9yzdnIQSpiH+8Ln5OqugpEszQK5KHlsjZrDae26fEhki9rPvQmsjI1q4CLuKIA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
     },
     "jest-worker": {
       "version": "24.9.0",
@@ -5902,9 +5895,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -9403,6 +9396,11 @@
         "has-symbols": "^1.0.1",
         "object.getownpropertydescriptors": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "choices.js": "^9.0.1",
     "flatpickr": "^4.6.3",
-    "formiojs": "^4.9.0-rc.10",
+    "formiojs": "^4.9.26",
     "interpolate": "^0.1.0",
     "rollup-plugin-terser": "^5.3.0",
     "uri-template-lite": "^19.12.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -95,6 +95,17 @@ export default [
     }
   },
   {
+    input: 'src/builder.js',
+    plugins: [
+      ...commonPlugins
+    ],
+    output: {
+      format: 'umd',
+      name,
+      file: 'dist/formio-sfds.builder.js'
+    }
+  },
+  {
     input: 'src/examples.js',
     plugins: [
       ...commonPlugins,

--- a/src/builder.js
+++ b/src/builder.js
@@ -1,5 +1,7 @@
 import FormioSFDS, { patch } from '.'
 
+delete FormioSFDS.templates
+
 const { Formio } = window
 
 patch(Formio)

--- a/src/builder.js
+++ b/src/builder.js
@@ -1,6 +1,3 @@
-import 'sf-design-system/public/dist/css/all.css'
-import '../dist/formio-sfds.css'
-
 import FormioSFDS, { patch } from '.'
 
 const { Formio } = window

--- a/src/builder.js
+++ b/src/builder.js
@@ -5,4 +5,4 @@ const { Formio } = window
 patch(Formio)
 Formio.use(FormioSFDS)
 
-window.FormioSFDS = FormioSFDS
+export default FormioSFDS

--- a/src/builder.js
+++ b/src/builder.js
@@ -1,14 +1,19 @@
 import FormioSFDS, { patch } from '.'
+import { hook } from './patch'
 
 delete FormioSFDS.templates
 
 const { Formio } = window
 
-// FIXME: this hack appears to be necessary to override the form builder
-// default options
-Formio.FormBuilder.options = FormioSFDS.options
+patch(Formio, {
+  icons: false
+})
 
-patch(Formio)
+hook(Formio.FormBuilder.prototype, 'create', function (create, args) {
+  this.options = FormioSFDS.options
+  return create(args)
+})
+
 Formio.use(FormioSFDS)
 
 export default FormioSFDS

--- a/src/builder.js
+++ b/src/builder.js
@@ -1,5 +1,5 @@
 import FormioSFDS, { patch } from '.'
-import { hook } from './patch'
+// import { hook } from './patch'
 
 delete FormioSFDS.templates
 
@@ -9,10 +9,12 @@ patch(Formio, {
   icons: false
 })
 
+/*
 hook(Formio.FormBuilder.prototype, 'create', function (create, args) {
   this.options = FormioSFDS.options
   return create(args)
 })
+*/
 
 Formio.use(FormioSFDS)
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -4,6 +4,10 @@ delete FormioSFDS.templates
 
 const { Formio } = window
 
+// FIXME: this hack appears to be necessary to override the form builder
+// default options
+Formio.FormBuilder.options = FormioSFDS.options
+
 patch(Formio)
 Formio.use(FormioSFDS)
 

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -74,7 +74,7 @@ export default class AddressComponent extends Container {
     return {
       title: 'Address',
       group: 'sfds',
-      icon: 'home',
+      icon: '',
       schema: AddressComponent.schema()
     }
   }

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -12,7 +12,7 @@ export default class AddressComponent extends Container {
       tableView: true,
       components: [
         {
-          label: 'Address line 1',
+          label: 'Line 1',
           key: 'line1',
           type: 'textfield',
           input: true,
@@ -20,7 +20,7 @@ export default class AddressComponent extends Container {
           validate: { required: true }
         },
         {
-          label: 'Address line 2',
+          label: 'Line 2',
           key: 'line2',
           type: 'textfield',
           customClass: componentClass,
@@ -36,6 +36,7 @@ export default class AddressComponent extends Container {
         },
         {
           type: 'columns',
+          hideLabel: true,
           customClass: 'mb-0',
           columns: [
             {
@@ -67,6 +68,15 @@ export default class AddressComponent extends Container {
         }
       ]
     }, ...extend)
+  }
+
+  static get builderInfo () {
+    return {
+      title: 'Address',
+      group: 'sfds',
+      icon: 'home',
+      schema: AddressComponent.schema()
+    }
   }
 
   get defaultSchema () {

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -8,11 +8,20 @@ export default class StateSelect extends Select {
       // these are schema fields that should be overridden
       key: 'state',
       widget: 'html5',
+      label: 'State',
       dataSrc: 'values',
       data: { values },
       valueProperty: 'code',
       template: '{{ item.name }}'
     }, ...extend)
+  }
+
+  static get builderInfo () {
+    return {
+      title: 'U.S. state',
+      group: 'sfds',
+      schema: StateSelect.schema()
+    }
   }
 
   get defaultSchema () {

--- a/src/components/zip.js
+++ b/src/components/zip.js
@@ -4,6 +4,7 @@ export default class ZIPCode extends TextField {
   static schema (...extend) {
     return TextField.schema({
       // these are schema fields that should be overridden
+      type: 'zip',
       key: 'zip',
       validate: {
         required: true,
@@ -14,6 +15,14 @@ export default class ZIPCode extends TextField {
         pattern: 'Please enter a 5-digit <a href="https://en.wikipedia.org/wiki/ZIP_Code">ZIP code</a>'
       }
     }, ...extend)
+  }
+
+  static get builderInfo () {
+    return {
+      title: 'ZIP code',
+      group: 'sfds',
+      schema: ZIPCode.schema()
+    }
   }
 
   get defaultSchema () {

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -162,3 +162,38 @@
         label: This is the label
         description: This is the description
         enableDate: false
+
+- id: select-basic
+  title: Select (basic)
+  form:
+    components:
+      - type: select
+        label: This is the label
+        description: This is the description
+        dataSrc: values
+        data:
+          values:
+            - label: One
+              value: 1
+            - label: Two
+              value: 2
+            - label: Three
+              value: 3
+
+- id: select-autocomplete
+  title: Select (auto-complete)
+  form:
+    components:
+      - type: select
+        label: This is the label
+        description: This is the description
+        tags: [autocomplete]
+        dataSrc: values
+        data:
+          values:
+            - label: One
+              value: 1
+            - label: Two
+              value: 2
+            - label: Three
+              value: 3

--- a/src/index.js
+++ b/src/index.js
@@ -16,5 +16,3 @@ const plugin = {
 
 export default plugin
 export { patch }
-
-observeIcons()

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
 import components from './components'
 import patch from './patch'
 import templates from './templates'
-import { observeIcons } from './icons'
+import options from './options'
 import 'regenerator-runtime'
 
 const framework = 'sfds'
 
 const plugin = {
-  framework,
   components,
+  framework,
+  options,
   templates: {
     [framework]: templates
   }

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,34 @@
+export default {
+  builder: {
+    premium: false,
+    sfds: {
+      title: 'SFDS fields',
+      weight: 90,
+      components: {
+        name: {
+          title: 'Name',
+          schema: {
+            type: 'container',
+            label: 'Name',
+            key: 'name',
+            tableView: true,
+            components: [
+              {
+                type: 'textfield',
+                key: 'first',
+                label: 'First name'
+              },
+              {
+                type: 'textfield',
+                key: 'last',
+                label: 'Last name'
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  editForm: {
+  }
+}

--- a/src/options.js
+++ b/src/options.js
@@ -2,8 +2,8 @@ export default {
   builder: {
     premium: false,
     sfds: {
-      title: 'SFDS fields',
-      weight: 90,
+      title: 'SF.gov',
+      weight: 15,
       components: {
         name: {
           title: 'Name',

--- a/src/options.js
+++ b/src/options.js
@@ -1,34 +1,35 @@
 export default {
   builder: {
-    premium: false,
-    sfds: {
-      title: 'SF.gov',
-      weight: 15,
-      components: {
-        name: {
-          title: 'Name',
-          schema: {
-            type: 'container',
-            label: 'Name',
-            key: 'name',
-            tableView: true,
-            components: [
-              {
-                type: 'textfield',
-                key: 'first',
-                label: 'First name'
-              },
-              {
-                type: 'textfield',
-                key: 'last',
-                label: 'Last name'
-              }
-            ]
+    // XXX the double nesting is required here
+    builder: {
+      premium: false,
+      sfds: {
+        title: 'SF.gov',
+        weight: 15,
+        components: {
+          name: {
+            title: 'Name',
+            schema: {
+              type: 'container',
+              label: 'Name',
+              key: 'name',
+              tableView: true,
+              components: [
+                {
+                  type: 'textfield',
+                  key: 'first',
+                  label: 'First name'
+                },
+                {
+                  type: 'textfield',
+                  key: 'last',
+                  label: 'Last name'
+                }
+              ]
+            }
           }
         }
       }
     }
-  },
-  editForm: {
   }
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,5 +1,6 @@
-import defaultTranslations from './i18n'
 import { observe } from 'selector-observer'
+import defaultTranslations from './i18n'
+import { observeIcons } from './icons'
 import { mergeObjects } from './utils'
 import buildHooks from './hooks'
 import loadTranslations from './i18n/load'
@@ -25,6 +26,7 @@ export default Formio => {
   patchDateTimeSuffix()
 
   Formio[PATCHED] = true
+  observeIcons()
 }
 
 function patch (Formio) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -4,9 +4,11 @@ import { observeIcons } from './icons'
 import { mergeObjects } from './utils'
 import buildHooks from './hooks'
 import loadTranslations from './i18n/load'
+import { dependencies } from '../package.json'
+
 import 'flatpickr/dist/l10n/es'
-// import 'flatpickr/dist/l10n/tl'
 import 'flatpickr/dist/l10n/zh'
+// import 'flatpickr/dist/l10n/tl'
 
 const WRAPPER_CLASS = 'formio-sfds'
 const PATCHED = `sfds-patch-${Date.now()}`
@@ -17,6 +19,12 @@ const forms = []
 export default Formio => {
   if (Formio[PATCHED]) {
     return
+  }
+
+  const { formiojs: formioVersion } = dependencies
+
+  if (formioVersion && Formio.version !== formioVersion.replace(/^\^/, '')) {
+    console.warn('Formio.version "%s" does not match formio-sfds expected: "%s"', Formio.version, formioVersion)
   }
 
   const { FormioUtils } = window

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -8,4 +8,4 @@ const { Formio } = window
 patch(Formio)
 Formio.use(FormioSFDS)
 
-window.FormioSFDS = FormioSFDS
+export default FormioSFDS


### PR DESCRIPTION
This PR adds a JS bundle that can be used to register our custom components with the form.ui builder on [next.form.io](https://next.form.io). The new bundle provides no CSS, and instead focuses on:

0. Adding a [builder.html](https://unpkg.com/formio-sfds@0.0.0-66b5134/builder.html) that helps us test the form builder modifications outside of form.io's portal;
1. Getting our components into the builder side bar; and
2. Adding/updating "builder info" for the components so that they show up with the right titles, etc.

One piece that I'm still not sure about how to implement is the "edit form" schema for each of these. More on that after I do the first round of testing.