### PR TITLE
Add translate view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2899,15 +2899,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001081",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz",
-          "integrity": "sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ==",
+          "version": "1.0.30001083",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001083.tgz",
+          "integrity": "sha512-CnYJ27awX4h7yj5glfK7r1TOI13LBytpLzEgfj0s4mY75/F8pnQcYjL+oVpmS38FB59+vU0gscQ9D8tc+lIXvA==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.467",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.467.tgz",
-          "integrity": "sha512-U+QgsL8TZDU/n+rDnYDa3hY5uy3C4iry9mrJS0PNBBGwnocuQ+aHSfgY44mdlaK9744X5YqrrGUvD9PxCLY1HA==",
+          "version": "1.3.473",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.473.tgz",
+          "integrity": "sha512-smevlzzMNz3vMz6OLeeCq5HRWEj2AcgccNPYnAx4Usx0IOciq9DU36RJcICcS09hXoY7t7deRfVYKD14IrGb9A==",
           "dev": true
         },
         "node-releases": {
@@ -4696,9 +4696,9 @@
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.3.tgz",
+      "integrity": "sha512-fWSEEcoqcYqlFJrpSH5dJTwv6o0r+2bLAmnlne8OQMbFhpSTQXA8Ngp6q1DGA4B+eewHeuH5ndZeiV2qyXXNsA==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5466,9 +5466,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.2.0.tgz",
+      "integrity": "sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -5979,9 +5979,9 @@
       "integrity": "sha512-ARADHortktl9IZ1tr4GHwGPIAzgz3mLNCbR/YjWtRtc/O0o634O3NeFlpLjv95EvuDA5dc8z6yfgbS8nUc4zcQ=="
     },
     "jsx-ast-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.3.0.tgz",
-      "integrity": "sha512-3HNoc7nZ1hpZIKB3hJ7BlFRkzCx2BynRtfSwbkqZdpRdvAPsGMnzclPwrvDBS7/lalHTj21NwIeaEpysHBOudg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+      "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -6930,22 +6930,37 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
             "object-inspect": "^1.7.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
           }
         }
       }
@@ -8567,9 +8582,9 @@
       }
     },
     "rollup": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.15.0.tgz",
-      "integrity": "sha512-HAk4kyXiV5sdNDnbKWk5zBPnkX/DAgx09Kbp8rRIRDVsTUVN3vnSowR7ZHkV6/lAiE6c2TQ8HtYb72aCPGW4Jw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.16.1.tgz",
+      "integrity": "sha512-UYupMcbFtoWLB6ZtL4hPZNUTlkXjJfGT33Mmhz3hYLNmRj/cOvX2B26ZxDQuEpwtLdcyyyraBGQ7EfzmMJnXXg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
@@ -8920,9 +8935,9 @@
       }
     },
     "sf-design-system": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sf-design-system/-/sf-design-system-1.3.0.tgz",
-      "integrity": "sha512-6h7wd9/3jg57fe8gd0OzdYhJPNJ0HFQVh7qYbJmv0twQY8nmVXel+/RKyVITM3HHpmHpvvn6/MCb5Uv2OzWCXg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/sf-design-system/-/sf-design-system-1.3.1.tgz",
+      "integrity": "sha512-NxetjHP4t6gnJlCYW2riNaVgPqgXt7mkhVAdyGrDf536mN/vpw6oO8iMcQLavJncGYaVd/w2bEsorGXvjeOLrA==",
       "dev": true
     },
     "shebang-command": {
@@ -9326,6 +9341,52 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        }
+      }
+    },
     "string.prototype.trimleft": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
@@ -9344,6 +9405,52 @@
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        }
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "autoprefixer": "^9.8.0",
     "dotenv": "^8.2.0",
     "google-spreadsheet": "^3.0.11",
+    "i18next": "^19.4.5",
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.31",
     "postcss-cli": "^7.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -104,5 +104,15 @@ export default [
       format: 'umd',
       file: 'dist/examples.js'
     }
+  },
+  {
+    input: 'src/translate.js',
+    plugins: [
+      ...commonPlugins
+    ],
+    output: {
+      format: 'umd',
+      file: 'dist/translate.js'
+    }
   }
 ]

