### PR TITLE
Release 6.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "form.io templates for the SF Design System",
   "module": "src/index.js",
   "browser": "dist/formio-sfds.standalone.js",

--- a/src/scss/forms/_buttons.scss
+++ b/src/scss/forms/_buttons.scss
@@ -6,6 +6,9 @@
   border-radius: radius(1);
   padding: spacer(1) spacer(2);
   margin: 0;
+  font-family: "Rubik", sans-serif;
+  font-size: 1rem;
+  line-height: 1.75;
 
   &:hover {
     background: $dark-blue;

--- a/src/templates/label/form.ejs
+++ b/src/templates/label/form.ejs
@@ -1,4 +1,4 @@
-{% if (!ctx.component.hideLabel && ['checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
+{% if (!ctx.component.hideLabel && ['button', 'checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
   <label
     class="{{ ctx.label.className }}"
     for="{{ ctx.inputId() }}">


### PR DESCRIPTION
This patch release includes some display fixes:

- [x] #99 Hide labels for button components (via `git cherry-pick` 163656d f2d24a0)
- [x] #104 Standardize button styles on sf.gov