### PR TITLE
Fix flatpickr year again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/scss/_flatpickr.scss
+++ b/src/scss/_flatpickr.scss
@@ -1,0 +1,7 @@
+@import url(flatpickr/dist/flatpickr.min.css);
+
+// this fixes a bug with the year
+.flatpickr-current-month .flatpickr-monthDropdown-months {
+  display: inline-block !important;
+  margin-right: 20px !important;
+}

--- a/src/scss/forms/_hacks.scss
+++ b/src/scss/forms/_hacks.scss
@@ -2,8 +2,3 @@
 .control-label--hidden {
   display: none;
 }
-
-.flatpickr-monthDropdown-months {
-  display: inline-block !important;
-  margin-right: 20px !important;
-}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -28,4 +28,4 @@
   @import "./overrides";
 }
 
-@import url(flatpickr/dist/flatpickr.min.css);
+@import "./flatpickr";


### PR DESCRIPTION
Turns out I didn't scope the CSS fix properly in #45: the fix was nested in the top-level `.formio-sfds` selector, but Flatpickr renders itself directly in the body to avoid z-index issues.

@skinnylatte You should be able to test this out [here](https://unpkg.com/formio-sfds@0.0.0-36ded71/standalone.html#res=https://sfds.form.io/copyofresiliencyfundforfixingcalendarbug). The only thing that's a bit funky is the AM/PM part of the date time format ("a") in the field value:

![image](https://user-images.githubusercontent.com/113896/83841825-74ad6200-a6b6-11ea-9625-be2a4e1fa970.png)
