### PR TITLE
Fix flatpickr tabindex="1"

### DIFF
--- a/src/examples.yml
+++ b/src/examples.yml
@@ -137,7 +137,7 @@
         title: Intro page
         components:
           - type: htmlelement
-            tag: h3
+            tag: h2
             content: Hello, world!
       - type: panel
         title: Basics page

--- a/src/patch.js
+++ b/src/patch.js
@@ -46,6 +46,7 @@ export default Formio => {
   patchDateTimeSuffix()
   patchDayLabels()
   patchDateTimeLabels()
+  patchFlatpickrTabIndex()
   patchDateTimeLocale(Formio)
 
   // this goes last so that if it fails it doesn't break everything else
@@ -291,6 +292,14 @@ function patchDateTimeLocale (Formio) {
 
   observe('.flatpickr-calendar', {
     add: disableGoogleTranslate
+  })
+}
+
+function patchFlatpickrTabIndex () {
+  observe('.flatpickr-input[tabindex=1]', {
+    add (el) {
+      el.tabIndex = 0
+    }
   })
 }
 

--- a/src/patch.js
+++ b/src/patch.js
@@ -298,7 +298,7 @@ function patchDateTimeLocale (Formio) {
 function patchFlatpickrTabIndex () {
   observe('.flatpickr-input[tabindex=1]', {
     add (el) {
-      el.tabIndex = 0
+      el.setAttribute('tabindex', 0)
     }
   })
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -296,7 +296,7 @@ function patchDateTimeLocale (Formio) {
 }
 
 function patchFlatpickrTabIndex () {
-  observe('.flatpickr-input[tabindex=1]', {
+  observe('.flatpickr-input[tabindex="1"]', {
     add (el) {
       el.setAttribute('tabindex', 0)
     }


### PR DESCRIPTION
This is an attempt to defeat flatpickr's explicit setting of `tabindex="1"` on the date/time text inputs.

https://github.com/flatpickr/flatpickr/blob/49a73d6f4c447fe69aace447696b91be7b1e37d4/src/index.ts#L2619