### PR TITLE
Fix flatpickr year input visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/scss/forms/_hacks.scss
+++ b/src/scss/forms/_hacks.scss
@@ -2,3 +2,8 @@
 .control-label--hidden {
   display: none;
 }
+
+.flatpickr-monthDropdown-months {
+  display: inline-block !important;
+  margin-right: 20px !important;
+}


### PR DESCRIPTION
@skinnylatte noticed that the year input in Flatpickr isn't visible by default:

![image](https://user-images.githubusercontent.com/113896/83801085-60894680-a65d-11ea-810a-37e6b004f5f5.png)

It was a CSS problem: all of our `<select>` elements get `display: block`, so by targeting Flatpickr's year input with `display: inline-block` (and some right margin) we can bring it back:

![image](https://user-images.githubusercontent.com/113896/83801192-93333f00-a65d-11ea-843c-eb9175f3d75a.png)

This will release version 4.2.1.