### PR TITLE
Fix bad confirmation flag setting in form submit listener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/patch.js
+++ b/src/patch.js
@@ -84,7 +84,7 @@ function patch(Formio) {
       form.on('nextPage', scrollToTop)
       form.on('prevPage', scrollToTop)
       form.on('nextPage', () => { warnBeforeLeaving = true })
-      form.on('submit', () => { warnBeforeLeaving = true })
+      form.on('submit', () => { warnBeforeLeaving = false })
 
       const { element } = form
 


### PR DESCRIPTION
In c882490e2c4b7cb96a2043d33f11000d82f666f8 I changed how the `warnBeforeLeaving` flag was being set (from `false` to `true`), which caused all of our forms to trigger the confirmation dialog before submitting. 🤦 

This fixes that. This will be a patch release.