### PR TITLE
Add patch to un-escape HTML in error messages

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -251,13 +251,11 @@ describe('patch()', () => {
         ]
       })
 
-      try {
-        await form.submit()
-      } catch (error) {
-        console.info('caught error:', error.message)
-      }
+      // black hole errors (this is supposed to fail)
+      await form.submit().catch(errors => { })
+
       const error = form.element.querySelector('[ref=errorRef]')
-      expect(error.textContent).toBe('Name: This is a message with HTML')
+      expect(error.textContent.trim()).toBe('Name: This is a message with HTML')
     })
   })
 })

--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -234,4 +234,30 @@ describe('patch()', () => {
       })
     })
   })
+
+  describe('error message HTML un-escaping', () => {
+    it('un-escapes HTML in error messages', async () => {
+      const form = await createForm({
+        components: [
+          {
+            key: 'name',
+            type: 'textfield',
+            label: 'Name',
+            validate: {
+              required: true,
+              customMessage: 'This is a message <b>with HTML</b>'
+            }
+          }
+        ]
+      })
+
+      try {
+        await form.submit()
+      } catch (error) {
+        console.info('caught error:', error.message)
+      }
+      const error = form.element.querySelector('[ref=errorRef]')
+      expect(error.textContent).toBe('Name: This is a message with HTML')
+    })
+  })
 })

--- a/src/patch.js
+++ b/src/patch.js
@@ -50,6 +50,7 @@ export default Formio => {
 
   // this goes last so that if it fails it doesn't break everything else
   patchLanguageObserver()
+  patchEscapedErrorMessageHTML()
 }
 
 // Prevent users from navigating away and losing their entries.
@@ -271,6 +272,18 @@ function patchDateTimeLabels () {
       const input = el.querySelector('input.form-control[type=text]')
       label.setAttribute('id', labelId)
       input.setAttribute('aria-labelledby', labelId)
+    }
+  })
+}
+
+function patchEscapedErrorMessageHTML () {
+  const attr = 'data-formio-sfds-unescaped'
+  observe(`[ref=errorRef]:not([${attr}])`, {
+    add (el) {
+      // console.info('errorRef:', el.outerHTML)
+      el.setAttribute('aria-label', el.textContent)
+      el.innerHTML = el.textContent
+      el.setAttribute(attr, 'true')
     }
   })
 }

--- a/templates/standalone.html
+++ b/templates/standalone.html
@@ -35,7 +35,7 @@
         unlockNavigation: params.get('nav') !== 'false',
         i18n: tryParse(params.get('i18n')),
         googleTranslate: params.get('googleTranslate') === 'true',
-        prefill: params
+        prefill: params,
         properties: tryParse(params.get('properties'))
       }
 


### PR DESCRIPTION
@hshaosf This is for you! You should be able to test it by putting your form URL into this one:

```
https://formio-sfds-git-patch-error-html.sfds.vercel.app/standalone?res=<url>
```