### PR TITLE
Fix aria/disabled states in wizard nav

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -1793,7 +1793,7 @@ exports[`component snapshots component "form" scenario: basic matches the snapsh
                   </rect>
                 </svg>
               </span>
-              <button disabled
+              <button ref="wizard-form-basic-1-link"
                       aria-current="page"
                       class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u"
               >
@@ -1896,7 +1896,7 @@ exports[`component snapshots component "form" scenario: translate matches the sn
                   </rect>
                 </svg>
               </span>
-              <button disabled
+              <button ref="wizard-form-translate-1-link"
                       aria-current="page"
                       class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u"
               >

--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -1776,9 +1776,7 @@ exports[`component snapshots component "form" scenario: basic matches the snapsh
              role="navigation"
         >
           <ul class="nav-list mt-2 mb-0 mx-0 p-0">
-            <li aria-current="page"
-                class="mb-1 d-flex flex-items-start"
-            >
+            <li class="mb-1 d-flex flex-items-start">
               <span data-icon="square"
                     class="fg-slate notranslate"
               >
@@ -1795,7 +1793,10 @@ exports[`component snapshots component "form" scenario: basic matches the snapsh
                   </rect>
                 </svg>
               </span>
-              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u">
+              <button disabled
+                      aria-current="page"
+                      class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u"
+              >
                 Page 1 link title
               </button>
             </li>
@@ -1816,7 +1817,9 @@ exports[`component snapshots component "form" scenario: basic matches the snapsh
                   </rect>
                 </svg>
               </span>
-              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-inherit fw-regular no-u">
+              <button disabled
+                      class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-inherit fw-regular no-u"
+              >
                 Page 2
               </button>
             </li>
@@ -1876,9 +1879,7 @@ exports[`component snapshots component "form" scenario: translate matches the sn
              role="navigation"
         >
           <ul class="nav-list mt-2 mb-0 mx-0 p-0">
-            <li aria-current="page"
-                class="mb-1 d-flex flex-items-start"
-            >
+            <li class="mb-1 d-flex flex-items-start">
               <span data-icon="square"
                     class="fg-slate notranslate"
               >
@@ -1895,7 +1896,10 @@ exports[`component snapshots component "form" scenario: translate matches the sn
                   </rect>
                 </svg>
               </span>
-              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u">
+              <button disabled
+                      aria-current="page"
+                      class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u"
+              >
                 Page 1 link title
               </button>
             </li>
@@ -1916,7 +1920,9 @@ exports[`component snapshots component "form" scenario: translate matches the sn
                   </rect>
                 </svg>
               </span>
-              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-inherit fw-regular no-u">
+              <button disabled
+                      class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-inherit fw-regular no-u"
+              >
                 Page 2
               </button>
             </li>

--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -147,4 +147,30 @@ describe('a11y', () => {
       destroyForm(form)
     })
   })
+
+  describe('wizard navigation', () => {
+    it('adds aria-current="page" to the current page', async () => {
+      const form = await createForm({
+        display: 'wizard',
+        components: [
+          {
+            type: 'panel',
+            title: 'Page 1'
+          },
+          {
+            type: 'panel',
+            title: 'Page 2'
+          }
+        ]
+      })
+
+      const buttons = form.element.querySelectorAll('nav button')
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0].getAttribute('aria-current')).toEqual('page')
+      expect(buttons[1].getAttribute('aria-current')).toEqual(null)
+    })
+
+    it('adds the disabled attribute to inaccessible pages', async () => {
+    })
+  })
 })

--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -160,20 +160,33 @@ describe('a11y', () => {
           {
             type: 'panel',
             title: 'Page 2'
+          },
+          {
+            type: 'panel',
+            title: 'Page 3'
           }
         ]
       })
 
       let buttons = form.element.querySelectorAll('nav button')
-      expect(buttons).toHaveLength(2)
+      expect(buttons).toHaveLength(3)
       expect(buttons[0].getAttribute('aria-current')).toEqual('page')
-      expect(buttons[1].getAttribute('aria-current')).toEqual(null)
+      expect(buttons[1].hasAttribute('aria-current')).toBe(false)
+      expect(buttons[2].hasAttribute('aria-current')).toBe(false)
 
       await form.setPage(1)
       buttons = form.element.querySelectorAll('nav button')
