### PR TITLE
Run Lighthouse on successful deployments

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,19 +6,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: event debug
-        run: echo '${{ toJson(github.event) }}'
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: determine branch
         run: |
-          NAME_REV=$(git name-rev --name-only "$GITHUB_SHA")
-          echo "NAME_REV: $NAME_REV"
-          REF_BRANCH=${NAME_REV/remotes\/origin\//}
-          echo "GITHUB_SHA: $GITHUB_SHA"
-          echo "REF_BRANCH: $REF_BRANCH"
-          echo "::set-env name=REF_BRANCH::$REF_BRANCH"
-          git checkout $REF_BRANCH
+          echo "GITHUB_REF: '$GITHUB_REF' (before git-the-branch)"
+          echo '${{ toJson(github.event) }}'
+
+      - uses: actions/checkout@v2
+
+      - name: determine branch
+        id: git-branch
+        uses: SFDigitalServices/git-the-branch@main
+
+      - name: debug some more
+        run: |
+          echo "GITHUB_REF: '$GITHUB_REF' (after git-the-branch)"
+          echo "git-branch output: ${{ toJson(steps.git-branch.outputs) }}"
 
       - if: github.event.deployment_status.state == 'success'
         uses: treosh/lighthouse-ci-action@v3
@@ -26,6 +27,6 @@ jobs:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
-          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.REF_BRANCH }}
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.GITHUB_REF }}
           LHCI_GITHUB_TOKEN: ${{ github.token }}
           LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,17 +9,17 @@ jobs:
         run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
         with:
-          ref: ${{ env.GITHUB_REF }}
+          ref: ${{ env.GITHUB_SHA }}
       - name: determine branch
         run: |
           echo "GITHUB_SHA: $GITHUB_SHA"
           echo "GITHUB_REF: $GITHUB_REF"
-          BRANCH=$(git branch --contains $GIT_REF --list --no-color | sed 's#^\* ##')
+          BRANCH=$(git branch --contains $GITHUB_SHA --list --no-color | sed 's#^\* ##')
           echo "BRANCH: $BRANCH"
           echo "::set-env name=BRANCH::$BRANCH"
       - uses: actions/checkout@v2
         with:
-          ref: ${{ env.GITHUB_REF }}
+          ref: ${{ env.BRANCH }}
       - if: github.event.deployment_status.state == 'success'
         uses: treosh/lighthouse-ci-action@v3
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,15 +9,14 @@ jobs:
         run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
         with:
-          ref: ${{ env.GITHUB_SHA }}
+          fetch-depth: 0
       - name: determine branch
         run: |
+          REF_BRANCH=$(git name-rev --name-only "$GITHUB_SHA" | sed 's/~[0-9]$//')
           echo "GITHUB_SHA: $GITHUB_SHA"
-          BRANCH=$(git name-rev --name-only HEAD | sed 's/~[0-9]$//')
-          echo "BRANCH: $BRANCH"
-          echo "::set-env name=BRANCH::$BRANCH"
-
-      - uses: mxschmitt/action-tmate@v3
+          echo "REF_BRANCH: $REF_BRANCH"
+          echo "::set-env name=REF_BRANCH::$REF_BRANCH"
+          git checkout $REF_BRANCH
 
       - if: github.event.deployment_status.state == 'success'
         uses: treosh/lighthouse-ci-action@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,13 +14,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: determine branch
-        id: git-branch
-        uses: SFDigitalServices/git-the-branch@main
-
-      - name: checkout branch
-        run: |
-          echo "Checking out '$GIT_BRANCH'..."
-          git checkout "$GIT_BRANCH"
+        uses: SFDigitalServices/git-the-branch@nodejs
+        with:
+          checkout: true
 
       - uses: treosh/lighthouse-ci-action@v3
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: determine branch
-        uses: SFDigitalServices/git-the-branch@nodejs
+        uses: SFDigitalServices/git-the-branch@v1
         with:
           checkout: true
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,17 +11,18 @@ jobs:
           echo '${{ toJson(github.event) }}'
 
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: determine branch
         id: git-branch
         uses: SFDigitalServices/git-the-branch@main
+        with:
+          checkout: true
 
       - name: debug some more
         run: |
           echo "GITHUB_REF: '$GITHUB_REF' (after git-the-branch)"
-          echo "git-branch output: ${{ toJson(steps.git-branch.outputs) }}"
+          echo "git-branch.outputs.branch: ${{ steps.git-branch.outputs.branch }}"
+          echo "git-branch.outputs.ref: ${{ steps.git-branch.outputs.ref }}"
 
       - if: github.event.deployment_status.state == 'success'
         uses: treosh/lighthouse-ci-action@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,12 +13,12 @@ jobs:
       - name: determine branch
         run: |
           echo "GITHUB_SHA: $GITHUB_SHA"
-          BRANCH=$(git name-rev --name-only HEAD | sed 's/~\d+$//')
+          BRANCH=$(git name-rev --name-only HEAD | sed 's/~[0-9]$//')
           echo "BRANCH: $BRANCH"
           echo "::set-env name=BRANCH::$BRANCH"
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ env.BRANCH }}
+
+      - uses: mxschmitt/action-tmate@v3
+
       - if: github.event.deployment_status.state == 'success'
         uses: treosh/lighthouse-ci-action@v3
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,26 +1,20 @@
 name: Lighthouse
-on: [push]
+on: [deployment_status]
 
 jobs:
   lighthouse:
+    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     env:
       DEPLOY_ENV: Preview
     steps:
       - uses: actions/checkout@v2
-
-      - id: deployment
-        uses: SFDigitalServices/wait-for-deployment-action@v1.0.1
         with:
