### PR TITLE
Add kitchen sink example

### DIFF
--- a/src/examples.yml
+++ b/src/examples.yml
@@ -303,7 +303,5 @@
         label: Datetime field
       - type: currency
         label: Currency field
-      - type: signature
-        label: Signature field
       - type: file
         label: File field

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -252,3 +252,58 @@
         label: This is the label
         description: This is the description
         enableDate: false
+
+
+- id: kitchen-sink
+  title: Kitchen sink
+  form:
+    components:
+      - type: textfield
+        label: A text field
+      - type: number
+        label: A number field
+      - type: textarea
+        label: A text area field
+      - type: checkbox
+        label: A checkbox
+      - type: select
+        label: Select field
+        data:
+          values:
+            - label: Option 1
+              value: 1
+            - label: Option 2
+              value: 2
+      - type: selectboxes
+        label: Select boxes
+        values:
+          - label: Select box 1
+            value: 1
+          - label: Select box 2
+            value: 2
+          - label: Select box 3
+            value: 3
+      - type: radio
+        values:
+          - label: Radio 1
+            value: 1
+          - label: Radio 2
+            value: 2
+          - label: Radio 3
+            value: 3
+      - type: button
+        label: This is a button
+      - type: email
+        label: Email field
+      - type: phonenumber
+        label: Phone number field
+      - type: address
+        label: Address field
+      - type: datetime
+        label: Datetime field
+      - type: currency
+        label: Currency field
+      - type: signature
+        label: Signature field
+      - type: file
+        label: File field


### PR DESCRIPTION
This adds a ["kitchen sink" example](https://formio-sfds-r5gl1rldy.vercel.app/examples/kitchen-sink) that allows most (all?) of the components we use to be included in our Lighthouse report. I expected the Lighthouse accessibility score should to drop (from 91) because it adds components that we weren't testing before; and sure enough, it dropped to 89:

![GitHub check "/lhci/url/" — Performance: 8, Accessibility: 89, ...](https://user-images.githubusercontent.com/113896/92152841-34a26c00-edd8-11ea-8bec-c4d6a942cec0.png)

However, after discovering that the source of the regression was the [signature component](https://help.form.io/userguide/form-components/#signature) I removed it and the score went back up to 91. Why remove it? Because the component is inherently _impossible_ to use with a keyboard since it relies on a pointer device to draw the signature. We don't actually use the signature component anywhere, and we probably shouldn't!