-      expect(buttons).toHaveLength(2)
-      expect(buttons[0].getAttribute('aria-current')).toEqual(null)
+      expect(buttons).toHaveLength(3)
+      expect(buttons[0].hasAttribute('aria-current')).toBe(false)
       expect(buttons[1].getAttribute('aria-current')).toEqual('page')
+      expect(buttons[2].hasAttribute('aria-current')).toBe(false)
+
+      await form.setPage(2)
+      buttons = form.element.querySelectorAll('nav button')
+      expect(buttons).toHaveLength(3)
+      expect(buttons[0].hasAttribute('aria-current')).toBe(false)
+      expect(buttons[1].hasAttribute('aria-current')).toBe(false)
+      expect(buttons[2].getAttribute('aria-current')).toEqual('page')
     })
 
     it('adds the disabled attribute to inaccessible pages', async () => {
@@ -197,15 +210,21 @@ describe('a11y', () => {
 
       let buttons = form.element.querySelectorAll('nav button')
       expect(buttons).toHaveLength(3)
-      expect(buttons[0].disabled).toBe(true)
+      expect(buttons[0].disabled).toBe(false)
       expect(buttons[1].disabled).toBe(true)
       expect(buttons[2].disabled).toBe(true)
 
       await form.setPage(1)
       buttons = form.element.querySelectorAll('nav button')
       expect(buttons[0].disabled).toBe(false)
-      expect(buttons[1].disabled).toBe(true)
+      expect(buttons[1].disabled).toBe(false)
       expect(buttons[2].disabled).toBe(true)
+
+      await form.setPage(2)
+      buttons = form.element.querySelectorAll('nav button')
+      expect(buttons[0].disabled).toBe(false)
+      expect(buttons[1].disabled).toBe(false)
+      expect(buttons[2].disabled).toBe(false)
     })
   })
 })

--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -164,10 +164,16 @@ describe('a11y', () => {
         ]
       })
 
-      const buttons = form.element.querySelectorAll('nav button')
+      let buttons = form.element.querySelectorAll('nav button')
       expect(buttons).toHaveLength(2)
       expect(buttons[0].getAttribute('aria-current')).toEqual('page')
       expect(buttons[1].getAttribute('aria-current')).toEqual(null)
