### PR TITLE
Upgrade formio.js

### DIFF
--- a/__tests__/icons.js
+++ b/__tests__/icons.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+import { createForm, destroyForm } from '../lib/test-helpers'
+import '../dist/formio-sfds.standalone.js'
+
+describe('icons', () => {
+  describe('datetime prefix', () => {
+    it('renders a calendar icon', async () => {
+      const form = await createForm({
+        type: 'form',
+        display: 'form',
+        components: [
+          {
+            type: 'datetime',
+            label: 'Date'
+          }
+        ]
+      }, {})
+
+      const prepend = form.element.querySelector('.input-group-prepend')
+      expect(prepend).not.toBe(null)
+      expect(prepend.innerHTML).not.toContain('[object HTMLElement]')
+
+      destroyForm(form)
+    })
+  })
+})

--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -74,6 +74,13 @@ describe('patch()', () => {
   })
 
   describe('localization', () => {
+    describe('i18next.t() fallback support', () => {
+      it('works with multiple fallback keys in an array', async () => {
+        const form = await createForm()
+        expect(form.t(['bleep.bloop', 'blurp'])).toEqual('blurp')
+      })
+    })
+
     describe('"language" option', () => {
       it('defaults to "en" if none is provided', async () => {
         const form = await createForm()

--- a/package-lock.json
+++ b/package-lock.json
@@ -2393,6 +2393,7 @@
       "version": "7.8.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
       "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -2545,17 +2546,17 @@
       "dev": true
     },
     "@formio/bootstrap3": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.6.3.tgz",
-      "integrity": "sha512-NFT3fExUVBPtUr/XjKdpNmUN0cEe7ZAJ+COTnkXzcE0UwkNQBz5AJtJ5tg0LOUqTL1IxI8bPQUZm8XRYukfTWw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.6.5.tgz",
+      "integrity": "sha512-Tmi5eTjTFJkqryEL4aHnfaU5RgmKnKUYNFVjJoqzVDod72r55+pBr5lQ/SQPP6GRaBOPAV5+12a7ZtA60yXZAQ==",
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
       }
     },
     "@formio/semantic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.4.3.tgz",
-      "integrity": "sha512-mUYYU6QwmiX1WNcTO3IeV7Y3hI/qulBIdOdzHaCNSYLjXDagTw2B2JCdOjjsVQVRVwSrbmJw+ilFMBl69lzFKQ=="
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.4.5.tgz",
+      "integrity": "sha512-azkpbc5HjjLFlXWEQxFfyVM/jpb3+4tqZX/MylePE4QYNZ9Oo4GoYSAhIyyP/u/JmcPgchldtP2jsbmP67cG6w=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4599,9 +4600,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+      "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -5078,9 +5079,9 @@
           },
           "dependencies": {
             "is-regex": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-              "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+              "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
               "requires": {
                 "has-symbols": "^1.0.1"
               }
@@ -5192,9 +5193,9 @@
       "dev": true
     },
     "dialog-polyfill": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.1.tgz",
-      "integrity": "sha512-1+VxuUxUz1aUpVoZZADSx/PAtMJedtvOFzLJ/HYWboXxmWwtxBPnYzK8IDgxvojcpetewaJJg30f2pIvo4zbLw=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.3.tgz",
+      "integrity": "sha512-DVYazl3klQtPjs4dOzDTOt4uQ8cRDfu8EBhoY81ISmH0fbrMvYuaethcQ9UevmF9kAaLnBJ0O5eDUnZ7QalArA=="
     },
     "diff-sequences": {
       "version": "26.0.0",
@@ -5277,9 +5278,9 @@
       }
     },
     "dompurify": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.12.tgz",
-      "integrity": "sha512-Fl8KseK1imyhErHypFPA8qpq9gPzlsJ/EukA6yk9o0gX23p1TzC+rh9LqNg1qvErRTc0UNMYlKxEGSfSh43NDg=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.11.tgz",
+      "integrity": "sha512-qVoGPjIW9IqxRij7klDQQ2j6nSe4UNWANBhZNLnsS7ScTtLb+3YdxkRY8brNTpkUiTtcXsCJO+jS0UCDfenLuA=="
     },
     "domutils": {
       "version": "1.7.0",
@@ -6252,9 +6253,9 @@
       }
     },
     "flatpickr": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.3.tgz",
