### PR TITLE
Fix language detection on sf.gov

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/patch.js
+++ b/src/patch.js
@@ -165,7 +165,7 @@ function patchLanguageObserver () {
 }
 
 function updateLanguage (form) {
-  const closestLangElement = form.element.closest('[lang]')
+  const closestLangElement = form.element.closest('[lang]:not([class*=sfgov-translate-lang-])')
   if (closestLangElement) {
     form.language = closestLangElement.getAttribute('lang')
   }

--- a/standalone.html
+++ b/standalone.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://sf.gov/sites/default/files/css/css_agj0hHq_5HVrrndLMoscH8SQhKRwitxKeDC_Y2RXMOc.css?q8589x">
   </head>
   <body>
-    <div class="page-node-type-form-page">
+    <div class="page-node-type-form-page sfgov-translate-lang-es" lang="en">
       <div class="form-page">
         <div id="formio" class="container p-3" data-resource="https://sfds.form.io/workers-families-first"></div>
       </div>
@@ -26,8 +26,19 @@
         const hooks = tryParse(params.get('hooks'))
         const resource = params.get('res') || root.getAttribute('data-resource')
 
-        const options = { language, renderMode, hooks, i18n, prefill: params }
-        options.googleTranslate = false
+        const options = {
+          language,
+          renderMode,
+          hooks,
+          i18n,
+          prefill: params,
+          googleTranslate: params.get('googleTranslate') === 'true'
+        }
+
+        if (params.lang && params.langMode === 'dom') {
+          document.documentElement.setAttribute('lang', language)
+          delete options.language
+        }
 
         Formio.createForm(root, resource, options).then(form => {
           console.log('form ready:', form)


### PR DESCRIPTION
https://github.com/SFDigitalServices/sfgov/issues/563 (moved to Jira) describes the issue at play here. TL;DR: sf.gov's DOM doesn't accurately reflect the selected language right now, so we need to skip over elements that have the `sfgov-translate-lang-*` classes when determining which language to use.

**Note:** There isn't currently any situation on sf.gov in which I'd expect forms in different languages to appear on the same page. A more robust fix would have updated this to look at `document.documentElement.lang` (the `<html>` element's `lang` attribute), but doing so would prevent us from testing localized components on a single page.