+
+      await form.setPage(1)
+      buttons = form.element.querySelectorAll('nav button')
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0].getAttribute('aria-current')).toEqual(null)
+      expect(buttons[1].getAttribute('aria-current')).toEqual('page')
     })
 
     it('adds the disabled attribute to inaccessible pages', async () => {

--- a/__tests__/a11y.js
+++ b/__tests__/a11y.js
@@ -171,6 +171,35 @@ describe('a11y', () => {
     })
 
     it('adds the disabled attribute to inaccessible pages', async () => {
+      const form = await createForm({
+        display: 'wizard',
+        components: [
+          {
+            type: 'panel',
+            title: 'Page 1'
+          },
+          {
+            type: 'panel',
+            title: 'Page 2'
+          },
+          {
+            type: 'panel',
+            title: 'Page 3'
+          }
+        ]
+      })
+
+      let buttons = form.element.querySelectorAll('nav button')
+      expect(buttons).toHaveLength(3)
+      expect(buttons[0].disabled).toBe(true)
+      expect(buttons[1].disabled).toBe(true)
+      expect(buttons[2].disabled).toBe(true)
+
+      await form.setPage(1)
+      buttons = form.element.querySelectorAll('nav button')
+      expect(buttons[0].disabled).toBe(false)
+      expect(buttons[1].disabled).toBe(true)
+      expect(buttons[2].disabled).toBe(true)
     })
   })
 })

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -12,15 +12,15 @@
       {% if (panel.properties.hideFromNavigation !== "false") { %}
         {%
           const completed = index < ctx.currentPage
-          const enabled = completed || ctx.options.unlockNavigation
           const active = index === ctx.currentPage
-          const color = active || completed ? 'slate' : 'inherit'
+          const enabled = active || completed || ctx.options.unlockNavigation
+          const color = active || completed ? 'fg-slate' : 'fg-inherit'
           const style = active ? 'fw-medium no-u' : `fw-regular ${completed ? 'u' : 'no-u'}`
         %}
         <li class="mb-1 d-flex flex-items-start">
-          <span class="fg-{{ active ? color : 'none' }}" data-icon="square"></span>
+          <span class="{{ active ? color : 'fg-none' }}" data-icon="square"></span>
           <button
-            class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-{{ color }} {{ style }}"
+            class="btn-link flex-auto align-left m-0 pl-1 py-0 {{ color }} {{ style }}"
             {% if (active) { %}
               aria-current="page"
             {% } %}

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -16,19 +16,22 @@
       {% if (panel.properties.hideFromNavigation !== "false") { %}
         {% const color = active || completed ? 'slate' : 'inherit' %}
         {% const style = active ? 'fw-medium no-u' : `fw-regular ${completed ? 'u' : 'no-u'}` %}
-        <li class="mb-1 d-flex flex-items-start" {% if (active) { %} aria-current="page" {% } %}>
+        <li class="mb-1 d-flex flex-items-start">
           <span class="fg-{{ active ? color : 'none' }}" data-icon="square"></span>
           <button
             class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-{{ color }} {{ style }}"
+            {% if (active) { %}
+              aria-current="page"
+            {% } %}
             {% if (completed || ctx.options.unlockNavigation) { %}
               ref="{{ ctx.wizardKey }}-link"
-            {% } %}
-          >
+            {% } %}>
             {{
               ctx.t([
                 `${panel.key}.displayTitle`,
+                panel.properties.displayTitle || '',
                 `${panel.key}.title`,
-                panel.properties.displayTitle || panel.title
+                panel.title
               ])
             }}
           </button>

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -10,12 +10,14 @@
   <ul class="nav-list mt-2 mb-0 mx-0 p-0">
     {% ctx.panels.forEach(function(panel, index) { %}
 
-      {% const completed = index < ctx.currentPage %}
-      {% const active = index === ctx.currentPage %}
-
       {% if (panel.properties.hideFromNavigation !== "false") { %}
-        {% const color = active || completed ? 'slate' : 'inherit' %}
-        {% const style = active ? 'fw-medium no-u' : `fw-regular ${completed ? 'u' : 'no-u'}` %}
+        {%
+          const completed = index < ctx.currentPage
+          const enabled = completed || ctx.options.unlockNavigation
+          const active = index === ctx.currentPage
+          const color = active || completed ? 'slate' : 'inherit'
+          const style = active ? 'fw-medium no-u' : `fw-regular ${completed ? 'u' : 'no-u'}`
+        %}
         <li class="mb-1 d-flex flex-items-start">
           <span class="fg-{{ active ? color : 'none' }}" data-icon="square"></span>
           <button
@@ -23,8 +25,10 @@
             {% if (active) { %}
               aria-current="page"
             {% } %}
-            {% if (completed || ctx.options.unlockNavigation) { %}
+            {% if (enabled) { %}
               ref="{{ ctx.wizardKey }}-link"
+            {% } else { %}
+              disabled
             {% } %}>
             {{
               ctx.t([

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -9,7 +9,6 @@
 
   <ul class="nav-list mt-2 mb-0 mx-0 p-0">
     {% ctx.panels.forEach(function(panel, index) { %}
-
       {% if (panel.properties.hideFromNavigation !== "false") { %}
         {%
           const completed = index < ctx.currentPage
@@ -33,9 +32,8 @@
             {{
               ctx.t([
                 `${panel.key}.displayTitle`,
-                panel.properties.displayTitle || '',
                 `${panel.key}.title`,
-                panel.title
+                panel.properties.displayTitle || panel.title
               ])
             }}
           </button>


### PR DESCRIPTION
The wizard (multi-page) form navigation is a bit wonky. This fixes two things:

1. The `aria-current="page"` attribute was added to the button's parent `<li>`, which is wrong. Now it's on the button.
2. Buttons that aren't enabled get the `disabled` attribute, which makes them un-focusable.

The new tests ensure that both of these things happen, both when the form is first rendered and when the page is changed. [The snapshot test diff](https://github.com/SFDigitalServices/formio-sfds/pull/93/files#diff-f1b3d71942fb7afe3da45e22709f756463a49f55dabdf537dcea60fcc064b582) actually shows the effects pretty clearly.