-      "integrity": "sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ=="
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.6.tgz",
+      "integrity": "sha512-EZ48CJMttMg3maMhJoX+GvTuuEhX/RbA1YeuI19attP3pwBdbYy6+yqAEVm0o0hSBFYBiLbVxscLW6gJXq6H3A=="
     },
     "flatted": {
       "version": "2.0.2",
@@ -6317,35 +6318,35 @@
       }
     },
     "formiojs": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.10.4.tgz",
-      "integrity": "sha512-A59azE+T632g1ROxu1ICgC+EhV3P7LfGbB9PGuIIFrKco0/89r10ShJ+4DPtIIpsjVvpZ/nDsBFK2J0M++tWEQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.11.2.tgz",
+      "integrity": "sha512-PV7E5veKAOWPtPu3eo20N2CV+BS8xWoPsOrA+mde3+7Sdpz6bk3KYLHvaknY4/4ekgCeK1pKRlLNZHbEgtwN5w==",
       "requires": {
-        "@formio/bootstrap3": "^2.6.1",
-        "@formio/semantic": "^2.4.1",
+        "@formio/bootstrap3": "^2.6.4",
+        "@formio/semantic": "^2.4.4",
         "autocompleter": "^6.0.3",
         "browser-cookies": "^1.2.0",
         "choices.js": "^9.0.1",
         "compare-versions": "^3.6.0",
-        "core-js": "^3.6.5",
+        "core-js": "3.5.0",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.1",
-        "dompurify": "^2.0.11",
+        "dompurify": "2.0.11",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.2",
-        "eventemitter2": "^6.4.1",
+        "eventemitter2": "^6.4.3",
         "fast-deep-equal": "^3.1.3",
         "fast-json-patch": "^2.2.1",
         "fetch-ponyfill": "^6.1.0",
-        "flatpickr": "^4.6.3",
-        "i18next": "^19.4.5",
+        "flatpickr": "^4.6.6",
+        "i18next": "^19.6.2",
         "idb": "^5.0.4",
         "ismobilejs": "^1.1.1",
         "json-logic-js": "^1.2.2",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^2.2.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.26.0",
+        "lodash": "^4.17.19",
+        "moment": "^2.27.0",
         "moment-timezone": "^0.5.31",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
@@ -6354,15 +6355,36 @@
         "string-hash": "^1.1.3",
         "text-mask-addons": "^3.8.0",
         "tooltip.js": "^1.3.3",
-        "uuid": "^8.1.0",
+        "uuid": "^8.2.0",
         "vanilla-picker": "^2.10.1",
         "vanilla-text-mask": "^5.1.1"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "flatpickr": {
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.6.tgz",
+          "integrity": "sha512-EZ48CJMttMg3maMhJoX+GvTuuEhX/RbA1YeuI19attP3pwBdbYy6+yqAEVm0o0hSBFYBiLbVxscLW6gJXq6H3A=="
+        },
+        "i18next": {
+          "version": "19.7.0",
+          "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.7.0.tgz",
+          "integrity": "sha512-sxZhj6u7HbEYOMx81oGwq5MiXISRBVg2wRY3n6YIbe+HtU8ydzlGzv6ErHdrRKYxATBFssVXYbc3lNZoyB4vfA==",
+          "requires": {
+            "@babel/runtime": "^7.10.1"
+          }
         }
       }
     },
