### PR TITLE
Add required attribute to most inputs, improve label associations

### DIFF
--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -4,7 +4,7 @@ import '../dist/formio-sfds.standalone.js'
 
 describe('a11y', () => {
   describe('input labels', () => {
-    it('textfield inputs have associated labels', async () => {
+    it('single textfield has an associated label', async () => {
       const form = await createForm({
         type: 'form',
         display: 'form',
@@ -14,7 +14,29 @@ describe('a11y', () => {
             key: 'name',
             label: 'Name',
             input: true
-          },
+          }
+        ]
+      }, {
+        debug: false
+      })
+
+      const component = form.getComponent('name')
+      expect(component).not.toBe(null)
+
+      const id = `input-${component.id}`
+      const input = form.element.querySelector(`input[id="${id}"]`)
+      expect(input).not.toBe(null, `No input found with id="${id}"`)
+      const label = form.element.querySelector(`label[for="${id}"]`)
+      expect(label).not.toBe(null, `No label found with for="${id}"`)
+
+      destroyForm(form)
+    })
+
+    it('nested inputs have associated labels', async () => {
+      const form = await createForm({
+        type: 'form',
+        display: 'form',
+        components: [
           {
             type: 'container',
             key: 'nested',
@@ -28,22 +50,52 @@ describe('a11y', () => {
             ]
           }
         ]
-      }, {})
+      }, {
+        debug: false
+      })
 
-      const inputs = form.element.querySelectorAll('input')
-      const labels = form.element.querySelectorAll('label:not(.control-label--hidden)')
-      expect(inputs).toHaveLength(2)
-      expect(labels).toHaveLength(2)
+      const component = form.getComponent('age')
+      expect(component).not.toBe(null)
 
-      const [nameField, ageField] = inputs
-      const [nameLabel, ageLabel] = labels
-      expect(nameField.name).toBe('data[name]')
-      expect(nameField.id).toBe(`input-${nameField.name}`)
-      expect(nameLabel.getAttribute('for')).toBe(nameField.id)
+      const id = `input-${component.id}`
+      const input = form.element.querySelector(`input[id="${id}"]`)
+      expect(input).not.toBe(null, `No input found with id="${id}"`)
+      const label = form.element.querySelector(`label[for="${id}"]`)
+      expect(label).not.toBe(null, `No label found with for="${id}"`)
 
-      expect(ageField.name).toBe('data[nested][age]')
-      expect(ageField.id).toBe(`input-${ageField.name}`)
-      expect(ageLabel.getAttribute('for')).toBe(ageField.id)
+      destroyForm(form)
+    })
+
+    it('select inputs have associated labels', async () => {
+      const form = await createForm({
+        type: 'form',
+        display: 'form',
+        components: [
+          {
+            type: 'select',
+            key: 'color',
+            label: 'Choose a color',
+            data: {
+              values: [
+                { label: 'Red', value: 'red' },
+                { label: 'Green', value: 'green' },
+                { label: 'Blue', value: 'blue' }
+              ]
+            }
+          }
+        ]
+      }, {
+        debug: false
+      })
+
+      const component = form.getComponent('color')
+      expect(component).not.toBe(null)
+
+      const id = `input-${component.id}`
+      const input = form.element.querySelector(`select[id="${id}"]`)
+      expect(input).not.toBe(null, `No input found with id="${id}"`)
+      const label = form.element.querySelector(`label[for="${id}"]`)
+      expect(label).not.toBe(null, `No label found with for="${id}"`)
 
       destroyForm(form)
     })

--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -48,4 +48,28 @@ describe('a11y', () => {
       destroyForm(form)
     })
   })
+
+  describe('required attributes', () => {
+    it('adds required="true" to required components', async () => {
+      const form = await createForm({
+        components: [
+          {
+            type: 'textfield',
+            key: 'name',
+            label: 'Name',
+            input: true,
+            validate: {
+              required: true
+            }
+          }
+        ]
+      }, {})
+
+      const input = form.element.querySelector('input')
+      expect(input).not.toBe(null)
+      expect(input.getAttribute('required')).toEqual('true')
+
+      destroyForm(form)
+    })
+  })
 })