--- a/src/patch.js
+++ b/src/patch.js
@@ -128,6 +128,9 @@ function patch(Formio) {
         console.info('submission before prefill:', form.submission)
         let params
         switch (opts.prefill) {
+          case 'url':
+            params = new URLSearchParams(window.location.search || window.location.hash.substr(1))
+            break
           case 'querystring':
             params = new URLSearchParams(window.location.search)
             break

--- a/src/scss/forms/_hacks.scss
+++ b/src/scss/forms/_hacks.scss
@@ -2,3 +2,10 @@
 .control-label--hidden {
   display: none;
 }
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+  border-color: $grey-4 !important;
+  background-color: $grey-1 !important;
+}

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -5,7 +5,7 @@
 {% if (ctx.component.prefix) { %}
   <div class="input-group-prepend" ref="prefix">
     <span class="input-group-text">
-      {{ctx.component.prefix}}
+      {{ ctx.t([`${ctx.component.key}_prefix`, ctx.component.prefix]) }}
     </span>
   </div>
 {% } %}
@@ -30,7 +30,7 @@
 {% if (ctx.component.suffix) { %}
   <div class="input-group-append" ref="suffix">
     <span class="input-group-text">
-      {{ctx.component.suffix}}
+      {{ ctx.t([`${ctx.component.key}_suffix`, ctx.component.suffix]) }}
     </span>
   </div>
 {% } %}

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -1,5 +1,7 @@
 <nav aria-label="navigation" id="{{ ctx.wizardKey }}-header" class="fg-slate-70">
-  <a class="back-link fg-black fw-medium" href="{{ ctx.options.properties.backURL}}">{{ ctx.options.properties.backTitle}}</a>
+  {% if (ctx.options.properties) { %}
+    <a class="back-link fg-black fw-medium" href="{{ ctx.options.properties.backURL}}">{{ ctx.options.properties.backTitle}}</a>
+  {% } %}
   <ul class="panel-list list-style-none mt-1">
     {% ctx.panels.forEach(function(panel, index) { %}
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -455,7 +455,7 @@ function fieldDescription (type) {
 
 function formatString (str) {
   // eslint-disable-next-line no-unused-vars
-  const [_, leading, inner, trailing] = str.match(/^(\s*)(.+)(\s*)$/, str)
+  const [_, leading, inner, trailing] = str.match(/^(\s*)(.+)(\s*)$/, str) || ['', '', str, '']
   return `&ldquo;${formatGremlins(leading)}${escapeHTML(inner)}${formatGremlins(trailing)}&rdquo;`
 }
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -166,7 +166,7 @@ Formio.createForm(document.getElementById('edit-form'), {
     })
   })
 
-  if (window.location.search) {
+  if (window.location.search || window.location.hash) {
     editForm.submit()
   }
 })

--- a/src/translate.js
+++ b/src/translate.js
@@ -99,6 +99,17 @@ Formio.createForm(document.getElementById('edit-form'), {
       lang
     } = submission.data
 
+    const params = { formUrl, translationsUrl, lang }
+    if (window.location.hash) {
+      console.info('replacing URL hash:', window.location.hash, params)
+      window.location.hash = new URLSearchParams(params).toString()
+    } else {
+      if (window.location.search) {
+        console.info('replacing query string:', window.location.search, params)
+      }
+      window.history.replaceState(params, '', `?${new URLSearchParams(params).toString()}`)
+    }
+
     const element = document.getElementById('translation-form')
     // element.hidden = false
     element.setAttribute('lang', lang)

--- a/src/translate.js
+++ b/src/translate.js
@@ -207,7 +207,7 @@ Formio.createForm(document.getElementById('edit-form'), {
         {
           type: 'htmlelement',
           tag: 'div',
-          content: 'Links: <a href="{{data.spreadsheetUrl}}">Spreadsheet</a>, <a href="{{data.translationsUrl}}">JSON</a>'
+          content: 'Links: <a href="{{data.spreadsheetUrl}}">Spreadsheet</a> (<a href="{{data.translationsUrl}}">JSON</a>), <a href="{{data.formUrl}}">form data JSON</a>'
         },
         {
           key: 'renderOptions',

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,0 +1,110 @@
+import i18next from 'i18next'
+import getJSON from './utils'
+
+let translationForm
+
+const { Formio } = window
+
+window.i18next = i18next
+
+Formio.createForm(document.getElementById('edit-form'), {
+  components: [
+    {
+      type: 'textfield',
+      key: 'formUrl',
+      label: 'form.io resource or form',
+      placeholder: 'https://sfds.form.io/...',
+      validate: {
+        required: true
+      }
+    },
+    {
+      type: 'textfield',
+      key: 'translationsUrl',
+      label: 'Translations URL',
+      description: 'A Google Sheets URL, sheet ID, or i18n-microservice JSON URL'
+    },
+    {
+      type: 'radio',
+      key: 'lang',
+      label: 'Language',
+      defaultValue: 'en',
+      values: [
+        {
+          label: 'English',
+          value: 'en'
+        },
+        {
+          label: 'Spanish',
+          value: 'es'
+        },
+        {
+          label: 'Chinese',
+          value: 'zh'
+        }
+      ]
+    },
+    {
+      type: 'button',
+      action: 'submit',
+      label: 'Translate',
+      hideLabel: true
+    }
+  ]
+}, {
+  // options
+  prefill: 'querystring'
+}).then(editForm => {
+  editForm.on('submit', submission => {
+    console.log('submit:', submission.data)
+
+    if (translationForm) {
+      translationForm.detach()
+    }
+
+    const {
+      formUrl,
+      translationsUrl,
+      lang
+    } = submission.data
+
+    const element = document.getElementById('translation-form')
+    element.hidden = false
+    element.setAttribute('lang', lang)
+
+    getJSON(translationsUrl).then(translations => {
+      console.info('loaded translations:', translations)
+
+      i18next.init({
+        debug: true,
+        lng: lang,
+        resources: translations,
+        missingKeyHandler (...args) {
+          console.error('Missing key:', args)
+        },
+        missingInterpolationHandler (...args) {
+          console.error('Missing interpolation:', args)
+        }
+      })
+        .then(() => {
+          console.log('i18next initialized:', i18next)
+          i18next.initialized = true
+
+          console.log('Hello, world!', i18next.t('Hello, world!'))
+
+          Formio.createForm(element, formUrl, {
+            i18next,
+            i18nReady: true,
+            language: lang
+          }).then(form => {
+            console.log('form created with options:', form.options)
+            translationForm = form
+          })
+        })
+    })
+  })
+
+  if (window.location.search) {
+    editForm.submit()
+  }
+})

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,13 +1,63 @@
-let translationForm
+import loadTranslations from './i18n/load'
 
-const { Formio } = window
+const languages = {
+  en: 'English',
+  es: 'Spanish',
+  zh: 'Chinese',
+  tl: 'Tagalog'
+}
+
+const errorTable = document.getElementById('errors')
+const errorList = errorTable.querySelector('tbody')
+
+const columns = [
+  ['string', s => `<code>${s}</code>`, 'String'],
+  // ['value', s => `<code>${s}</code>`, 'Translation'],
+  ['message', s => s, 'Message'],
+  ['link', ({ title, href, path }) => `&ldquo;${title}&rdquo; (${path})`, 'Component']
+]
+
+const thead = errorTable.querySelector('thead').appendChild(document.createElement('tr'))
+for (const [key, format, heading] of columns) { // eslint-disable-line no-unused-vars
+  const th = document.createElement('th')
+  th.className = 'align-left p-1'
+  th.textContent = heading || key
+  thead.appendChild(th)
+}
+
+const { Formio, FormioUtils } = window
+
+const fields = [
+  field('label'),
+  field('description'),
+  field('tooltip'),
+  field('data', (data, component) => {
+    const { dataSrc, template } = component
+    if (dataSrc === 'values' && data.values) {
+      const { values } = data
+      const match = template.match(/{{\s*item\.(\w+)\s*}}/)
+      const labelProperty = match ? match[0] : 'label'
+      return values.map((value, index) => {
+        return {
+          value: value[labelProperty],
+          path: `data.values[${index}].${labelProperty}`
+        }
+      })
+    }
+  })
+]
 
 Formio.createForm(document.getElementById('edit-form'), {
   components: [
     {
+      type: 'htmlelement',
+      content: 'If you don&rsquo;t know the values below, you can find them in the "Edit" view of your page on sf.gov.'
+    },
+    {
       type: 'textfield',
       key: 'formUrl',
-      label: 'form.io resource or form',
+      label: 'Data source',
+      description: 'This is the "Data Source" field in the Drupal edit UI.',
       placeholder: 'https://sfds.form.io/...',
       validate: {
         required: true
@@ -17,27 +67,17 @@ Formio.createForm(document.getElementById('edit-form'), {
       type: 'textfield',
       key: 'translationsUrl',
       label: 'Translations URL',
-      description: 'A Google Sheets URL, sheet ID, or i18n-microservice JSON URL'
+      description: 'This is the "i18n" key from the JSON in the "Form.io Render Options" field.'
     },
     {
       type: 'radio',
       key: 'lang',
       label: 'Language',
       defaultValue: 'en',
-      values: [
-        {
-          label: 'English',
-          value: 'en'
-        },
-        {
-          label: 'Spanish',
-          value: 'es'
-        },
-        {
-          label: 'Chinese',
-          value: 'zh'
-        }
-      ]
+      values: Array.from(Object.entries(languages)).map(([value, label]) => ({
+        value,
+        label
+      }))
     },
     {
       type: 'button',
@@ -51,11 +91,7 @@ Formio.createForm(document.getElementById('edit-form'), {
   prefill: 'querystring'
 }).then(editForm => {
   editForm.on('submit', submission => {
-    console.log('submit:', submission.data)
-
-    if (translationForm) {
-      translationForm.detach()
-    }
+    errorList.innerHTML = ''
 
     const {
       formUrl,
@@ -67,24 +103,55 @@ Formio.createForm(document.getElementById('edit-form'), {
     // element.hidden = false
     element.setAttribute('lang', lang)
 
-    Formio.createForm(element, formUrl, {
-      i18n: translationsUrl,
-      language: lang
-    }).then(form => {
-      Object.assign(form.options.i18next.options, {
-        saveMissing: true,
-        missingKeyHandler (lng, ns, key, fallback, updateMissing, options) {
-          console.error('Missing key: "%s"', key, options)
-        },
-        missingInterpolationHandler (text, value, options) {
-          console.error('Missing interpolation: "%s"', text, value, options)
-        }
+    loadTranslations(translationsUrl).then(async translations => {
+      console.info('translations:', translations)
+
+      if (!translations[lang]) {
+        listError({
+          lang,
+          string: lang,
+          value: undefined,
+          link: {
+            title: 'Translations',
+            href: translationsUrl
+          },
+          message: `Missing "${lang}" language code column`
+        })
+
+        return
+      }
+
+      await Formio.createForm(element, formUrl, {
+        i18n: translations,
+        language: lang
       })
+        .then(form => {
+          FormioUtils.eachComponent(form.form.components, component => {
+            const allStrings = fields.reduce((all, getStrings) => {
+              const strings = getStrings(component).filter(data => data && data.value)
+              return all.concat(strings)
+            }, [])
 
-      console.log('form created with options:', form.options)
-      translationForm = form
+            for (const { path, value } of allStrings) {
+              const translated = form.i18next.t(value)
+              if (translated === value && lang !== 'en') {
+                listError({
+                  lang,
+                  string: value,
+                  value: '',
+                  message: 'Missing translation',
+                  link: {
+                    title: component.label || `Key: "${component.key}"`,
+                    href: `#component-${component.key}`,
+                    path
+                  }
+                })
+              }
+            }
+          })
 
-      form.redraw()
+          form.detach()
+        })
     })
   })
 
@@ -92,3 +159,23 @@ Formio.createForm(document.getElementById('edit-form'), {
     editForm.submit()
   }
 })
+
+function listError (data) {
+  const row = document.createElement('tr')
+  for (const [key, format] of columns) {
+    const cell = document.createElement('td')
+    cell.className = 'border-top-1 border-grey-1 p-1'
+    cell.setAttribute('data-key', key)
+    cell.innerHTML = data[key] ? format(data[key]) : ''
+    row.appendChild(cell)
+  }
+  errorList.appendChild(row)
+}
+
+function field (key, get) {
+  if (get) {
+    return component => (key in component) ? get(component[key], component) || [] : []
+  } else {
+    return component => (key in component) ? [{ value: component[key], path: key }] : []
+  }
+}

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,4 +1,7 @@
+import i18next from 'i18next'
 import loadTranslations from './i18n/load'
+
+const I18N_SERVICE_URL = 'https://i18n-microservice-js.herokuapp.com'
 
 const languages = {
   en: 'English',
@@ -17,6 +20,8 @@ const columns = [
   ['link', ({ title, href, path }) => `&ldquo;${title}&rdquo; (${path})`, 'Component']
 ]
 
+const loadingIndicator = document.getElementById('loading')
+
 const thead = errorTable.querySelector('thead').appendChild(document.createElement('tr'))
 for (const [key, format, heading] of columns) { // eslint-disable-line no-unused-vars
   const th = document.createElement('th')
@@ -33,8 +38,8 @@ const fields = [
   field('tooltip'),
   field('data', (data, component) => {
     const { dataSrc, template } = component
-    if (dataSrc === 'values' && data.values) {
-      const { values } = data
+    const { values } = data
+    if (dataSrc === 'values' && values) {
       const match = template.match(/{{\s*item\.(\w+)\s*}}/)
       const labelProperty = match ? match[0] : 'label'
       return values.map((value, index) => {
@@ -48,26 +53,73 @@ const fields = [
 ]
 
 Formio.createForm(document.getElementById('edit-form'), {
+  // passing a distinct instance of i18next prevents this form from being
+  // translated by strings in the form we're testing
+  i18next: i18next.createInstance({ lng: 'en' }),
+  language: 'en',
   components: [
     {
       type: 'htmlelement',
       content: 'If you don&rsquo;t know the values below, you can find them in the "Edit" view of your page on sf.gov.'
     },
     {
-      type: 'textfield',
       key: 'formUrl',
+      type: 'textfield',
       label: 'Data source',
-      description: 'This is the "Data Source" field in the Drupal edit UI.',
+      description: 'This is the "Data Source" field in the Drupal admin view of your form page.',
       placeholder: 'https://sfds.form.io/...',
       validate: {
         required: true
       }
     },
     {
-      type: 'textfield',
-      key: 'translationsUrl',
-      label: 'Translations URL',
-      description: 'This is the "i18n" key from the JSON in the "Form.io Render Options" field.'
+      type: 'columns',
+      columns: [
+        {
+          width: 5,
+          components: [
+            {
+              key: 'sheetsUrl',
+              type: 'textfield',
+              label: 'Google Sheets URL',
+              validate: {
+                // required: true
+              },
+              customDefaultValue ({ data: { sheetId } }) {
+                return sheetId ? getSpreadsheetUrl(sheetId) : ''
+              },
+              calculateValue ({ value, data: { sheetId } }) {
+                const urlOrId = sheetId || value
+                return urlOrId ? getSpreadsheetUrl(urlOrId) : ''
+              }
+            },
+            {
+              key: 'sheetId',
+              type: 'textfield',
+              hidden: true,
+              calculateValue ({ data: { sheetId, sheetsUrl } }) {
+                return sheetId || (sheetsUrl ? getSheetId(sheetsUrl) : '')
+              }
+            }
+          ]
+        },
+        {
+          width: 1,
+          components: [
+            {
+              key: 'translationsVersion',
+              type: 'textfield',
+              label: 'Version'
+            }
+          ]
+        }
+      ],
+      description: `
+        Setting the version "freezes" the Google Sheet in the JSON service&rsquo;s cache.
+        If you leave the "Version" field blank, data will be loaded from the Sheet each time (which is slow).
+        Set this when you&rsquo;re ready to publish, then either update it (using <a href="https://semver.org">semver conventions</a>),
+        or leave it blank to test changes in Google Sheets without "committing" to a new version.
+      `.trim()
     },
     {
       type: 'radio',
@@ -84,37 +136,99 @@ Formio.createForm(document.getElementById('edit-form'), {
       action: 'submit',
       label: 'Translate',
       hideLabel: true
+    },
+    {
+      type: 'fieldset',
+      legend: 'Form settings',
+      refreshOn: 'change',
+      components: [
+        {
+          type: 'htmlelement',
+          tag: 'div',
+          content: 'These fields are calculated from the values provided above.'
+        },
+        {
+          type: 'textfield',
+          key: 'spreadsheetUrl',
+          label: 'Google Sheets',
+          disabled: true,
+          customDefaultValue: calculatedSpreadsheetUrl,
+          calculateValue: calculatedSpreadsheetUrl
+        },
+        {
+          key: 'translationsUrl',
+          type: 'textfield',
+          label: 'Translations',
+          disabled: true,
+          customDefaultValue: calculatedTranslationsUrl,
+          calculateValue: calculatedTranslationsUrl
+        },
+        {
+          type: 'htmlelement',
+          tag: 'div',
+          content: 'Links: <a href="{{data.spreadsheetUrl}}">Spreadsheet</a>, <a href="{{data.translationsUrl}}">JSON</a>'
+        },
+        {
+          key: 'renderOptions',
+          type: 'textarea',
+          label: 'Render options',
+          description: 'Copy and paste this JSON into the "Form.io render options" field in Drupal to use these translations.',
+          rows: 8,
+          attributes: {
+            style: 'resize: vertical;',
+            disabled: true
+          },
+          calculateValue ({ data: { translationsUrl, translationsVersion } }) {
+            return translationsUrl ? JSON.stringify({
+              i18n: translationsUrl,
+              googleTranslate: false
+            }, null, 2) : '{}'
+          }
+        }
+      ]
     }
   ]
 }, {
   // options
   prefill: 'url'
 }).then(editForm => {
-  editForm.on('submit', submission => {
+  editForm.on('submit', async submission => {
     errorList.innerHTML = ''
+    loadingIndicator.hidden = false
+
+    console.info('submit:', submission)
+
+    await editForm.redraw()
 
     const {
       formUrl,
+      sheetId,
+      translationsVersion,
       translationsUrl,
       lang
     } = submission.data
 
-    const params = { formUrl, translationsUrl, lang }
+    const params = { formUrl, sheetId, translationsVersion, lang }
     if (window.location.hash) {
       console.info('replacing URL hash:', window.location.hash, params)
-      window.location.hash = new URLSearchParams(params).toString()
+      window.location.hash = formatQueryString(params)
     } else {
       if (window.location.search) {
         console.info('replacing query string:', window.location.search, params)
       }
-      window.history.replaceState(params, '', `?${new URLSearchParams(params).toString()}`)
+      window.history.replaceState(params, '', `?${formatQueryString(params)}`)
     }
 
     const element = document.getElementById('translation-form')
     // element.hidden = false
     element.setAttribute('lang', lang)
 
-    loadTranslations(translationsUrl).then(async translations => {
+    if (!translationsUrl) {
+      console.error('Translations URL was not set in:', submission.data)
+      return
+    }
+
+    await loadTranslations(translationsUrl).then(translations => {
       console.info('translations:', translations)
 
       if (!translations[lang]) {
@@ -128,42 +242,42 @@ Formio.createForm(document.getElementById('edit-form'), {
           },
           message: `Missing "${lang}" language code column`
         })
-
-        return
-      }
-
-      await Formio.createForm(element, formUrl, {
-        i18n: translations,
-        language: lang
-      })
-        .then(form => {
-          FormioUtils.eachComponent(form.form.components, component => {
-            const allStrings = fields.reduce((all, getStrings) => {
-              const strings = getStrings(component).filter(data => data && data.value)
-              return all.concat(strings)
-            }, [])
-
-            for (const { path, value } of allStrings) {
-              const translated = form.i18next.t(value)
-              if (translated === value && lang !== 'en') {
-                listError({
-                  lang,
-                  string: value,
-                  value: '',
-                  message: 'Missing translation',
-                  link: {
-                    title: component.label || `Key: "${component.key}"`,
-                    href: `#component-${component.key}`,
-                    path
-                  }
-                })
-              }
-            }
-          })
-
-          form.detach()
+      } else {
+        return Formio.createForm(element, formUrl, {
+          i18n: translations,
+          language: lang
         })
+          .then(form => {
+            FormioUtils.eachComponent(form.form.components, component => {
+              const allStrings = fields.reduce((all, getStrings) => {
+                const strings = getStrings(component).filter(data => data && data.value)
+                return all.concat(strings)
+              }, [])
+
+              for (const { path, value } of allStrings) {
+                const translated = form.i18next.t(value)
+                if (translated === value && lang !== 'en') {
+                  listError({
+                    lang,
+                    string: value,
+                    value: '',
+                    message: 'Missing translation',
+                    link: {
+                      title: component.label || `Key: "${component.key}"`,
+                      href: `#component-${component.key}`,
+                      path
+                    }
+                  })
+                }
+              }
+            })
+
+            form.detach()
+          })
+      }
     })
+
+    loadingIndicator.hidden = true
   })
 
   if (window.location.search || window.location.hash) {
@@ -189,4 +303,42 @@ function field (key, get) {
   } else {
     return component => (key in component) ? [{ value: component[key], path: key }] : []
   }
+}
+
+function getSheetId (urlOrId) {
+  if (urlOrId.includes('/')) {
+    const match = urlOrId.match(/\/d\/([^/]+)\/edit/)
+    console.warn('match?', match, urlOrId)
+    return match ? match[1] : urlOrId
+  } else {
+    return urlOrId
+  }
+}
+
+function getTranslationUrl (sheetId, version) {
+  return sheetId
+    ? appendPath(`${I18N_SERVICE_URL}/google/${sheetId}`, version)
+    : ''
+}
+
+function appendPath (path, ...parts) {
+  return [path, ...parts].filter(Boolean).join('/')
+}
+
+function getSpreadsheetUrl (sheetId) {
+  return `https://docs.google.com/spreadsheets/d/${sheetId}/edit#gid=0`
+}
+
+function calculatedSpreadsheetUrl ({ data: { sheetId } }) {
+  return sheetId ? getSpreadsheetUrl(sheetId) : ''
+}
+
+function calculatedTranslationsUrl ({ data: { sheetId, translationsVersion } }) {
+  return getTranslationUrl(sheetId, translationsVersion)
+}
+
+function formatQueryString (data) {
+  return new URLSearchParams(data).toString()
+    .replace(/%3A/g, ':')
+    .replace(/%2F/g, '/')
 }

--- a/src/translate.js
+++ b/src/translate.js
@@ -88,7 +88,7 @@ Formio.createForm(document.getElementById('edit-form'), {
   ]
 }, {
   // options
-  prefill: 'querystring'
+  prefill: 'url'
 }).then(editForm => {
   editForm.on('submit', submission => {
     errorList.innerHTML = ''

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,11 +1,6 @@
-import i18next from 'i18next'
-import getJSON from './utils'
-
 let translationForm
 
 const { Formio } = window
-
-window.i18next = i18next
 
 Formio.createForm(document.getElementById('edit-form'), {
   components: [
@@ -69,38 +64,27 @@ Formio.createForm(document.getElementById('edit-form'), {
     } = submission.data
 
     const element = document.getElementById('translation-form')
-    element.hidden = false
+    // element.hidden = false
     element.setAttribute('lang', lang)
 
-    getJSON(translationsUrl).then(translations => {
-      console.info('loaded translations:', translations)
-
-      i18next.init({
-        debug: true,
-        lng: lang,
-        resources: translations,
-        missingKeyHandler (...args) {
-          console.error('Missing key:', args)
+    Formio.createForm(element, formUrl, {
+      i18n: translationsUrl,
+      language: lang
+    }).then(form => {
+      Object.assign(form.options.i18next.options, {
+        saveMissing: true,
+        missingKeyHandler (lng, ns, key, fallback, updateMissing, options) {
+          console.error('Missing key: "%s"', key, options)
         },
-        missingInterpolationHandler (...args) {
-          console.error('Missing interpolation:', args)
+        missingInterpolationHandler (text, value, options) {
+          console.error('Missing interpolation: "%s"', text, value, options)
         }
       })
-        .then(() => {
-          console.log('i18next initialized:', i18next)
-          i18next.initialized = true
 
-          console.log('Hello, world!', i18next.t('Hello, world!'))
+      console.log('form created with options:', form.options)
+      translationForm = form
 
-          Formio.createForm(element, formUrl, {
-            i18next,
-            i18nReady: true,
-            language: lang
-          }).then(form => {
-            console.log('form created with options:', form.options)
-            translationForm = form
-          })
-        })
+      form.redraw()
     })
   })
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -27,7 +27,7 @@ const errorList = errorTable.querySelector('tbody')
 
 const columns = [
   ['String', d => formatString(d.string), 'String'],
-  ['Message', d => d.message],
+  // ['Message', d => d.message],
   ['Location', ({ loc }) => {
     if (loc instanceof Object) {
       const { text, href } = loc
@@ -60,7 +60,6 @@ const fields = [
   }),
   field('description'),
   field('content'),
-  field('prefix'),
   field('suffix'),
   field('values', (values, component) => fieldValues(values, 'values', 'label')),
   field('data', (data, component) => {

--- a/src/translate.js
+++ b/src/translate.js
@@ -67,8 +67,10 @@ const fields = [
     const { values } = data
     if (dataSrc === 'values' && values) {
       const match = template.match(/{{\s*item\.(\w+)\s*}}/)
-      const labelProperty = match ? match[0] : 'label'
+      const labelProperty = match ? match[1] : 'label'
       return fieldValues(values, 'data.values', labelProperty)
+    } else {
+      console.info('Skipping "data" for:', data, 'in:', component)
     }
   }),
   field('validate', ({ customMessage, custom }, component) => {

--- a/src/translate.js
+++ b/src/translate.js
@@ -60,6 +60,8 @@ const fields = [
   }),
   field('description'),
   field('content'),
+  field('prefix'),
+  field('suffix'),
   field('values', (values, component) => fieldValues(values, 'values', 'label')),
   field('data', (data, component) => {
     const { dataSrc, template } = component

--- a/translate.html
+++ b/translate.html
@@ -10,20 +10,35 @@
       <div class="p-3">
         <div class="d-flex">
           <div class="col-3 pr-3">
-            <h2>Form config</h2>
-            <div id="edit-form"></div>
+            <details open>
+              <summary><h2 class="d-inline-block m-0">Form config</h2></summary>
+              <div id="edit-form"></div>
+            </details>
+
+            <details>
+              <summary><h3 class="d-inline-block m-0">Translation data</h3></summary>
+              <textarea class="mt-2" id="translation-data" disabled style="resize: vertical;" rows="50"></textarea>
+            </details>
           </div>
           <div class="col-3">
-            <h2>Possible issues</h2>
-            <table id="errors">
-              <thead></thead>
-              <tbody>
-              </tbody>
-              <tfoot id="loading" hidden>
-                <tr><td>Loading...</td></tr>
-              </tfoot>
-            </table>
-            <div id="translation-form" hidden></div>
+            <details open>
+              <summary><h2 class="d-inline-block m-0">Possible issues</h2></summary>
+              <table id="errors">
+                <thead></thead>
+                <tbody>
+                </tbody>
+                <tfoot id="loading" hidden>
+                  <tr><td>Loading...</td></tr>
+                </tfoot>
+              </table>
+            </details>
+
+            <details class="mt-4">
+              <summary><h2 class="d-inline-block m-0">View the form</h2></summary>
+              <div class="mt-2 border-1 border-grey-1 p-2">
+                <div id="translation-form"></div>
+              </div>
+            </details>
           </div>
         </div>
       </div>

--- a/translate.html
+++ b/translate.html
@@ -7,14 +7,20 @@
   </head>
   <body>
     <div class="formio-sfds">
-      <div class="container p-3">
+      <div class="p-3">
         <div class="d-flex">
           <div class="col-3 pr-3">
             <h2>Form config</h2>
             <div id="edit-form"></div>
           </div>
           <div class="col-3">
-            <h2>Translation info</h2>
+            <h2>Possible issues</h2>
+            <table id="errors">
+              <thead></thead>
+              <tbody>
+                <tr><td>Loading...</td></tr>
+              </tbody>
+            </table>
             <div id="translation-form" hidden></div>
           </div>
         </div>

--- a/translate.html
+++ b/translate.html
@@ -18,8 +18,10 @@
             <table id="errors">
               <thead></thead>
               <tbody>
-                <tr><td>Loading...</td></tr>
               </tbody>
+              <tfoot id="loading" hidden>
+                <tr><td>Loading...</td></tr>
+              </tfoot>
             </table>
             <div id="translation-form" hidden></div>
           </div>

--- a/translate.html
+++ b/translate.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Translate!</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+  </head>
+  <body>
+    <div class="formio-sfds">
+      <div class="container p-3">
+        <div class="d-flex">
+          <div class="col-3 pr-3">
+            <h2>Form config</h2>
+            <div id="edit-form"></div>
+          </div>
+          <div class="col-3">
+            <h2>Translation info</h2>
+            <div id="translation-form" hidden></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="https://unpkg.com/formiojs@latest/dist/formio.full.js"></script>
+    <script src="dist/formio-sfds.standalone.js"></script>
+    <script src="dist/translate.js"></script>
+  </body>
+</html>

--- a/translate.html
+++ b/translate.html
@@ -22,7 +22,7 @@
           </div>
           <div class="col-3">
             <details open>
-              <summary><h2 class="d-inline-block m-0">Possible issues</h2></summary>
+              <summary><h2 class="d-inline-block m-0">Missing translations</h2></summary>
               <table id="errors">
                 <thead></thead>
                 <tbody>


### PR DESCRIPTION
This adds a very bare-bones, experimental HTML page to the published package that just lists form component labels, descriptions, and other content that don't have corresponding translations in the given data. For now, you need to specify the form.io data source and the URL of the [i18n-microservice](https://github.com/SFDigitalServices/i18n-microservice-js) translation endpoint (rather than, say, the spreadsheet URL). I've tried to make the field descriptions for these inputs as helpful as possible, but they could probably still use some work. Here's what it looks like as of 9125760:

![image](https://user-images.githubusercontent.com/113896/84710019-374b9e80-af18-11ea-902c-dd5aabd030eb.png)