@@ -6872,11 +6894,23 @@
       "dev": true
     },
     "i18next": {
-      "version": "19.4.5",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.4.5.tgz",
-      "integrity": "sha512-aLvSsURoupi3x9IndmV6+m3IGhzLzhYv7Gw+//K3ovdliyGcFRV0I1MuddI0Bk/zR7BG1U+kJOjeHFUcUIdEgg==",
+      "version": "19.7.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.7.0.tgz",
+      "integrity": "sha512-sxZhj6u7HbEYOMx81oGwq5MiXISRBVg2wRY3n6YIbe+HtU8ydzlGzv6ErHdrRKYxATBFssVXYbc3lNZoyB4vfA==",
+      "dev": true,
       "requires": {
-        "@babel/runtime": "^7.3.1"
+        "@babel/runtime": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -7366,6 +7400,11 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
     },
     "is-number": {
       "version": "7.0.0",
@@ -10346,9 +10385,9 @@
           "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
         },
         "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -12784,12 +12823,51 @@
       "optional": true
     },
     "side-channel": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
-      "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
+      "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
       "requires": {
-        "es-abstract": "^1.17.0-next.1",
-        "object-inspect": "^1.7.0"
+        "es-abstract": "^1.18.0-next.0",
+        "object-inspect": "^1.8.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+        }
       }
     },
     "signal-exit": {
@@ -14581,9 +14659,9 @@
           "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
         },
         "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
           "requires": {
             "has-symbols": "^1.0.1"
           }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "dependencies": {
     "choices.js": "^9.0.1",
-    "flatpickr": "^4.6.3",
-    "formiojs": "4.10.4",
+    "flatpickr": "4.6.6",
+    "formiojs": "4.11.2",
     "interpolate": "^0.1.0",
     "uri-template-lite": "^19.12.0",
     "whatwg-fetch": "^3.0.0"
@@ -57,7 +57,7 @@
     "dotenv": "^8.2.0",
     "globby": "^11.0.1",
     "google-spreadsheet": "^3.0.11",
-    "i18next": "^19.4.5",
+    "i18next": "19.7.0",
     "jest": "^26.1.0",
     "js-yaml": "^3.14.0",
     "mkdirp": "^1.0.4",

--- a/src/patch.js
+++ b/src/patch.js
@@ -214,15 +214,13 @@ function hook (obj, methodName, wrapper) {
 }
 
 function patchDateTimeSuffix () {
-  observe('.formio-component-datetime', {
+  observe('.formio-component-datetime .input-group', {
     add (el) {
-      const group = el.querySelector('.input-group')
-      if (!group) return
-      const text = group.querySelector('.input-group-append')
+      const text = el.querySelector('.input-group-append')
       if (text) {
         text.classList.remove('input-group-append')
         text.classList.add('input-group-prepend')
-        group.insertBefore(text, group.firstChild)
+        el.insertBefore(text, el.firstChild)
       }
     }
   })

--- a/src/patch.js
+++ b/src/patch.js
@@ -226,6 +226,12 @@ function patchDateTimeSuffix () {
   })
 }
 
+/**
+ * This patch can go away as soon as we upgrade to formiojs's (eventual)
+ * release of 4.12.0, which should include this fix:
+ *
+ * <https://github.com/formio/formio.js/pull/3129>
+ */
 function patchDateTimeLocale (Formio) {
   hook(Formio.Components.components.datetime.prototype, 'attach', function (attach, args) {
     if (this.options.language) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -164,8 +164,6 @@ function patch (Formio) {
     })
   })
 
-  patchI18nMultipleKeys(Formio)
-
   patchDateTimeLocale(Formio)
 
   // this goes last so that if it fails it doesn't break everything else
@@ -213,38 +211,6 @@ function hook (obj, methodName, wrapper) {
   obj[methodName] = function (...args) {
     return wrapper.call(this, method.bind(this), args)
   }
-}
-
-function patchI18nMultipleKeys (Formio) {
-  /*
-   * Patch the base Component class's t() method to support multiple key
-   * fallbacks as the first argument. As of 4.10.0-beta.3.1, form.io's
-   * implementation treats the first argument as a string even if it's an Array,
-   * which means that in a template, this call:
-   *
-   * ```js
-   * ctx.t(['some.nonexistent.key', ''])
-   * ```
-   *
-   * Will render the string "some.nonexistent.key,". The trailing comma is from
-   * the array being coerced to a string in the last line here:
-   *
-   * <https://github.com/formio/formio.js/blob/58996eac1207803cb597b4ab7c3abc6636078c72/src/components/_classes/component/Component.js#L707-L708>
-   */
-  hook(Formio.Components._components.component.prototype, 't', function (t, [keys, params]) {
-    if (Array.isArray(keys)) {
-      const last = keys.length - 1
-      const fallback = (key, index) => {
-        const value = t(key, params)
-        return value === key ? (index === last) ? value : '' : value
-      }
-      return keys.reduce((value, key, index) => {
-        return value || fallback(key, index)
-      }, '')
-    } else {
-      return t(keys, params)
-    }
-  })
 }
 
 function patchDateTimeSuffix () {

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -1,11 +1,15 @@
-{% if (ctx.component.prefix || ctx.component.suffix) { %}
+{%
+  let prefix = ctx.prefix
+  let suffix = ctx.suffix
+%}
+{% if (prefix || suffix) { %}
   <div class="input-group">
 {% } %}
 
-{% if (ctx.component.prefix) { %}
+{% if (prefix) { %}
   <div class="input-group-prepend" ref="prefix">
     <span class="input-group-text">
-      {{ ctx.t([`${ctx.component.key}_prefix`, ctx.component.prefix]) }}
+      {{ ctx.t([`${ctx.component.key}_prefix`, prefix]) }}
     </span>
   </div>
 {% } %}
@@ -28,14 +32,14 @@
   <span class="text-muted pull-right" ref="wordcount"></span>
 {% } %}
 
-{% if (ctx.component.suffix) { %}
+{% if (suffix) { %}
   <div class="input-group-append" ref="suffix">
     <span class="input-group-text">
-      {{ ctx.t([`${ctx.component.key}_suffix`, ctx.component.suffix]) }}
+      {{ ctx.t([`${ctx.component.key}_suffix`, suffix]) }}
     </span>
   </div>
 {% } %}
 
-{% if (ctx.component.prefix || ctx.component.suffix) { %}
+{% if (prefix || suffix) { %}
   </div>
 {% } %}

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -1,6 +1,8 @@
 {%
   let prefix = ctx.prefix
+  if (prefix instanceof HTMLElement) prefix = prefix.outerHTML
   let suffix = ctx.suffix
+  if (suffix instanceof HTMLElement) suffix = suffix.outerHTML
 %}
 {% if (prefix || suffix) { %}
   <div class="input-group">


### PR DESCRIPTION
- [x] Upgrade to [formiojs@4.11.2](https://github.com/formio/formio.js/blob/v4.11.2/Changelog.md#readme). The diff is since 4.10.4 is too big to see on github, but you can break it up by version:
    * [v4.10.4 → v4.10.5](https://github.com/formio/formio.js/compare/v4.10.4...v4.10.5) includes two of our PRs:
        - https://github.com/formio/formio.js/pull/2959 enable localization of prefix and suffix strings
        - https://github.com/formio/formio.js/pull/2972 fixes references to each form's (potentially unique) i18next instance
    * [v4.10.5 → v4.11.0](https://github.com/formio/formio.js/compare/v4.10.5...v4.11.0) includes:
        - https://github.com/formio/formio.js/pull/2984 allows us to localize the `alertMessage` string and incorporates i18next fallback support so that we don't need to patch it anymore
    * [v4.11.0 → v4.11.1](https://github.com/formio/formio.js/compare/v4.11.0...v4.11.1)
    * [v4.11.1 → v4.11.2](https://github.com/formio/formio.js/compare/v4.11.1...v4.11.2)
- [x] Fix the `[object HTMLElement]` rendering issue in datetime components (with failing test!)
    * [:eyes: test datetime example](https://formio-sfds-git-formio-upgrade.sfds.vercel.app/examples/datetime-default)
- [x] Remove the patch for `t()` fallback arrays
    * [:eyes: test feedback form](https://formio-sfds-git-formio-upgrade.sfds.vercel.app/standalone?res=https://sfds-test.form.io/feedback&i18n=https://translate.sf.gov/google/1ialzMAruk1wk2sIAR-WHzlCsJ73yy7LIxruD3cvTYFE@1.0.0&lang=es)