### PR TITLE
Nix dot import from patch.js

### DIFF
--- a/__tests__/phrase.js
+++ b/__tests__/phrase.js
@@ -257,6 +257,17 @@ describe('Phrase functionality', () => {
       destroyForm(form)
     })
 
+    it('does not load the editor if window.drupalSettings.user.uid === "0"', async () => {
+      window.drupalSettings = { user: { uid: '0' } }
+      const form = await createForm({
+        properties: {
+          phraseProjectId: '123'
+        }
+      })
+      expect(window.PHRASEAPP_ENABLED).not.toBe(true)
+      destroyForm(form)
+    })
+
     it('does not load if ?translate=true is not in the query string', async () => {
       window.drupalSettings = { user: { uid: 12345 } }
       const form = await createForm({

--- a/package-lock.json
+++ b/package-lock.json
@@ -5460,7 +5460,8 @@
     "dotmap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dotmap/-/dotmap-0.1.0.tgz",
-      "integrity": "sha1-WC9ACSuvqOjRz2gFeONdkVBos5g="
+      "integrity": "sha1-WC9ACSuvqOjRz2gFeONdkVBos5g=",
+      "dev": true
     },
     "downloadjs": {
       "version": "1.4.7",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "choices.js": "^9.0.1",
-    "dotmap": "^0.1.0",
     "flatpickr": "4.6.6",
     "formiojs": "4.11.2",
     "interpolate": "^0.1.0",
@@ -64,6 +63,7 @@
     "autoprefixer": "^9.8.0",
     "babel-plugin-lodash": "^3.3.4",
     "dotenv": "^8.2.0",
+    "dotmap": "^0.1.0",
     "globby": "^11.0.1",
     "google-spreadsheet": "^3.0.11",
     "i18next": "19.7.0",

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,5 +1,4 @@
 import { observe } from 'selector-observer'
-import dot from 'dotmap'
 import defaultTranslations from './i18n'
 import buildHooks from './hooks'
 import loadTranslations from './i18n/load'
@@ -342,7 +341,7 @@ function scrollToTop () {
 }
 
 function userIsTranslating () {
-  const uid = dot.get(window, 'drupalSettings.user.uid')
+  const uid = window.drupalSettings?.user?.uid
   if (uid && uid !== '0') {
     const translate = new URLSearchParams(window.location.search).get('translate')
     return translate === 'true'


### PR DESCRIPTION
We don't need to use `dot.get()` now that we can use [optional chaining syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining). 🎉 