### PR TITLE
"master" → "main" internal updates

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -80,8 +80,9 @@ npm package for every push that passes the [CI
 workflow](../.github/workflows/ci.yml). The name of the branch determines the
 "type" of release:
 
-- Merges to `master` will release new versions to the `latest` (default)
-  dist-tag if the `version` field in `package.json` has been incremented.
+- Merges to the default branch (`main`) will release new versions to the
+  `latest` (default) dist-tag if the `version` field in `package.json` has been
+  incremented.
 - Pushes to `release-<version>` will publish npm releases to the `next`
   dist-tag with versions in the form `<version>-rc.<sha>`, where `<sha>` is the
   7-character commit SHA.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   ],
   "author": "San Francisco Digital Services",
   "license": "MIT",
+  "@primer/publish": {
+    "releaseBranch": "main"
+  },
   "dependencies": {
     "choices.js": "^9.0.1",
     "flatpickr": "^4.6.3",


### PR DESCRIPTION
Two things:

1. Development docs referred to `master` specifically, but can safely refer to the "default branch" instead.
2. We'll need to set the [`defaultBranch` option in primer/publish](https://github.com/primer/publish/blob/201272b0eea8518e503a2cf831f49d99a1a279fc/src/context.js#L29) so that the action knows when to publish to the npm `latest` dist-tag.