### PR TITLE
Release 6.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
       - run: npm ci
       - run: npm run lint
-      - run: npm test
       - run: npm run build
         env:
           NODE_ENV: production
+      - run: npm test
 
       - uses: primer/publish@v2.0.0
         env:

--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+import { createForm, destroyForm } from '../lib/test-helpers'
+import '../dist/formio-sfds.standalone.js'
+
+describe('a11y', () => {
+  describe('input labels', () => {
+    it('textfield inputs have associated labels', async () => {
+      const form = await createForm({
+        type: 'form',
+        display: 'form',
+        components: [
+          {
+            type: 'textfield',
+            key: 'name',
+            label: 'Name',
+            input: true
+          },
+          {
+            type: 'container',
+            key: 'nested',
+            components: [
+              {
+                type: 'number',
+                key: 'age',
+                label: 'Age',
+                input: true
+              }
+            ]
+          }
+        ]
+      }, {})
+
+      const inputs = form.element.querySelectorAll('input')
+      const labels = form.element.querySelectorAll('label:not(.control-label--hidden)')
+      expect(inputs).toHaveLength(2)
+      expect(labels).toHaveLength(2)
+
+      const [nameField, ageField] = inputs
+      const [nameLabel, ageLabel] = labels
+      expect(nameField.name).toBe('data[name]')
+      expect(nameField.id).toBe(`input-${nameField.name}`)
+      expect(nameLabel.getAttribute('for')).toBe(nameField.id)
+
+      expect(ageField.name).toBe('data[nested][age]')
+      expect(ageField.id).toBe(`input-${ageField.name}`)
+      expect(ageLabel.getAttribute('for')).toBe(ageField.id)
+
+      destroyForm(form)
+    })
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  bail: 1
+  bail: 1,
+  setupFiles: ['<rootDir>/lib/test-setup.js']
 }

--- a/lib/test-helpers.js
+++ b/lib/test-helpers.js
@@ -18,7 +18,7 @@ function createForm (form = {}, options = {}) {
     id: `form-${Date.now().toString(36)}`
   })
   document.body.appendChild(el)
-  return global.Formio.createForm(el, options)
+  return global.Formio.createForm(el, form, options)
 }
 
 function destroyForm (form) {
@@ -27,8 +27,8 @@ function destroyForm (form) {
   element.remove()
 }
 
-function sleep (ms) {
+function sleep (ms = 1) {
   return new Promise(resolve => {
-    setTimeout(resolve, 10)
+    setTimeout(resolve, ms)
   })
 }

--- a/lib/test-setup.js
+++ b/lib/test-setup.js
@@ -1,0 +1,10 @@
+/* eslint-env jest */
+import 'regenerator-runtime'
+import 'formiojs/dist/formio.full.min.js'
+
+// jsdom doesn't provide an implementation for these, and it throws an error if
+// you call them directly. Thankfully, Jest can spy on and mock them. See:
+// <https://github.com/jsdom/jsdom/issues/1422>
+const scroll = jest.fn()
+jest.spyOn(window, 'scroll').mockImplementation(scroll)
+jest.spyOn(window, 'scrollTo').mockImplementation(scroll)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "main": "dist/formio-sfds.cjs.js",

--- a/src/templates/file/form.ejs
+++ b/src/templates/file/form.ejs
@@ -97,7 +97,7 @@
       {% } %}
       <td class="remove text-align-right pr-0">
         {% if (!ctx.disabled) { %}
-        <button ref="removeLink" aria-label="Remove"
+        <button ref="removeLink" aria-label="{{ ctx.t('Remove') }}"
           class="m-0 p-1 bg-blue fg-white border-0 d-flex flex-items-center">
           <span data-icon="delete" class="d-flex flex-items-center"></span>
         </button>
@@ -119,7 +119,7 @@
       </td>
       <td class="remove text-align-right pr-0">
         {% if (!ctx.disabled) { %}
-        <button ref="fileStatusRemove" aria-label="Remove"
+        <button ref="fileStatusRemove" aria-label="{{ ctx.t('Remove') }}"
           class="m-0 p-1 bg-blue fg-white border-0 d-flex flex-items-center">
           <span data-icon="delete" class="d-flex flex-items-center"></span>
         </button>

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -13,6 +13,7 @@
 <div class="form-input">
   <{{ctx.input.type}}
     ref="{{ctx.input.ref ? ctx.input.ref : 'input'}}"
+    id="input-{{ ctx.input.attr.name }}"
     {% for (var attr in ctx.input.attr) { %}
     {{attr}}="{{ctx.input.attr[attr]}}"
     {% } %}

--- a/src/templates/label/form.ejs
+++ b/src/templates/label/form.ejs
@@ -1,5 +1,5 @@
 {% if (!ctx.component.hideLabel && ['checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
-  <label class="{{ ctx.label.className }}">
+  <label class="{{ ctx.label.className }}" for="input-{{ ctx.self.options.name }}">
     {{ ctx.t([`${ctx.component.key}_label`, ctx.component.label]) }}
     <!--
     {% if (ctx.component.tooltip) { %}

--- a/src/templates/multiValueRow/form.ejs
+++ b/src/templates/multiValueRow/form.ejs
@@ -2,7 +2,8 @@
   <div class="mr-1">{{ ctx.element }}</div>
   {% if (!ctx.disabled) { %}
     <div>
-      <button type="button" class="btn bg-slate-65" ref="removeRow">
+      <button type="button" class="btn bg-slate-65" ref="removeRow"
+         aria-label="{{ ctx.t('Remove') }}">
         <span data-icon="delete"></span>
       </button>
     </div>


### PR DESCRIPTION
In this patch release:

- [x] #70  fixes an accessibility issue with components that use the "input" template by adding `for` and `id` attributes to the `<label>` and `<input>` elements (respectively) so that AT will announce the label of the input when focused.
- [x] #70 Adds the ability to localize "Remove" labels and button text in file upload and multi-value components