--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -67,7 +67,26 @@ describe('a11y', () => {
 
       const input = form.element.querySelector('input')
       expect(input).not.toBe(null)
-      expect(input.getAttribute('required')).toEqual('true')
+      expect(input.hasAttribute('required')).toBe(true)
+
+      destroyForm(form)
+    })
+
+    it('does not fail without a validate prop', async () => {
+      const form = await createForm({
+        components: [
+          {
+            type: 'textfield',
+            key: 'name',
+            label: 'Name',
+            input: true
+          }
+        ]
+      }, {})
+
+      const input = form.element.querySelector('input')
+      expect(input).not.toBe(null)
+      expect(input.hasAttribute('required')).toBe(false)
 
       destroyForm(form)
     })

--- a/__tests__/icons.js
+++ b/__tests__/icons.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+import { createForm, destroyForm } from '../lib/test-helpers'
+import '../dist/formio-sfds.standalone.js'
+
+describe('icons', () => {
+  describe('datetime prefix', () => {
+    it('renders a calendar icon', async () => {
+      const form = await createForm({
+        type: 'form',
+        display: 'form',
+        components: [
+          {
+            type: 'datetime',
+            label: 'Date'
+          }
+        ]
+      }, {})
+
+      const prepend = form.element.querySelector('.input-group-prepend')
+      expect(prepend).not.toBe(null)
+      expect(prepend.innerHTML).not.toContain('[object HTMLElement]')
+
+      destroyForm(form)
+    })
+  })
+})

--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -74,6 +74,13 @@ describe('patch()', () => {
   })
 
   describe('localization', () => {
+    describe('i18next.t() fallback support', () => {
+      it('works with multiple fallback keys in an array', async () => {
+        const form = await createForm()
+        expect(form.t(['bleep.bloop', 'blurp'])).toEqual('blurp')
+      })
+    })
+
     describe('"language" option', () => {
       it('defaults to "en" if none is provided', async () => {
         const form = await createForm()

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ module.exports = {
     }]
   ],
   plugins: [
+    '@babel/plugin-proposal-optional-chaining',
     ['babel-plugin-lodash', {
     }]
   ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  bail: 1,
   setupFiles: ['<rootDir>/lib/test-setup.js']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2393,6 +2393,7 @@
       "version": "7.8.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
       "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -2545,17 +2546,17 @@
       "dev": true
     },
     "@formio/bootstrap3": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.6.3.tgz",
-      "integrity": "sha512-NFT3fExUVBPtUr/XjKdpNmUN0cEe7ZAJ+COTnkXzcE0UwkNQBz5AJtJ5tg0LOUqTL1IxI8bPQUZm8XRYukfTWw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.6.5.tgz",
+      "integrity": "sha512-Tmi5eTjTFJkqryEL4aHnfaU5RgmKnKUYNFVjJoqzVDod72r55+pBr5lQ/SQPP6GRaBOPAV5+12a7ZtA60yXZAQ==",
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
       }
     },
     "@formio/semantic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.4.3.tgz",
-      "integrity": "sha512-mUYYU6QwmiX1WNcTO3IeV7Y3hI/qulBIdOdzHaCNSYLjXDagTw2B2JCdOjjsVQVRVwSrbmJw+ilFMBl69lzFKQ=="
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.4.5.tgz",
+      "integrity": "sha512-azkpbc5HjjLFlXWEQxFfyVM/jpb3+4tqZX/MylePE4QYNZ9Oo4GoYSAhIyyP/u/JmcPgchldtP2jsbmP67cG6w=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4599,9 +4600,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+      "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -5078,9 +5079,9 @@
           },
           "dependencies": {
             "is-regex": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-              "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+              "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
               "requires": {
                 "has-symbols": "^1.0.1"
               }
@@ -5192,9 +5193,9 @@
       "dev": true
     },
     "dialog-polyfill": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.1.tgz",
-      "integrity": "sha512-1+VxuUxUz1aUpVoZZADSx/PAtMJedtvOFzLJ/HYWboXxmWwtxBPnYzK8IDgxvojcpetewaJJg30f2pIvo4zbLw=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.3.tgz",
+      "integrity": "sha512-DVYazl3klQtPjs4dOzDTOt4uQ8cRDfu8EBhoY81ISmH0fbrMvYuaethcQ9UevmF9kAaLnBJ0O5eDUnZ7QalArA=="
     },
     "diff-sequences": {
       "version": "26.0.0",
@@ -5277,9 +5278,9 @@
       }
     },
     "dompurify": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.12.tgz",
