### PR TITLE
Replace all i18n-microservice URLs with translate.sf.gov

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ import { readFileSync } from 'fs'
 
 const {
   NODE_ENV = 'development',
-  I18N_SERVICE_URL = 'https://i18n-microservice-js.sfds.vercel.app'
+  I18N_SERVICE_URL = 'https://translate.sf.gov'
 } = process.env
 
 const prod = NODE_ENV === 'production'

--- a/src/phrase.js
+++ b/src/phrase.js
@@ -4,7 +4,7 @@ import loadTranslations from './i18n/load'
 const I18NEXT_DEFAULT_NAMESPACE = 'translation' // ???
 
 const {
-  I18N_SERVICE_URL = 'https://i18n-microservice-js.sfds.vercel.app',
+  I18N_SERVICE_URL = 'https://translate.sf.gov',
   NODE_ENV
 } = process.env
 

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
   ],
   "build": {
     "env": {
-      "I18N_SERVICE_URL": "https://i18n-microservice-js-git-phrase-endpoint.sfds.vercel.app"
+      "I18N_SERVICE_URL": "https://translate.sf.gov"
     }
   }
 }


### PR DESCRIPTION
There's no good reason to reference the `vercel.app` URL in our code anymore, and it's too hard to remember anyway.