### PR TITLE
Localize field prefixes and suffixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -5,7 +5,7 @@
 {% if (ctx.component.prefix) { %}
   <div class="input-group-prepend" ref="prefix">
     <span class="input-group-text">
-      {{ctx.component.prefix}}
+      {{ ctx.t([`${ctx.component.key}_prefix`, ctx.component.prefix]) }}
     </span>
   </div>
 {% } %}
@@ -30,7 +30,7 @@
 {% if (ctx.component.suffix) { %}
   <div class="input-group-append" ref="suffix">
     <span class="input-group-text">
-      {{ctx.component.suffix}}
+      {{ ctx.t([`${ctx.component.key}_suffix`, ctx.component.suffix]) }}
     </span>
   </div>
 {% } %}


### PR DESCRIPTION
We noticed recently that field prefixes and suffixes (like "feet") weren't being localized. Turns out, the `t()` call was missing from the input template! This should probably go upstream as well, [here](https://github.com/formio/formio.js/blob/60a9cb2c7a7107c1f2a83ed4f93766e9d95dde91/src/templates/bootstrap/input/form.ejs#L5-L9) and [here](https://github.com/formio/formio.js/blob/60a9cb2c7a7107c1f2a83ed4f93766e9d95dde91/src/templates/bootstrap/input/form.ejs#L29-L33).

This is a bug fix, and will release version 5.0.3.