-      "integrity": "sha512-Fl8KseK1imyhErHypFPA8qpq9gPzlsJ/EukA6yk9o0gX23p1TzC+rh9LqNg1qvErRTc0UNMYlKxEGSfSh43NDg=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.11.tgz",
+      "integrity": "sha512-qVoGPjIW9IqxRij7klDQQ2j6nSe4UNWANBhZNLnsS7ScTtLb+3YdxkRY8brNTpkUiTtcXsCJO+jS0UCDfenLuA=="
     },
     "domutils": {
       "version": "1.7.0",
@@ -6252,9 +6253,9 @@
       }
     },
     "flatpickr": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.3.tgz",
-      "integrity": "sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ=="
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.6.tgz",
+      "integrity": "sha512-EZ48CJMttMg3maMhJoX+GvTuuEhX/RbA1YeuI19attP3pwBdbYy6+yqAEVm0o0hSBFYBiLbVxscLW6gJXq6H3A=="
     },
     "flatted": {
       "version": "2.0.2",
@@ -6317,35 +6318,35 @@
       }
     },
     "formiojs": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.10.4.tgz",
-      "integrity": "sha512-A59azE+T632g1ROxu1ICgC+EhV3P7LfGbB9PGuIIFrKco0/89r10ShJ+4DPtIIpsjVvpZ/nDsBFK2J0M++tWEQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.11.2.tgz",
+      "integrity": "sha512-PV7E5veKAOWPtPu3eo20N2CV+BS8xWoPsOrA+mde3+7Sdpz6bk3KYLHvaknY4/4ekgCeK1pKRlLNZHbEgtwN5w==",
       "requires": {
-        "@formio/bootstrap3": "^2.6.1",
-        "@formio/semantic": "^2.4.1",
+        "@formio/bootstrap3": "^2.6.4",
+        "@formio/semantic": "^2.4.4",
         "autocompleter": "^6.0.3",
         "browser-cookies": "^1.2.0",
         "choices.js": "^9.0.1",
         "compare-versions": "^3.6.0",
-        "core-js": "^3.6.5",
+        "core-js": "3.5.0",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.1",
-        "dompurify": "^2.0.11",
+        "dompurify": "2.0.11",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.2",
-        "eventemitter2": "^6.4.1",
+        "eventemitter2": "^6.4.3",
         "fast-deep-equal": "^3.1.3",
         "fast-json-patch": "^2.2.1",
         "fetch-ponyfill": "^6.1.0",
-        "flatpickr": "^4.6.3",
-        "i18next": "^19.4.5",
+        "flatpickr": "^4.6.6",
+        "i18next": "^19.6.2",
         "idb": "^5.0.4",
         "ismobilejs": "^1.1.1",
         "json-logic-js": "^1.2.2",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^2.2.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.26.0",
+        "lodash": "^4.17.19",
+        "moment": "^2.27.0",
         "moment-timezone": "^0.5.31",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
@@ -6354,15 +6355,36 @@
         "string-hash": "^1.1.3",
         "text-mask-addons": "^3.8.0",
         "tooltip.js": "^1.3.3",
-        "uuid": "^8.1.0",
+        "uuid": "^8.2.0",
         "vanilla-picker": "^2.10.1",
         "vanilla-text-mask": "^5.1.1"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "flatpickr": {
+          "version": "4.6.6",
+          "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.6.tgz",
+          "integrity": "sha512-EZ48CJMttMg3maMhJoX+GvTuuEhX/RbA1YeuI19attP3pwBdbYy6+yqAEVm0o0hSBFYBiLbVxscLW6gJXq6H3A=="
+        },
+        "i18next": {
+          "version": "19.7.0",
+          "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.7.0.tgz",
+          "integrity": "sha512-sxZhj6u7HbEYOMx81oGwq5MiXISRBVg2wRY3n6YIbe+HtU8ydzlGzv6ErHdrRKYxATBFssVXYbc3lNZoyB4vfA==",
+          "requires": {
+            "@babel/runtime": "^7.10.1"
+          }
         }
       }
     },
