### PR TITLE
Add standalone component example pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5534,6 +5534,15 @@
             "resolve-from": "^4.0.0"
           }
         },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -9947,13 +9956,10 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "moment": {
       "version": "2.27.0",
@@ -13735,6 +13741,17 @@
         "stable": "^0.1.8",
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "symbol-observable": {
@@ -14630,6 +14647,17 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "watch": "npm run build-css && run-p watch-css watch-js watch-templates",
     "watch-css": "watchy -w 'src/scss/**/*.scss' -- npm run build-css",
     "watch-js": "rollup -c --watch",
-    "watch-templates": "watchy -w 'templates/*' -- npm run build-templates"
+    "watch-templates": "watchy -w 'templates/*' -w src/examples.yml -- npm run build-templates"
   },
   "browserslist": [
     "> 1%",
@@ -60,6 +60,7 @@
     "i18next": "^19.4.5",
     "jest": "^26.1.0",
     "js-yaml": "^3.14.0",
+    "mkdirp": "^1.0.4",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",
     "nunjucks": "^3.2.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -66,6 +66,14 @@ export default [
     }
   },
   {
+    input: 'src/example.js',
+    plugins: commonPlugins,
+    output: {
+      format: 'umd',
+      file: 'dist/examples/example.js'
+    }
+  },
+  {
     input: 'src/examples.js',
     plugins: [
       ...commonPlugins,

--- a/script/render-templates
+++ b/script/render-templates
@@ -1,26 +1,37 @@
 #!/usr/bin/env node
 const globby = require('globby')
 const nunjucks = require('nunjucks')
+const mkdirp = require('mkdirp')
+const yaml = require('js-yaml')
 const { basename, join } = require('path')
-const { writeFileSync } = require('fs')
+const { readFileSync, writeFileSync } = require('fs')
 
 const data = require('../templates/data')
+const examples = yaml.safeLoad(readFileSync('src/examples.yml', 'utf8'))
 const outDir = join(__dirname, '../dist')
 
-nunjucks.configure(join(__dirname, '../templates'), {
-  throwOnUndefined: true
-})
+const env = nunjucks.configure(join(__dirname, '../templates'))
 
 console.warn('finding templates...')
+
 globby('templates/*.html')
   .then(templates => {
     for (const templatePath of templates) {
       const filename = basename(templatePath)
       console.warn('rendering "%s"...', filename)
-      const output = nunjucks.render(filename, data)
+      const output = env.render(filename, data)
       const outPath = join(outDir, filename)
       console.warn('writing "%s"...', outPath)
       writeFileSync(outPath, output, 'utf8')
     }
-    console.warn('done!')
+  })
+  .then(async () => {
+    const exDir = join(outDir, 'examples')
+    await mkdirp(exDir)
+    for (const example of examples) {
+      console.warn('rendering example "%s"...', example.id)
+      const output = env.render('example.html', Object.assign({ example }, data))
+      const outPath = join(exDir, `${example.id}.html`)
+      writeFileSync(outPath, output, 'utf8')
+    }
   })

--- a/src/example.js
+++ b/src/example.js
@@ -4,29 +4,16 @@ const root = document.getElementById('formio')
 
 const params = new URLSearchParams(location.search || location.hash.substr(1))
 const language = params.get('lang')
-const i18n = tryParse(params.get('i18n'))
-const renderMode = params.get('mode')
-const hooks = tryParse(params.get('hooks'))
 const formData = tryParse(root.getAttribute('data-form')) || {}
-const unlockNavigation = true
 
 const options = Object.assign({
   language,
-  renderMode,
-  hooks,
-  unlockNavigation,
-  i18n,
-  googleTranslate: params.get('googleTranslate') === 'true',
-  prefill: params,
-  properties: tryParse(params.get('properties')) || {
-    backURL: 'https://sf.gov/apply-building-permit',
-    backTitle: 'Apply for a building permit'
-  }
+  unlockNavigation: true,
+  googleTranslate: params.get('googleTranslate') === 'true'
 }, tryParse(root.getAttribute('data-options')))
 
 Formio.createForm(root, formData, options).then(form => {
   console.log('form ready:', form)
-  document.title = form.schema.title
 })
 
 function tryParse (str) {

--- a/src/example.js
+++ b/src/example.js
@@ -1,0 +1,38 @@
+const { Formio, location } = window
+
+const root = document.getElementById('formio')
+
+const params = new URLSearchParams(location.search || location.hash.substr(1))
+const language = params.get('lang')
+const i18n = tryParse(params.get('i18n'))
+const renderMode = params.get('mode')
+const hooks = tryParse(params.get('hooks'))
+const formData = tryParse(root.getAttribute('data-form')) || {}
+const unlockNavigation = true
+
+const options = Object.assign({
+  language,
+  renderMode,
+  hooks,
+  unlockNavigation,
+  i18n,
+  googleTranslate: params.get('googleTranslate') === 'true',
+  prefill: params,
+  properties: tryParse(params.get('properties')) || {
+    backURL: 'https://sf.gov/apply-building-permit',
+    backTitle: 'Apply for a building permit'
+  }
+}, tryParse(root.getAttribute('data-options')))
+
+Formio.createForm(root, formData, options).then(form => {
+  console.log('form ready:', form)
+  document.title = form.schema.title
+})
+
+function tryParse (str) {
+  if (!str) return
+  try { return JSON.parse(str) } catch (error) {
+    console.error('Unable to parse JSON:', str)
+    return str
+  }
+}

--- a/templates/example.html
+++ b/templates/example.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Loading...</title>
+    <title>{{ example.title }} | formio-sfds examples</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/dist/common.css">

--- a/templates/example.html
+++ b/templates/example.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Loading...</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="/dist/common.css">
+  </head>
+  <body>
+    <div class="formio-sfds">
+      <div class="container p-2">
+        <h1 class="h3 mb-4">
+          <a href="/">Examples</a> /
+          {{ example.title }}
+        </h1>
+        <div id="formio"
+             data-form="{{ example.form | dump }}"
+             data-options="{{ example.options | dump }}">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.js"></script>
+  <script src="/dist/formio-sfds.standalone.js"></script>
+  <script src="/dist/examples/example.js"></script>
+</body>
+
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
       "destination": "/dist/:view.html"
     },
     {
+      "source": "/examples/:id",
+      "destination": "/dist/examples/:id.html"
+    },
+    {
       "source": "/:view",
       "destination": "/dist/:view.html"
     }


### PR DESCRIPTION
This PR cherry-picks commits from #77 that set up individual HTML pages for each of the component examples listed in [src/examples.yml](https://github.com/SFDigitalServices/formio-sfds/blob/main/src/examples.yml). Here's the deal:

1. Each example entry in `src/examples.yml` has a unique `id`, which becomes the output path: `dist/examples/:id.html`. For instance, the multi-file upload example gets rendered to `dist/examples/multi-file.html`.
2. The Vercel config has a new rewrite rule for `/examples/:id` → `dist/examples/:id.html` for simpler URLs, e.g. [/examples/address](https://formio-sfds-git-example-pages.sfds.vercel.app/examples/address).
3. The `watch-templates` npm script now also watches `src/examples.yml` and rebuilds all the templates if it changes.

There aren't currently links to all of these example pages, but I'm going to add them in the index template.

My goal is for this to be part of #76.