### PR TITLE
Use Vercel "rewrites" instead of "routes"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,16 @@
 {
-  "routes": [
+  "rewrites": [
     {
-      "src": "/",
-      "dest": "/dist/index.html"
+      "source": "/",
+      "destination": "/dist/index.html"
     },
     {
-      "src": "/([-\\w]+)",
-      "dest": "/dist/$1.html"
+      "source": "/:view",
+      "destination": "/dist/:view.html"
     },
     {
-      "src": "/examples/([-\\w]+)",
-      "dest": "/dist/examples/$1.html"
+      "source": "/examples/:example",
+      "destination": "/dist/examples/:example.html"
     }
   ],
   "build": {


### PR DESCRIPTION
The syntax of these is much easier to understand, and equivalent:

| Before | After |
| :--- | :--- |
| <pre>"routes": [<br>  {<br>    "src": "/([-\\w]+)",<br>    "dest": "/dist/$1.html"<br>  }<br>]</pre> | <pre>"rewrites": [<br>  {<br>    "source": "/:view",<br>    "destination": "/dist/:view.html"<br>  }<br>]</pre>