@@ -6872,11 +6894,23 @@
       "dev": true
     },
     "i18next": {
-      "version": "19.4.5",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.4.5.tgz",
-      "integrity": "sha512-aLvSsURoupi3x9IndmV6+m3IGhzLzhYv7Gw+//K3ovdliyGcFRV0I1MuddI0Bk/zR7BG1U+kJOjeHFUcUIdEgg==",
+      "version": "19.7.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.7.0.tgz",
+      "integrity": "sha512-sxZhj6u7HbEYOMx81oGwq5MiXISRBVg2wRY3n6YIbe+HtU8ydzlGzv6ErHdrRKYxATBFssVXYbc3lNZoyB4vfA==",
+      "dev": true,
       "requires": {
-        "@babel/runtime": "^7.3.1"
+        "@babel/runtime": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -7366,6 +7400,11 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
     },
     "is-number": {
       "version": "7.0.0",
@@ -10346,9 +10385,9 @@
           "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
         },
         "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -12784,12 +12823,51 @@
       "optional": true
     },
     "side-channel": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
-      "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
+      "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
       "requires": {
-        "es-abstract": "^1.17.0-next.1",
-        "object-inspect": "^1.7.0"
+        "es-abstract": "^1.18.0-next.0",
+        "object-inspect": "^1.8.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-inspect": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+        }
       }
     },
     "signal-exit": {
@@ -14581,9 +14659,9 @@
           "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
         },
         "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
           "requires": {
             "has-symbols": "^1.0.1"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,6 +1292,34 @@
         }
       }
     },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+      "integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+          "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
@@ -1570,13 +1598,22 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.1.tgz",
-      "integrity": "sha512-dqQj475q8+/avvok72CF3AOSV/SGEcH29zT5hhohqqvvZ2+boQoOr7iGldBG5YXTO2qgCgc2B3WvVLUdbeMlGA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
+      "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-proposal-private-methods": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@babel/cli": "^7.10.1",
     "@babel/core": "^7.10.1",
+    "@babel/plugin-proposal-optional-chaining": "^7.11.0",
     "@babel/preset-env": "^7.10.2",
     "@csstools/postcss-sass": "^4.0.0",
     "@rollup/plugin-commonjs": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "dependencies": {
     "choices.js": "^9.0.1",
-    "flatpickr": "^4.6.3",
-    "formiojs": "4.10.4",
+    "flatpickr": "4.6.6",
+    "formiojs": "4.11.2",
     "interpolate": "^0.1.0",
     "uri-template-lite": "^19.12.0",
     "whatwg-fetch": "^3.0.0"
@@ -57,7 +57,7 @@
     "dotenv": "^8.2.0",
     "globby": "^11.0.1",
     "google-spreadsheet": "^3.0.11",
-    "i18next": "^19.4.5",
+    "i18next": "19.7.0",
     "jest": "^26.1.0",
     "js-yaml": "^3.14.0",
     "mkdirp": "^1.0.4",

--- a/src/patch.js
+++ b/src/patch.js
@@ -14,6 +14,12 @@ const PATCHED = `sfds-patch-${Date.now()}`
 const { NODE_ENV } = process.env
 const debugDefault = NODE_ENV !== 'test'
 
+const defaultEvalContext = {
+  requiredAttributes () {
+    return this.component?.validate?.required ? 'required' : ''
+  }
+}
+
 let util
 const forms = []
 
@@ -76,6 +82,8 @@ function patch (Formio) {
     if (opts.on instanceof Object) {
       eventHandlers = buildHooks(opts.on)
     }
+
+    opts.evalContext = Object.assign({}, defaultEvalContext, opts.evalContext)
 
     const rest = resourceOrOptions ? [resourceOrOptions, opts] : [opts]
     return createForm(el, ...rest).then(form => {
@@ -165,7 +173,6 @@ function patch (Formio) {
   })
 
   patchDateTimeLocale(Formio)
-  patchRequiredAttribute(Formio)
 
   // this goes last so that if it fails it doesn't break everything else
   patchLanguageObserver()
@@ -223,22 +230,6 @@ function patchDateTimeSuffix () {
         text.classList.add('input-group-prepend')
         el.insertBefore(text, el.firstChild)
       }
-    }
-  })
-}
-
-function patchRequiredAttribute (Formio) {
-  const Input = Formio.Components.components.input
-  const descriptor = Object.getOwnPropertyDescriptor(Input.prototype, 'inputInfo')
-  const getInputInfo = descriptor.get
-
-  Object.defineProperty(Input.prototype, 'inputInfo', {
-    get: function () {
-      const info = getInputInfo.call(this)
-      if (this.component.validate && this.component.validate.required) {
-        info.attr.required = 'true'
-      }
-      return info
     }
   })
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -165,6 +165,7 @@ function patch (Formio) {
   })
 
   patchDateTimeLocale(Formio)
