### PR TITLE
Release 5.0.2

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -80,8 +80,9 @@ npm package for every push that passes the [CI
 workflow](../.github/workflows/ci.yml). The name of the branch determines the
 "type" of release:
 
-- Merges to `master` will release new versions to the `latest` (default)
-  dist-tag if the `version` field in `package.json` has been incremented.
+- Merges to the default branch (`main`) will release new versions to the
+  `latest` (default) dist-tag if the `version` field in `package.json` has been
+  incremented.
 - Pushes to `release-<version>` will publish npm releases to the `next`
   dist-tag with versions in the form `<version>-rc.<sha>`, where `<sha>` is the
   7-character commit SHA.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   ],
   "author": "San Francisco Digital Services",
   "license": "MIT",
+  "@primer/publish": {
+    "releaseBranch": "main"
+  },
   "dependencies": {
     "choices.js": "^9.0.1",
     "flatpickr": "^4.6.3",


### PR DESCRIPTION
This patch release includes internal updates to facilitate our switch of the default branch name from `master` to `main`.

![image](https://user-images.githubusercontent.com/113896/84533789-b4b7aa80-ac9d-11ea-948f-ff61f16fca1a.png)