-          github-token: ${{ github.token }}
-          environment: ${{ env.DEPLOY_ENV }}
-          interval: 5
-          timeout: 300
-
+          ref: ${{ github.event.deployment.sha }}
       - uses: treosh/lighthouse-ci-action@v3
         with:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
           LHCI_GITHUB_TOKEN: ${{ github.token }}
-          LHCI_COLLECT_BASE_URL: ${{ steps.deployment.outputs.url }}
+          LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: determine branch
         id: git-branch
-        uses: SFDigitalServices/git-the-branch@v0
+        uses: SFDigitalServices/git-the-branch@main
 
       - name: debug some more
         run: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,6 +5,11 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
+      - name: event debug
+        run: echo '${{ toJson(github.event) }}'
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.GITHUB_REF }}
       - name: determine branch
         run: |
           echo "GITHUB_SHA: $GITHUB_SHA"
@@ -12,8 +17,6 @@ jobs:
           BRANCH=$(git branch --contains $GIT_REF --list --no-color | sed 's#^\* ##')
           echo "BRANCH: $BRANCH"
           echo "::set-env name=BRANCH::$BRANCH"
-      - name: event debug
-        run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.GITHUB_REF }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,14 +4,19 @@ on: [deployment_status]
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
-    env:
-      DEPLOY_ENV: Preview
     steps:
+      - name: determine branch
+        run: |
+          echo "GITHUB_SHA: $GITHUB_SHA"
+          echo "GITHUB_REF: $GITHUB_REF"
+          BRANCH=$(git branch --contains $GIT_REF --list --no-color | sed 's#^\* ##')
+          echo "BRANCH: $BRANCH"
+          echo "::set-env name=BRANCH::$BRANCH"
       - name: event debug
         run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.deployment.sha }}
+          ref: ${{ env.GITHUB_REF }}
       - if: github.event.deployment_status.state == 'success'
         uses: treosh/lighthouse-ci-action@v3
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -12,7 +12,9 @@ jobs:
           fetch-depth: 0
       - name: determine branch
         run: |
-          REF_BRANCH=$(git name-rev --name-only "$GITHUB_SHA" | sed 's/~[0-9]$//')
+          NAME_REV=$(git name-rev --name-only "$GITHUB_SHA")
+          echo "NAME_REV: $NAME_REV"
+          REF_BRANCH=${NAME_REV/remotes\/origin\//}
           echo "GITHUB_SHA: $GITHUB_SHA"
           echo "REF_BRANCH: $REF_BRANCH"
           echo "::set-env name=REF_BRANCH::$REF_BRANCH"
@@ -24,5 +26,6 @@ jobs:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.REF_BRANCH }}
           LHCI_GITHUB_TOKEN: ${{ github.token }}
           LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,7 +7,8 @@ jobs:
     env:
       DEPLOY_ENV: Preview
     steps:
-      - run: echo '${{ toJson(github.event) }}'
+      - name: event debug
+        run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.deployment.sha }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: determine branch
         id: git-branch
-        uses: SFDigitalServices/git-the-branch@main
+        uses: SFDigitalServices/git-the-branch@v0
 
       - name: debug some more
         run: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,8 +13,7 @@ jobs:
       - name: determine branch
         run: |
           echo "GITHUB_SHA: $GITHUB_SHA"
-          echo "GITHUB_REF: $GITHUB_REF"
-          BRANCH=$(git branch --contains $GITHUB_SHA --list --no-color | sed 's#^\* ##')
+          BRANCH=$(git name-rev --name-only HEAD | sed 's/~\d+$//')
           echo "BRANCH: $BRANCH"
           echo "::set-env name=BRANCH::$BRANCH"
       - uses: actions/checkout@v2

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,6 +3,7 @@ on: [deployment_status]
 
 jobs:
   lighthouse:
+    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: event debug
@@ -15,21 +16,17 @@ jobs:
       - name: determine branch
         id: git-branch
         uses: SFDigitalServices/git-the-branch@main
-        with:
-          checkout: true
 
-      - name: debug some more
+      - name: checkout branch
         run: |
-          echo "GITHUB_REF: '$GITHUB_REF' (after git-the-branch)"
-          echo "git-branch.outputs.branch: ${{ steps.git-branch.outputs.branch }}"
-          echo "git-branch.outputs.ref: ${{ steps.git-branch.outputs.ref }}"
+          echo "Checking out '$GIT_BRANCH'..."
+          git checkout "$GIT_BRANCH"
 
-      - if: github.event.deployment_status.state == 'success'
-        uses: treosh/lighthouse-ci-action@v3
+      - uses: treosh/lighthouse-ci-action@v3
         with:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
-          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.GITHUB_REF }}
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.GIT_BRANCH }}
           LHCI_GITHUB_TOKEN: ${{ github.token }}
           LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,6 +11,8 @@ jobs:
           echo '${{ toJson(github.event) }}'
 
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: determine branch
         id: git-branch

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,15 +3,16 @@ on: [deployment_status]
 
 jobs:
   lighthouse:
-    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     env:
       DEPLOY_ENV: Preview
     steps:
+      - run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.deployment.sha }}
-      - uses: treosh/lighthouse-ci-action@v3
+      - if: github.event.deployment_status.state == 'success'
+        uses: treosh/lighthouse-ci-action@v3
         with:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com


### PR DESCRIPTION
This reworks the Lighthouse CI Actions workflow to run only on successful deployments via the [`deployment_status` event](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#deployment_status) rather than on every `push`, obviating the need for wait-for-deployment-action.

Also underway for sf.gov in https://github.com/SFDigitalServices/sfgov/pull/660, and for DAHLIA in https://github.com/SFDigitalServices/sf-dahlia-web/pull/1412.