+  patchRequiredAttribute(Formio)
 
   // this goes last so that if it fails it doesn't break everything else
   patchLanguageObserver()
@@ -222,6 +223,22 @@ function patchDateTimeSuffix () {
         text.classList.add('input-group-prepend')
         el.insertBefore(text, el.firstChild)
       }
+    }
+  })
+}
+
+function patchRequiredAttribute (Formio) {
+  const Input = Formio.Components.components.input
+  const descriptor = Object.getOwnPropertyDescriptor(Input.prototype, 'inputInfo')
+  const getInputInfo = descriptor.get
+
+  Object.defineProperty(Input.prototype, 'inputInfo', {
+    get: function () {
+      const info = getInputInfo.call(this)
+      if (this.component.validate && this.component.validate.required) {
+        info.attr.required = 'true'
+      }
+      return info
     }
   })
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -214,15 +214,13 @@ function hook (obj, methodName, wrapper) {
 }
 
 function patchDateTimeSuffix () {
-  observe('.formio-component-datetime', {
+  observe('.formio-component-datetime .input-group', {
     add (el) {
-      const group = el.querySelector('.input-group')
-      if (!group) return
-      const text = group.querySelector('.input-group-append')
+      const text = el.querySelector('.input-group-append')
       if (text) {
         text.classList.remove('input-group-append')
         text.classList.add('input-group-prepend')
-        group.insertBefore(text, group.firstChild)
+        el.insertBefore(text, el.firstChild)
       }
     }
   })

--- a/src/patch.js
+++ b/src/patch.js
@@ -226,6 +226,12 @@ function patchDateTimeSuffix () {
   })
 }
 
+/**
+ * This patch can go away as soon as we upgrade to formiojs's (eventual)
+ * release of 4.12.0, which should include this fix:
+ *
+ * <https://github.com/formio/formio.js/pull/3129>
+ */
 function patchDateTimeLocale (Formio) {
   hook(Formio.Components.components.datetime.prototype, 'attach', function (attach, args) {
     if (this.options.language) {

--- a/src/patch.js
+++ b/src/patch.js
@@ -164,8 +164,6 @@ function patch (Formio) {
     })
   })
 
-  patchI18nMultipleKeys(Formio)
-
   patchDateTimeLocale(Formio)
 
   // this goes last so that if it fails it doesn't break everything else
@@ -213,38 +211,6 @@ function hook (obj, methodName, wrapper) {
   obj[methodName] = function (...args) {
     return wrapper.call(this, method.bind(this), args)
   }
-}
-
-function patchI18nMultipleKeys (Formio) {
-  /*
-   * Patch the base Component class's t() method to support multiple key
-   * fallbacks as the first argument. As of 4.10.0-beta.3.1, form.io's
-   * implementation treats the first argument as a string even if it's an Array,
-   * which means that in a template, this call:
-   *
-   * ```js
-   * ctx.t(['some.nonexistent.key', ''])
-   * ```
-   *
-   * Will render the string "some.nonexistent.key,". The trailing comma is from
-   * the array being coerced to a string in the last line here:
-   *
-   * <https://github.com/formio/formio.js/blob/58996eac1207803cb597b4ab7c3abc6636078c72/src/components/_classes/component/Component.js#L707-L708>
-   */
-  hook(Formio.Components._components.component.prototype, 't', function (t, [keys, params]) {
-    if (Array.isArray(keys)) {
-      const last = keys.length - 1
-      const fallback = (key, index) => {
-        const value = t(key, params)
-        return value === key ? (index === last) ? value : '' : value
-      }
-      return keys.reduce((value, key, index) => {
-        return value || fallback(key, index)
-      }, '')
-    } else {
-      return t(keys, params)
-    }
-  })
 }
 
 function patchDateTimeSuffix () {

--- a/src/patch.js
+++ b/src/patch.js
@@ -15,6 +15,15 @@ const { NODE_ENV } = process.env
 const debugDefault = NODE_ENV !== 'test'
 
 const defaultEvalContext = {
+  inputId () {
+    const parts = [
+      'input',
+      this.component.row,
+      this.id || this.input?.attr?.name
+    ].filter(Boolean)
+    return parts.join('-')
+  },
+
   requiredAttributes () {
     return this.component?.validate?.required ? 'required' : ''
   }

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -1,11 +1,15 @@
-{% if (ctx.component.prefix || ctx.component.suffix) { %}
+{%
+  let prefix = ctx.prefix
+  let suffix = ctx.suffix
+%}
+{% if (prefix || suffix) { %}
   <div class="input-group">
 {% } %}
 
-{% if (ctx.component.prefix) { %}
+{% if (prefix) { %}
   <div class="input-group-prepend" ref="prefix">
     <span class="input-group-text">
-      {{ ctx.t([`${ctx.component.key}_prefix`, ctx.component.prefix]) }}
+      {{ ctx.t([`${ctx.component.key}_prefix`, prefix]) }}
     </span>
   </div>
 {% } %}
@@ -28,14 +32,14 @@
   <span class="text-muted pull-right" ref="wordcount"></span>
 {% } %}
 
-{% if (ctx.component.suffix) { %}
+{% if (suffix) { %}
   <div class="input-group-append" ref="suffix">
     <span class="input-group-text">
-      {{ ctx.t([`${ctx.component.key}_suffix`, ctx.component.suffix]) }}
+      {{ ctx.t([`${ctx.component.key}_suffix`, suffix]) }}
     </span>
   </div>
 {% } %}
 
-{% if (ctx.component.prefix || ctx.component.suffix) { %}
+{% if (prefix || suffix) { %}
   </div>
 {% } %}

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -17,13 +17,14 @@
 {% } %}
 
 <div class="form-input">
-  <{{ctx.input.type}}
-    ref="{{ctx.input.ref ? ctx.input.ref : 'input'}}"
+  <{{ ctx.input.type }}
+    ref="{{ ctx.input.ref || 'input' }}"
     id="input-{{ ctx.input.attr.name }}"
-    {% for (var attr in ctx.input.attr) { %}
-    {{attr}}="{{ctx.input.attr[attr]}}"
+    {{ ctx.requiredAttributes() }}
+    {% for (const attr in ctx.input.attr) { %}
+      {{ attr }}="{{ ctx.input.attr[attr] }}"
     {% } %}
-  >{{ctx.input.content}}</{{ctx.input.type}}>
+  >{{ ctx.input.content }}</{{ ctx.input.type }}>
 </div>
 
 {% if (ctx.component.showCharCount) { %}

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -19,7 +19,7 @@
 <div class="form-input">
   <{{ ctx.input.type }}
     ref="{{ ctx.input.ref || 'input' }}"
-    id="input-{{ ctx.input.attr.name }}"
+    id="{{ ctx.inputId() }}"
     {{ ctx.requiredAttributes() }}
     {% for (const attr in ctx.input.attr) { %}
       {{ attr }}="{{ ctx.input.attr[attr] }}"

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -1,6 +1,8 @@
 {%
   let prefix = ctx.prefix
+  if (prefix instanceof HTMLElement) prefix = prefix.outerHTML
   let suffix = ctx.suffix
+  if (suffix instanceof HTMLElement) suffix = suffix.outerHTML
 %}
 {% if (prefix || suffix) { %}
   <div class="input-group">

--- a/src/templates/label/form.ejs
+++ b/src/templates/label/form.ejs
@@ -1,5 +1,7 @@
 {% if (!ctx.component.hideLabel && ['checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
-  <label class="{{ ctx.label.className }}" for="input-{{ ctx.self.options.name }}">
+  <label
+    class="{{ ctx.label.className }}"
+    for="{{ ctx.inputId() }}">
     {{ ctx.t([`${ctx.component.key}_label`, ctx.component.label]) }}
     <!--
     {% if (ctx.component.tooltip) { %}

--- a/src/templates/select/form.ejs
+++ b/src/templates/select/form.ejs
@@ -1,7 +1,10 @@
 <select
   ref="{{ctx.input.ref ? ctx.input.ref : 'selectContainer'}}"
-  {{ ctx.input.multiple ? 'multiple' : '' }}
+  {% if (ctx.input.multiple) { %}
+    multiple
+  {% } %}
+  {{ ctx.requiredAttributes() }}
   {% for (var attr in ctx.input.attr) { %}
-  {{attr}}="{{ctx.input.attr[attr]}}"
+    {{ attr }}="{{ ctx.input.attr[attr] }}"
   {% } %}
 >{{ctx.selectOptions}}</select>

--- a/src/templates/select/form.ejs
+++ b/src/templates/select/form.ejs
@@ -1,9 +1,10 @@
 <select
-  ref="{{ctx.input.ref ? ctx.input.ref : 'selectContainer'}}"
+  ref="{{ ctx.input.ref || 'selectContainer' }}"
+  {{ ctx.requiredAttributes() }}
+  id="{{ ctx.inputId() }}"
   {% if (ctx.input.multiple) { %}
     multiple
   {% } %}
-  {{ ctx.requiredAttributes() }}
   {% for (var attr in ctx.input.attr) { %}
     {{ attr }}="{{ ctx.input.attr[attr] }}"
   {% } %}

--- a/templates/example.html
+++ b/templates/example.html
@@ -20,7 +20,7 @@
       </div>
     </div>
 
-    <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.js"></script>
+    <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.min.js"></script>
     <script src="/dist/formio-sfds.standalone.js"></script>
     <script src="/dist/examples.js"></script>
   </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,7 +76,7 @@
       </div>
     </div>
 
-    <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.js"></script>
+    <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.min.js"></script>
     <script src="/dist/formio-sfds.standalone.js"></script>
     <script src="/dist/examples.js"></script>
   </body>

--- a/templates/standalone.html
+++ b/templates/standalone.html
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.js"></script>
+  <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.min.js"></script>
   <script src="/dist/formio-sfds.standalone.js"></script>
   <script>
     (() => {


### PR DESCRIPTION
This PR adds tests for whether some representative fields (a proxy for testing formio.js's Input class inherited by most of the single-input components) render the `required` attribute if the component is required, and gets the tests passing.

My first instinct with this was to patch the [`inputInfo` getter](https://github.com/formio/formio.js/blob/26d74a4580d8087b297324ed6c5d93526f3f84f9/src/components/_classes/input/Input.js#L21-L54), since that appears to be how most components get the HTML attributes of their input element. This worked, but it left me feeling kinda yucky.

After looking at it more closely, I decided to do this by extending our patched forms' `evalContext` option, which is the blessed way for adding new properties to the `ctx` object passed to our templates. (Side note: because the methods of this object are always called _on_ the object a la `ctx.function()`, they can access the context object via `this`, which makes the calls nice and concise). I've added two new functions to this object:

1. `requiredAttributes()` returns the HTML for an element's required attributes, namely `required`. (I made this plural to leave open the question of whether to also add `aria-required="true"`.) The templates now just add this inside the input tags, e.g. `<input {{ ctx.requiredAttributes() }}>`.

1. `inputId()` returns a unique identifier for a component's input element, which can also be used in the label template's `for` attribute. This eliminates the possibility of the input and label templates not agreeing, and allows us to test the identifier logic outside of the templates.

Now that we know this works, we can also consider reducing the boilerplate of so many `ctx.t([...])` calls in our templates to something like `ctx.translate('description')` as shorthand for `ctx.t([ctx.component.key + '.description', ctx.component.description])`.