### PR TITLE
Phrase translation API integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5285,11 +5285,6 @@
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "dev": true
     },
-    "dotmap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dotmap/-/dotmap-0.1.0.tgz",
-      "integrity": "sha1-WC9ACSuvqOjRz2gFeONdkVBos5g="
-    },
     "downloadjs": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5285,6 +5285,11 @@
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "dev": true
     },
+    "dotmap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dotmap/-/dotmap-0.1.0.tgz",
+      "integrity": "sha1-WC9ACSuvqOjRz2gFeONdkVBos5g="
+    },
     "downloadjs": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
@@ -12265,6 +12270,15 @@
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-inject-process-env": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject-process-env/-/rollup-plugin-inject-process-env-1.3.0.tgz",
+      "integrity": "sha512-LYuOvcnLZErqK1WaDGMT5ECn1JPvOgeURfQGR9tRRyMb/sqmt5G7jT2/KSChRkyEDNKsn24J4FBxubB8bbs2Fg==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.7"
       }
     },
     "rollup-plugin-jst": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "choices.js": "^9.0.1",
-    "dotmap": "^0.1.0",
     "flatpickr": "^4.6.3",
     "formiojs": "4.10.4",
     "interpolate": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "choices.js": "^9.0.1",
+    "dotmap": "^0.1.0",
     "flatpickr": "^4.6.3",
     "formiojs": "4.10.4",
     "interpolate": "^0.1.0",
@@ -72,6 +73,7 @@
     "regenerator-runtime": "^0.13.5",
     "rollup": "^2.11.2",
     "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-inject-process-env": "^1.3.0",
     "rollup-plugin-jst": "^1.2.0",
     "rollup-plugin-postcss": "^2.9.0",
     "rollup-plugin-svgo": "^1.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,10 +6,15 @@ import pkg from './package.json'
 import postcss from 'rollup-plugin-postcss'
 import resolve from '@rollup/plugin-node-resolve'
 import svg from 'rollup-plugin-svgo'
+import injectProcessEnv from 'rollup-plugin-inject-process-env'
 import { terser } from 'rollup-plugin-terser'
 import yaml from '@rollup/plugin-yaml'
 
-const { NODE_ENV = 'development' } = process.env
+const {
+  NODE_ENV = 'development',
+  I18N_SERVICE_URL
+} = process.env
+
 const prod = NODE_ENV === 'production'
 const name = 'FormioSFDS'
 
@@ -24,6 +29,12 @@ const commonPlugins = [
       escape: /\{\{\{([\s\S]+?)\}\}\}/g,
       variable: 'ctx'
     }
+  }),
+  injectProcessEnv({
+    NODE_ENV,
+    I18N_SERVICE_URL
+  }, {
+    include: 'src/**/*.js'
   }),
   svg({
     plugins: [

--- a/src/i18n/load.js
+++ b/src/i18n/load.js
@@ -2,5 +2,11 @@ import { getJSON } from '../utils'
 
 export default function loadTranslations (url) {
   return getJSON(url, {}, { method: 'GET' })
-    .then(res => res.data || {})
+    .then(res => {
+      if (res.status === 'success') {
+        return res.data
+      } else {
+        throw new Error(`Translation load error: ${JSON.stringify(res)}`)
+      }
+    })
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -283,6 +283,7 @@ function loadFormTranslations (form) {
     console.warn('Loading translations from:', url)
     return loadTranslations(url)
       .then(resourcesByLanguage => {
+        console.warn('Loaded resources:', resourcesByLanguage)
         const { i18next } = form
         for (const [lang, resources] of Object.entries(resourcesByLanguage)) {
           i18next.addResourceBundle(lang, I18NEXT_DEFAULT_NAMESPACE, resources)

--- a/src/patch.js
+++ b/src/patch.js
@@ -272,7 +272,7 @@ function loadFormTranslations (form) {
   const {
     phraseProjectId,
     phraseProjectVersion,
-    i18nServiceUrl = I18N_SERVICE_URL
+    i18nServiceUrl = form.options.i18nServiceUrl || I18N_SERVICE_URL
   } = props
 
   if (phraseProjectId) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -12,7 +12,7 @@ const {
   I18N_SERVICE_URL = 'https://i18n-microservice-js.herokuapp.com'
 } = process.env
 
-const I18NEXT_DEFAULT_NAMESPACE = 'translations' // ???
+const I18NEXT_DEFAULT_NAMESPACE = 'translation' // ???
 const WRAPPER_CLASS = 'formio-sfds'
 const PATCHED = `sfds-patch-${Date.now()}`
 

--- a/templates/standalone.html
+++ b/templates/standalone.html
@@ -23,6 +23,7 @@
       const params = new URLSearchParams(location.search || location.hash.substr(1))
       const language = params.get('lang')
       const i18n = tryParse(params.get('i18n'))
+      const i18nServiceUrl = params.get('i18nServiceUrl')
       const renderMode = params.get('mode')
       const hooks = tryParse(params.get('hooks'))
       const resource = params.get('res') || root.getAttribute('data-resource')
@@ -34,6 +35,7 @@
         hooks,
         unlockNavigation,
         i18n,
+        i18nServiceUrl,
         googleTranslate: params.get('googleTranslate') === 'true',
         prefill: params,
         properties: tryParse(params.get('properties')) || {


### PR DESCRIPTION
This provides support for Phrase project metadata (project ID and version) defined in a form.io form or resource's "custom properties" (exposed in the data source JSON under `properties`):

![image](https://user-images.githubusercontent.com/113896/88114083-fa527780-cb67-11ea-98a1-b85273db617a.png)

The idea is that if you provide a `phraseProjectId` property, we will use the API introduced in https://github.com/SFDigitalServices/i18n-microservice-js/pull/9 to **automatically** fetch the translations in that project and register them as localization resources.

There are some new moving parts:

1. I've allowed for a default i18n service API via the `I18N_SERVICE_URL` environment variable and set the fallback to our production deployment at [i18n-microservice-js.herokuapp.com](https://i18n-microservice-js.herokuapp.com). This makes it easier to test with the service running locally (e.g. on port 8001):

    ```bash
    I18N_SERVICE_URL=http://localhost:8001 npm run watch
    ```

2. I've introduced [rollup-plugin-inject-process-env](https://www.npmjs.com/package/rollup-plugin-inject-process-env) to our rollup config to manage replacing `process.env` in our source with a subset of env variables: `NODE_ENV` and `I18N_SERVICE_URL`. (⚠️ Just passing `process.env` grows the JS bundle by a lot and has the potential to inline any private tokens!)