### PR TITLE
Nix blue background, improve vertical form spacing

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -53,10 +53,6 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                      class="messages"
                 >
                 </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
               <div ref="component"
                    class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
@@ -79,10 +75,6 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                            ref="input"
                     >
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
                 <div ref="messageContainer"
                      class="messages"
@@ -111,10 +103,6 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                            ref="input"
                     >
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
                 <div ref="messageContainer"
                      class="messages"
@@ -156,10 +144,6 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                            class="messages"
                       >
                       </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
                     </div>
                   </div>
                   <div ref="column-address-basic-6"
@@ -192,16 +176,8 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                            class="messages"
                       >
                       </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
                 <div ref="messageContainer"
                      class="messages"
@@ -215,15 +191,7 @@ exports[`component snapshots component "address" scenario: basic matches the sna
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -286,10 +254,6 @@ exports[`component snapshots component "address" scenario: required matches the 
                      class="messages"
                 >
                 </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
               <div ref="component"
                    class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
@@ -312,10 +276,6 @@ exports[`component snapshots component "address" scenario: required matches the 
                            ref="input"
                     >
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
                 <div ref="messageContainer"
                      class="messages"
@@ -344,10 +304,6 @@ exports[`component snapshots component "address" scenario: required matches the 
                            ref="input"
                     >
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
                 <div ref="messageContainer"
                      class="messages"
@@ -389,10 +345,6 @@ exports[`component snapshots component "address" scenario: required matches the 
                            class="messages"
                       >
                       </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
                     </div>
                   </div>
                   <div ref="column-address-required-6"
@@ -425,16 +377,8 @@ exports[`component snapshots component "address" scenario: required matches the 
                            class="messages"
                       >
                       </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
                 <div ref="messageContainer"
                      class="messages"
@@ -448,15 +392,7 @@ exports[`component snapshots component "address" scenario: required matches the 
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -498,15 +434,7 @@ exports[`component snapshots component "button" scenario: basic matches the snap
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -548,15 +476,7 @@ exports[`component snapshots component "button" scenario: required matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -608,15 +528,7 @@ exports[`component snapshots component "checkbox" scenario: basic matches the sn
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -668,15 +580,7 @@ exports[`component snapshots component "checkbox" scenario: required matches the
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -741,10 +645,6 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
           <div ref="column-columns-basic-2"
@@ -776,10 +676,6 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -787,15 +683,7 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -860,10 +748,6 @@ exports[`component snapshots component "columns" scenario: required matches the 
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
           <div ref="column-columns-required-2"
@@ -895,10 +779,6 @@ exports[`component snapshots component "columns" scenario: required matches the 
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -906,15 +786,7 @@ exports[`component snapshots component "columns" scenario: required matches the 
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -950,15 +822,7 @@ exports[`component snapshots component "container" scenario: basic matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -994,15 +858,7 @@ exports[`component snapshots component "container" scenario: required matches th
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1082,15 +938,7 @@ exports[`component snapshots component "datetime" scenario: basic matches the sn
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1172,15 +1020,7 @@ exports[`component snapshots component "datetime" scenario: required matches the
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1322,15 +1162,7 @@ exports[`component snapshots component "day" scenario: basic matches the snapsho
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1475,15 +1307,7 @@ exports[`component snapshots component "day" scenario: required matches the snap
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1524,10 +1348,6 @@ exports[`component snapshots component "html" scenario: basic matches the snapsh
          class="messages"
     >
     </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
-    </div>
   </div>
 </div>
 `;
@@ -1558,10 +1378,6 @@ exports[`component snapshots component "html" scenario: required matches the sna
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1614,15 +1430,7 @@ exports[`component snapshots component "number" scenario: basic matches the snap
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1676,15 +1484,7 @@ exports[`component snapshots component "number" scenario: required matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1751,10 +1551,6 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -1763,10 +1559,6 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1833,10 +1625,6 @@ exports[`component snapshots component "panel" scenario: required matches the sn
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -1845,10 +1633,6 @@ exports[`component snapshots component "panel" scenario: required matches the sn
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1934,15 +1718,7 @@ exports[`component snapshots component "radio" scenario: basic matches the snaps
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2028,15 +1804,7 @@ exports[`component snapshots component "radio" scenario: required matches the sn
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2124,15 +1892,7 @@ exports[`component snapshots component "selectboxes" scenario: basic matches the
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2220,15 +1980,7 @@ exports[`component snapshots component "selectboxes" scenario: required matches 
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2280,15 +2032,7 @@ exports[`component snapshots component "textfield" scenario: basic matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2341,15 +2085,7 @@ exports[`component snapshots component "textfield" scenario: required matches th
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"

--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -20,176 +20,210 @@ exports[`component snapshots component "address" scenario: basic matches the sna
            class="form-group has-feedback formio-component formio-component-address formio-component-address"
            id="address-basic-2"
       >
-        <label for="input-address-basic-2"
-               class
-        >
-          This is a address
-        </label>
-        <div ref="nested-address">
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
-               id="address-basic-3"
-          >
-            <label for="input-address-basic-3"
-                   class="field-required"
-            >
-              Address line 1
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[address][line1]"
-                       required
-                       id="input-address-basic-3"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
-               id="address-basic-4"
-          >
-            <label for="input-address-basic-4"
-                   class
-            >
-              Address line 2
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[address][line2]"
-                       id="input-address-basic-4"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
-               id="address-basic-5"
-          >
-            <label for="input-address-basic-5"
-                   class="field-required"
-            >
-              City
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value="San Francisco"
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[address][city]"
-                       required
-                       id="input-address-basic-5"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
-          <div ref="component"
-               class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
-               id="address-basic-6"
-          >
-            <label for="input-address-basic-6"
-                   class="control-label--hidden"
-            >
-              Columns
-            </label>
-            <div class="d-md-flex mr-md-n2">
-              <div ref="column-address-basic-6"
-                   class="col-md-6 mr-md-2"
+        <fieldset class="bg-blue-1 round-1">
+          <div class="p-2">
+            <legend class="f-3">
+              This is a address
+            </legend>
+            <div ref="nested-address">
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+                   id="address-basic-3"
               >
-                <div ref="component"
-                     class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
-                     id="address-basic-7"
+                <label for="input-address-basic-3"
+                       class="field-required"
                 >
-                  <label for="input-address-basic-7"
-                         class="field-required"
-                  >
-                    State
-                  </label>
-                  <select lang="en"
-                          class="form-control"
-                          type="text"
-                          name="data[address][state]"
-                          id="input-address-basic-7"
-                          required
-                          ref="selectContainer"
-                  >
-                  </select>
-                  <div ref="messageContainer"
-                       class="messages"
-                  >
+                  Address line 1
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line1]"
+                           required
+                           id="input-address-basic-3"
+                           ref="input"
+                    >
                   </div>
                 </div>
-              </div>
-              <div ref="column-address-basic-6"
-                   class="col-md-6 mr-md-2"
-              >
-                <div ref="component"
-                     class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
-                     id="address-basic-8"
+                <div ref="messageContainer"
+                     class="messages"
                 >
-                  <label for="input-address-basic-8"
-                         class="field-required"
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+                   id="address-basic-4"
+              >
+                <label for="input-address-basic-4"
+                       class
+                >
+                  Address line 2
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line2]"
+                           id="input-address-basic-4"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+                   id="address-basic-5"
+              >
+                <label for="input-address-basic-5"
+                       class="field-required"
+                >
+                  City
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value="San Francisco"
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][city]"
+                           required
+                           id="input-address-basic-5"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+                   id="address-basic-6"
+              >
+                <label for="input-address-basic-6"
+                       class="control-label--hidden"
+                >
+                  Columns
+                </label>
+                <div class="d-md-flex mr-md-n2">
+                  <div ref="column-address-basic-6"
+                       class="col-md-6 mr-md-2"
                   >
-                    ZIP code
-                  </label>
-                  <div ref="element">
-                    <div class="form-input">
-                      <input value
-                             spellcheck="true"
-                             lang="en"
-                             class="form-control"
-                             type="text"
-                             name="data[address][zip]"
-                             required
-                             id="input-address-basic-8"
-                             ref="input"
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
+                         id="address-basic-7"
+                    >
+                      <label for="input-address-basic-7"
+                             class="field-required"
                       >
+                        State
+                      </label>
+                      <select lang="en"
+                              class="form-control"
+                              type="text"
+                              name="data[address][state]"
+                              id="input-address-basic-7"
+                              required
+                              ref="selectContainer"
+                      >
+                      </select>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
                     </div>
                   </div>
-                  <div ref="messageContainer"
-                       class="messages"
+                  <div ref="column-address-basic-6"
+                       class="col-md-6 mr-md-2"
                   >
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
+                         id="address-basic-8"
+                    >
+                      <label for="input-address-basic-8"
+                             class="field-required"
+                      >
+                        ZIP code
+                      </label>
+                      <div ref="element">
+                        <div class="form-input">
+                          <input value
+                                 spellcheck="true"
+                                 lang="en"
+                                 class="form-control"
+                                 type="text"
+                                 name="data[address][zip]"
+                                 required
+                                 id="input-address-basic-8"
+                                 ref="input"
+                          >
+                        </div>
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                    </div>
                   </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
                 </div>
               </div>
             </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
           </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -219,176 +253,210 @@ exports[`component snapshots component "address" scenario: required matches the 
            class="form-group has-feedback formio-component formio-component-address formio-component-address  required"
            id="address-required-2"
       >
-        <label for="input-address-required-2"
-               class="field-required"
-        >
-          This is a address
-        </label>
-        <div ref="nested-address">
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
-               id="address-required-3"
-          >
-            <label for="input-address-required-3"
-                   class="field-required"
-            >
-              Address line 1
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[address][line1]"
-                       required
-                       id="input-address-required-3"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
-               id="address-required-4"
-          >
-            <label for="input-address-required-4"
-                   class
-            >
-              Address line 2
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[address][line2]"
-                       id="input-address-required-4"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
-               id="address-required-5"
-          >
-            <label for="input-address-required-5"
-                   class="field-required"
-            >
-              City
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value="San Francisco"
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[address][city]"
-                       required
-                       id="input-address-required-5"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
-          <div ref="component"
-               class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
-               id="address-required-6"
-          >
-            <label for="input-address-required-6"
-                   class="control-label--hidden"
-            >
-              Columns
-            </label>
-            <div class="d-md-flex mr-md-n2">
-              <div ref="column-address-required-6"
-                   class="col-md-6 mr-md-2"
+        <fieldset class="bg-blue-1 round-1">
+          <div class="p-2">
+            <legend class="f-3">
+              This is a address
+            </legend>
+            <div ref="nested-address">
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+                   id="address-required-3"
               >
-                <div ref="component"
-                     class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
-                     id="address-required-7"
+                <label for="input-address-required-3"
+                       class="field-required"
                 >
-                  <label for="input-address-required-7"
-                         class="field-required"
-                  >
-                    State
-                  </label>
-                  <select lang="en"
-                          class="form-control"
-                          type="text"
-                          name="data[address][state]"
-                          id="input-address-required-7"
-                          required
-                          ref="selectContainer"
-                  >
-                  </select>
-                  <div ref="messageContainer"
-                       class="messages"
-                  >
+                  Address line 1
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line1]"
+                           required
+                           id="input-address-required-3"
+                           ref="input"
+                    >
                   </div>
                 </div>
-              </div>
-              <div ref="column-address-required-6"
-                   class="col-md-6 mr-md-2"
-              >
-                <div ref="component"
-                     class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
-                     id="address-required-8"
+                <div ref="messageContainer"
+                     class="messages"
                 >
-                  <label for="input-address-required-8"
-                         class="field-required"
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+                   id="address-required-4"
+              >
+                <label for="input-address-required-4"
+                       class
+                >
+                  Address line 2
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line2]"
+                           id="input-address-required-4"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+                   id="address-required-5"
+              >
+                <label for="input-address-required-5"
+                       class="field-required"
+                >
+                  City
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value="San Francisco"
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][city]"
+                           required
+                           id="input-address-required-5"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+                   id="address-required-6"
+              >
+                <label for="input-address-required-6"
+                       class="control-label--hidden"
+                >
+                  Columns
+                </label>
+                <div class="d-md-flex mr-md-n2">
+                  <div ref="column-address-required-6"
+                       class="col-md-6 mr-md-2"
                   >
-                    ZIP code
-                  </label>
-                  <div ref="element">
-                    <div class="form-input">
-                      <input value
-                             spellcheck="true"
-                             lang="en"
-                             class="form-control"
-                             type="text"
-                             name="data[address][zip]"
-                             required
-                             id="input-address-required-8"
-                             ref="input"
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
+                         id="address-required-7"
+                    >
+                      <label for="input-address-required-7"
+                             class="field-required"
                       >
+                        State
+                      </label>
+                      <select lang="en"
+                              class="form-control"
+                              type="text"
+                              name="data[address][state]"
+                              id="input-address-required-7"
+                              required
+                              ref="selectContainer"
+                      >
+                      </select>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
                     </div>
                   </div>
-                  <div ref="messageContainer"
-                       class="messages"
+                  <div ref="column-address-required-6"
+                       class="col-md-6 mr-md-2"
                   >
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
+                         id="address-required-8"
+                    >
+                      <label for="input-address-required-8"
+                             class="field-required"
+                      >
+                        ZIP code
+                      </label>
+                      <div ref="element">
+                        <div class="form-input">
+                          <input value
+                                 spellcheck="true"
+                                 lang="en"
+                                 class="form-control"
+                                 type="text"
+                                 name="data[address][zip]"
+                                 required
+                                 id="input-address-required-8"
+                                 ref="input"
+                          >
+                        </div>
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                    </div>
                   </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
                 </div>
               </div>
             </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
           </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -430,7 +498,15 @@ exports[`component snapshots component "button" scenario: basic matches the snap
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -472,7 +548,15 @@ exports[`component snapshots component "button" scenario: required matches the s
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -524,7 +608,15 @@ exports[`component snapshots component "checkbox" scenario: basic matches the sn
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -576,7 +668,15 @@ exports[`component snapshots component "checkbox" scenario: required matches the
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -641,6 +741,10 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
                    class="messages"
               >
               </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
             </div>
           </div>
           <div ref="column-columns-basic-2"
@@ -672,6 +776,10 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
                    class="messages"
               >
               </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -679,7 +787,15 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -744,6 +860,10 @@ exports[`component snapshots component "columns" scenario: required matches the 
                    class="messages"
               >
               </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
             </div>
           </div>
           <div ref="column-columns-required-2"
@@ -775,6 +895,10 @@ exports[`component snapshots component "columns" scenario: required matches the 
                    class="messages"
               >
               </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -782,7 +906,15 @@ exports[`component snapshots component "columns" scenario: required matches the 
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -818,7 +950,15 @@ exports[`component snapshots component "container" scenario: basic matches the s
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -854,7 +994,15 @@ exports[`component snapshots component "container" scenario: required matches th
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -934,7 +1082,15 @@ exports[`component snapshots component "datetime" scenario: basic matches the sn
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1016,7 +1172,15 @@ exports[`component snapshots component "datetime" scenario: required matches the
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1158,7 +1322,15 @@ exports[`component snapshots component "day" scenario: basic matches the snapsho
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1303,7 +1475,15 @@ exports[`component snapshots component "day" scenario: required matches the snap
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1344,6 +1524,10 @@ exports[`component snapshots component "html" scenario: basic matches the snapsh
          class="messages"
     >
     </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
   </div>
 </div>
 `;
@@ -1374,6 +1558,10 @@ exports[`component snapshots component "html" scenario: required matches the sna
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1426,7 +1614,15 @@ exports[`component snapshots component "number" scenario: basic matches the snap
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1480,7 +1676,15 @@ exports[`component snapshots component "number" scenario: required matches the s
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1547,6 +1751,10 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
                    class="messages"
               >
               </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -1555,6 +1763,10 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1621,6 +1833,10 @@ exports[`component snapshots component "panel" scenario: required matches the sn
                    class="messages"
               >
               </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
             </div>
           </div>
         </div>
@@ -1629,6 +1845,10 @@ exports[`component snapshots component "panel" scenario: required matches the sn
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1658,67 +1878,71 @@ exports[`component snapshots component "radio" scenario: basic matches the snaps
            class="form-group has-feedback formio-component formio-component-radio formio-component-radio"
            id="radio-basic-2"
       >
-        <div class="form-group mt-2">
-          <fieldset>
-            <legend>
-              This is a radio
-            </legend>
-            <div class="field-wrapper bg-blue-1 round-1">
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="radio-basic-2-1"
-                         value="1"
-                         lang="en"
-                         type="radio"
-                         name="data[radio][radio-basic-2]"
-                         ref="input"
-                         class="input-radio position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  One
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="radio-basic-2-2"
-                         value="2"
-                         lang="en"
-                         type="radio"
-                         name="data[radio][radio-basic-2]"
-                         ref="input"
-                         class="input-radio position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  Two
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="radio-basic-2-3"
-                         value="3"
-                         lang="en"
-                         type="radio"
-                         name="data[radio][radio-basic-2]"
-                         ref="input"
-                         class="input-radio position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  Three
-                </span>
-              </label>
+        <fieldset class>
+          <legend class="f-3">
+            This is a radio
+          </legend>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-basic-2-1"
+                     value="1"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-basic-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
             </div>
-            <div class="help-block with-errors">
+            <span class="flex-auto">
+              One
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-basic-2-2"
+                     value="2"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-basic-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
             </div>
-          </fieldset>
+            <span class="flex-auto">
+              Two
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-basic-2-3"
+                     value="3"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-basic-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              Three
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1748,67 +1972,71 @@ exports[`component snapshots component "radio" scenario: required matches the sn
            class="form-group has-feedback formio-component formio-component-radio formio-component-radio  required"
            id="radio-required-2"
       >
-        <div class="form-group mt-2">
-          <fieldset>
-            <legend>
-              This is a radio
-            </legend>
-            <div class="field-wrapper bg-blue-1 round-1">
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="radio-required-2-1"
-                         value="1"
-                         lang="en"
-                         type="radio"
-                         name="data[radio][radio-required-2]"
-                         ref="input"
-                         class="input-radio position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  One
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="radio-required-2-2"
-                         value="2"
-                         lang="en"
-                         type="radio"
-                         name="data[radio][radio-required-2]"
-                         ref="input"
-                         class="input-radio position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  Two
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="radio-required-2-3"
-                         value="3"
-                         lang="en"
-                         type="radio"
-                         name="data[radio][radio-required-2]"
-                         ref="input"
-                         class="input-radio position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  Three
-                </span>
-              </label>
+        <fieldset class>
+          <legend class="f-3  field-required">
+            This is a radio
+          </legend>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-required-2-1"
+                     value="1"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-required-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
             </div>
-            <div class="help-block with-errors">
+            <span class="flex-auto">
+              One
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-required-2-2"
+                     value="2"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-required-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
             </div>
-          </fieldset>
+            <span class="flex-auto">
+              Two
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-required-2-3"
+                     value="3"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-required-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              Three
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1843,64 +2071,68 @@ exports[`component snapshots component "selectboxes" scenario: basic matches the
         >
           This is a selectboxes
         </label>
-        <div class="form-group mt-2">
-          <fieldset>
-            <div class="field-wrapper bg-blue-1 round-1">
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="selectboxes-basic-2-a"
-                         value="a"
-                         lang="en"
-                         type="checkbox"
-                         name="data[selectBoxes][]"
-                         ref="input"
-                         class="input-checkbox position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  A
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="selectboxes-basic-2-b"
-                         value="b"
-                         lang="en"
-                         type="checkbox"
-                         name="data[selectBoxes][]"
-                         ref="input"
-                         class="input-checkbox position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  B
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="selectboxes-basic-2-c"
-                         value="c"
-                         lang="en"
-                         type="checkbox"
-                         name="data[selectBoxes][]"
-                         ref="input"
-                         class="input-checkbox position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  C
-                </span>
-              </label>
+        <fieldset class>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-basic-2-a"
+                     value="a"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
             </div>
-            <div class="help-block with-errors">
+            <span class="flex-auto">
+              A
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-basic-2-b"
+                     value="b"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
             </div>
-          </fieldset>
+            <span class="flex-auto">
+              B
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-basic-2-c"
+                     value="c"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              C
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1935,64 +2167,68 @@ exports[`component snapshots component "selectboxes" scenario: required matches 
         >
           This is a selectboxes
         </label>
-        <div class="form-group mt-2">
-          <fieldset>
-            <div class="field-wrapper bg-blue-1 round-1">
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="selectboxes-required-2-a"
-                         value="a"
-                         lang="en"
-                         type="checkbox"
-                         name="data[selectBoxes][]"
-                         ref="input"
-                         class="input-checkbox position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  A
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="selectboxes-required-2-b"
-                         value="b"
-                         lang="en"
-                         type="checkbox"
-                         name="data[selectBoxes][]"
-                         ref="input"
-                         class="input-checkbox position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  B
-                </span>
-              </label>
-              <label class="d-flex flex-items-center fs-inherit my-2">
-                <div class="flex-shrink-0">
-                  <input id="selectboxes-required-2-c"
-                         value="c"
-                         lang="en"
-                         type="checkbox"
-                         name="data[selectBoxes][]"
-                         ref="input"
-                         class="input-checkbox position-relative d-block mr-2 mb-0"
-                  >
-                </div>
-                <span class="flex-auto">
-                  C
-                </span>
-              </label>
+        <fieldset class>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-required-2-a"
+                     value="a"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
             </div>
-            <div class="help-block with-errors">
+            <span class="flex-auto">
+              A
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-required-2-b"
+                     value="b"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
             </div>
-          </fieldset>
+            <span class="flex-auto">
+              B
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-required-2-c"
+                     value="c"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              C
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2044,7 +2280,15 @@ exports[`component snapshots component "textfield" scenario: basic matches the s
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2097,7 +2341,15 @@ exports[`component snapshots component "textfield" scenario: required matches th
              class="messages"
         >
         </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
       </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
     </div>
     <div ref="messageContainer"
          class="messages"

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -1,5 +1,28 @@
 const { container: Container } = window.Formio.Components.components
 
+export default class AddressComponent extends Container {
+  static schema (...extend) {
+    return Container.schema(defaultSchema, ...extend)
+  }
+
+  get defaultSchema () {
+    return defaultSchema
+  }
+
+  get templateName () {
+    return 'address'
+  }
+
+  static get builderInfo () {
+    return {
+      title: 'Address',
+      icon: 'home',
+      group: 'sfgov',
+      schema: defaultSchema
+    }
+  }
+}
+
 const defaultSchema = {
   label: 'Address',
   hideLabel: false,
@@ -63,23 +86,4 @@ const defaultSchema = {
       ]
     }
   ]
-}
-
-export default class AddressComponent extends Container {
-  static schema (...extend) {
-    return Container.schema(defaultSchema, ...extend)
-  }
-
-  get defaultSchema () {
-    return defaultSchema
-  }
-
-  static get builderInfo () {
-    return {
-      title: 'Address',
-      icon: 'home',
-      group: 'sfgov',
-      schema: defaultSchema
-    }
-  }
 }

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -260,14 +260,19 @@
     components:
       - type: textfield
         label: A text field
+        description: The description
       - type: number
         label: A number field
+        description: The description
       - type: textarea
         label: A text area field
+        description: The description
       - type: checkbox
         label: A checkbox
+        description: The description
       - type: select
         label: Select field
+        description: The description
         data:
           values:
             - label: Option 1
@@ -276,6 +281,7 @@
               value: 2
       - type: selectboxes
         label: Select boxes
+        description: The description
         values:
           - label: Select box 1
             value: 1
@@ -284,6 +290,7 @@
           - label: Select box 3
             value: 3
       - type: radio
+        description: The description
         values:
           - label: Radio 1
             value: 1
@@ -293,15 +300,23 @@
             value: 3
       - type: button
         label: This is a button
+        description: The description
       - type: email
         label: Email field
-      - type: phonenumber
+        description: The description
+      - type: phoneNumber
         label: Phone number field
+        description: The description
       - type: address
         label: Address field
+        description: The description
       - type: datetime
         label: Datetime field
+        description: The description
       - type: currency
         label: Currency field
+        description: The description
       - type: file
         label: File field
+        description: The description
+        storage: base64

--- a/src/patch.js
+++ b/src/patch.js
@@ -24,15 +24,14 @@ const defaultEvalContext = {
     return parts.join('-')
   },
 
-  tk (field, defaultValue) {
+  tk (field, defaultValue = '') {
     const { component = {} } = this
     const { type, key = type } = component
-    const fallback = defaultValue || component[field]
     return key ? this.t([
       `${key}.${field}`,
       `${key}_${field}`,
-      fallback || ''
-    ]) : fallback
+      component[field] || ''
+    ]) : defaultValue
   },
 
   requiredAttributes () {

--- a/src/patch.js
+++ b/src/patch.js
@@ -25,13 +25,14 @@ const defaultEvalContext = {
   },
 
   tk (field, defaultValue) {
-    const { component } = this
-    const { key } = component
-    return this.t([
+    const { component = {} } = this
+    const { type, key = type } = component
+    const fallback = defaultValue || component[field]
+    return key ? this.t([
       `${key}.${field}`,
       `${key}_${field}`,
-      defaultValue || component[field]
-    ])
+      fallback || ''
+    ]) : fallback
   },
 
   requiredAttributes () {

--- a/src/patch.js
+++ b/src/patch.js
@@ -24,6 +24,16 @@ const defaultEvalContext = {
     return parts.join('-')
   },
 
+  tk (field, defaultValue) {
+    const { component } = this
+    const { key } = component
+    return this.t([
+      `${key}.${field}`,
+      `${key}_${field}`,
+      defaultValue || component[field]
+    ])
+  },
+
   requiredAttributes () {
     return this.component?.validate?.required ? 'required' : ''
   }

--- a/src/scss/forms/_buttons.scss
+++ b/src/scss/forms/_buttons.scss
@@ -12,6 +12,7 @@
 
   &:hover {
     background: $dark-blue;
+    border-bottom: 0 !important;
   }
 }
 

--- a/src/scss/forms/_buttons.scss
+++ b/src/scss/forms/_buttons.scss
@@ -12,7 +12,6 @@
 
   &:hover {
     background: $dark-blue;
-    border-bottom: 0 !important;
   }
 }
 
@@ -50,6 +49,10 @@
 button[ref=removeLink] {
   position: relative;
   z-index: 99;
+}
+
+button:hover:not(.btn-border) {
+  border-bottom: 0;
 }
 
 // FIXME this is a hack to work around sf.gov's CSS

--- a/src/scss/forms/_fieldsets.scss
+++ b/src/scss/forms/_fieldsets.scss
@@ -1,27 +1,21 @@
 fieldset {
-  .fieldset-body {
-    margin: 0 -15px 40px;
-    padding: 15px 15px 1px;
-    border-radius: radius(1);
+  border: 0;
+  margin: 0;
+  padding: 0.01em 0 0 0;
+  min-width: 0;
+
+  legend {
+    display: table;
+    padding: 0;
   }
 
   label {
     font-size: 16px;
-    line-height: 1;
-  }
-
-  .formio-component {
-    margin-bottom: 20px;
-
-    &.row {
-      margin-bottom: 0;
-    }
   }
 }
 
 .formio-component-radio {
   fieldset label {
-    letter-spacing: 0;
     line-height: 24px;
   }
 }

--- a/src/scss/forms/_hacks.scss
+++ b/src/scss/forms/_hacks.scss
@@ -3,6 +3,11 @@
   display: none;
 }
 
+label {
+  // this overrides sf.gov's letter-spacing: -0.016em
+  letter-spacing: 0;
+}
+
 input:disabled,
 select:disabled,
 textarea:disabled {

--- a/src/scss/forms/_inputs.scss
+++ b/src/scss/forms/_inputs.scss
@@ -112,14 +112,6 @@ input[type="radio"] {
   }
 }
 
-.formio-component-radio,
-.formio-component-selectboxes {
-  .field-wrapper {
-    margin: 0 -15px 10px;
-    padding: 1px 15px 1px;
-  }
-}
-
 .formio-component-signature {
   border: solid $grey-2 border-width(1);
 }

--- a/src/scss/forms/index.scss
+++ b/src/scss/forms/index.scss
@@ -21,6 +21,7 @@
   }
 
   input:not([type="button"]),
+  select,
   textarea {
     border-color: $red-3 !important;
   }

--- a/src/templates/address/form.ejs
+++ b/src/templates/address/form.ejs
@@ -6,7 +6,7 @@
 
     {% const desc = ctx.tk('description') %}
     {% if (desc) { %}
-      <div class="fg-light-slate mb-2">{{ desc }}</div>
+      <div class="f-2 mb-2">{{ desc }}</div>
     {% } %}
 
     <div ref="{{ ctx.nestedKey }}">

--- a/src/templates/address/form.ejs
+++ b/src/templates/address/form.ejs
@@ -1,9 +1,16 @@
-<div class="formio-component formio-component-address round-1 bg-blue-1 p-2">
-  {% var desc = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
-  {% if (desc) { %}
-    <p class="description mt-0 mb-1">{{ desc }}</p>
-  {% } %}
-  <div ref="{{ ctx.nestedKey }}">
-    {{ ctx.children }}
+<fieldset class="bg-blue-1 round-1">
+  <div class="p-2">
+    <legend class="f-3">
+      {{ ctx.tk('label') }}
+    </legend>
+
+    {% const desc = ctx.tk('description') %}
+    {% if (desc) { %}
+      <div class="fg-light-slate mb-2">{{ desc }}</div>
+    {% } %}
+
+    <div ref="{{ ctx.nestedKey }}">
+      {{ ctx.children }}
+    </div>
   </div>
-</div>
+</fieldset>

--- a/src/templates/checkbox/form.ejs
+++ b/src/templates/checkbox/form.ejs
@@ -15,9 +15,9 @@
       <span class="label-required">
         {{ ctx.t([`${ctx.component.key}_label`, ctx.input.label]) }}
       </span>
-      {% var description = ctx.t([`${ctx.component.key}_description`, ctx.component.tooltip]) %}
+      {% const description = ctx.tk('description') %}
       {% if (description) { %}
-        <div class="field-description small mt-1">{{ description }}</div>
+        <div class="fg-light-slate">{{ description }}</div>
       {% } %}
     </div>
   </label>

--- a/src/templates/checkbox/form.ejs
+++ b/src/templates/checkbox/form.ejs
@@ -8,16 +8,18 @@
           {{attr}}="{{ctx.input.attr[attr]}}"
         {% } %}
         value="{{ ctx.value }}"
-        {% if (ctx.checked) { %}checked{% } %}
+        {% if (ctx.checked) { %}
+          checked
+        {% } %}
       >
     </div>
     <div class="flex-auto">
       <span class="label-required">
-        {{ ctx.t([`${ctx.component.key}_label`, ctx.input.label]) }}
+        {{ ctx.tk('label') }}
       </span>
-      {% const description = ctx.tk('description') %}
-      {% if (description) { %}
-        <div class="fg-light-slate">{{ description }}</div>
+      {% const desc = ctx.tk('description') %}
+      {% if (desc) { %}
+        <div class="fg-light-slate">{{ desc }}</div>
       {% } %}
     </div>
   </label>

--- a/src/templates/field/form.ejs
+++ b/src/templates/field/form.ejs
@@ -2,6 +2,8 @@
 
 {{ ctx.element }}
 
+<div class="messages" ref="messageContainer"></div>
+
 {% if (['address', 'checkbox', 'radio', 'review', 'selectboxes', 'well'].indexOf(ctx.component.type) === -1) { %}
   {% const description = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
   {% if (description) { %}

--- a/src/templates/field/form.ejs
+++ b/src/templates/field/form.ejs
@@ -2,18 +2,11 @@
 
 {{ ctx.element }}
 
-{% if (['address', 'review', 'checkbox', 'well'].indexOf(ctx.component.type) === -1) { %}
-  {% var description = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
+{% if (['address', 'checkbox', 'radio', 'review', 'selectboxes', 'well'].indexOf(ctx.component.type) === -1) { %}
+  {% const description = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
   {% if (description) { %}
-    <div class="field-description">
+    <div class="fg-light-slate mt-1">
       {{ description }}
     </div>
   {% } %}
-
-  <!--
-  {% var tooltip = ctx.t([`${ctx.component.key}_tooltip`, ctx.component.tooltip]) %}
-  {% if (tooltip) { %}
-    <div class="tooltip">{{ tooltip }}</div>
-  {% } %}
-  -->
 {% } %}

--- a/src/templates/field/form.ejs
+++ b/src/templates/field/form.ejs
@@ -5,10 +5,10 @@
 <div class="messages" ref="messageContainer"></div>
 
 {% if (['address', 'checkbox', 'radio', 'review', 'selectboxes', 'well'].indexOf(ctx.component.type) === -1) { %}
-  {% const description = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
-  {% if (description) { %}
+  {% const desc = ctx.tk('description') %}
+  {% if (desc) { %}
     <div class="fg-light-slate mt-1">
-      {{ description }}
+      {{ desc }}
     </div>
   {% } %}
 {% } %}

--- a/src/templates/field/form.ejs
+++ b/src/templates/field/form.ejs
@@ -2,8 +2,6 @@
 
 {{ ctx.element }}
 
-<div class="messages" ref="messageContainer"></div>
-
 {% if (['address', 'checkbox', 'radio', 'review', 'selectboxes', 'well'].indexOf(ctx.component.type) === -1) { %}
   {% const desc = ctx.tk('description') %}
   {% if (desc) { %}

--- a/src/templates/fieldset/form.ejs
+++ b/src/templates/fieldset/form.ejs
@@ -1,15 +1,16 @@
-<fieldset>
-  {% if (ctx.component.legend) { %}
-  <legend ref="header" class="{{ctx.component.collapsible ? 'formio-clickable' : ''}}">
-    {{ ctx.t(ctx.component.legend) }}
-    {% if (ctx.component.tooltip) { %}
-    <i ref="tooltip" class="{{ctx.iconClass('question-sign')}} text-muted"></i>
+<fieldset class="bg-blue-1 round-1">
+  <div class="p-2">
+    <legend class="f-3" ref="header">
+      {{ ctx.tk('legend') }}
+    </legend>
+
+    {% const desc = ctx.tk('description') %}
+    {% if (desc) { %}
+      <div class="fg-light-slate mb-1">{{ desc }}</div>
     {% } %}
-  </legend>
-  {% } %}
-  {% if (!ctx.collapsed) { %}
-  <div class="bg-blue-1 fieldset-body" ref="{{ctx.nestedKey}}">
-    {{ctx.children}}
+
+    <div ref="{{ctx.nestedKey}}">
+      {{ctx.children}}
+    </div>
   </div>
-  {% } %}
 </fieldset>

--- a/src/templates/fieldset/form.ejs
+++ b/src/templates/fieldset/form.ejs
@@ -6,7 +6,7 @@
 
     {% const desc = ctx.tk('description') %}
     {% if (desc) { %}
-      <div class="fg-light-slate mb-1">{{ desc }}</div>
+      <div class="f-2 fg-light-slate mb-1">{{ desc }}</div>
     {% } %}
 
     <div ref="{{ctx.nestedKey}}">

--- a/src/templates/file/form.ejs
+++ b/src/templates/file/form.ejs
@@ -5,14 +5,12 @@
   <button class="btn btn-primary" ref="cameraButton"><i class="fa fa-camera"></i> {{ctx.t('Camera')}}</button>
 </div>
 {% } else if (!ctx.self.cameraMode) { %}
-<div class="my-1">
-  <div class="fileSelector" ref="fileDrop">
-    <div class="align-center">
-      {{ ctx.t('Drop files to attach, or') }}
-      <button class="ml-1 mr-0 mb-0 btn btn-border" ref="fileBrowse">
-        {{ ctx.t('Browse')}}
-      </button>
-    </div>
+<div class="fileSelector" ref="fileDrop">
+  <div class="align-center">
+    {{ ctx.t('Drop files to attach, or') }}
+    <button class="ml-1 mr-0 mb-0 btn btn-border" ref="fileBrowse">
+      {{ ctx.t('Browse')}}
+    </button>
   </div>
 </div>
 {% } else { %}

--- a/src/templates/html/form.ejs
+++ b/src/templates/html/form.ejs
@@ -2,4 +2,4 @@
   {% ctx.attrs.forEach(function(attr) { %}
     {{attr.attr}}="{{attr.value}}"
   {% }) %}
->{{ ctx.t([`${ctx.component.key}_content`, ctx.content]) }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}
+>{{ ctx.tk('content') }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}

--- a/src/templates/input/form.ejs
+++ b/src/templates/input/form.ejs
@@ -1,7 +1,7 @@
 {%
-  let prefix = ctx.prefix
+  let prefix = ctx.tk('prefix') || ctx.prefix
   if (prefix instanceof HTMLElement) prefix = prefix.outerHTML
-  let suffix = ctx.suffix
+  let suffix = ctx.tk('suffix') || ctx.suffix
   if (suffix instanceof HTMLElement) suffix = suffix.outerHTML
 %}
 {% if (prefix || suffix) { %}
@@ -11,7 +11,7 @@
 {% if (prefix) { %}
   <div class="input-group-prepend" ref="prefix">
     <span class="input-group-text">
-      {{ ctx.t([`${ctx.component.key}_prefix`, prefix]) }}
+      {{ prefix }}
     </span>
   </div>
 {% } %}
@@ -38,7 +38,7 @@
 {% if (suffix) { %}
   <div class="input-group-append" ref="suffix">
     <span class="input-group-text">
-      {{ ctx.t([`${ctx.component.key}_suffix`, suffix]) }}
+      {{ suffix }}
     </span>
   </div>
 {% } %}

--- a/src/templates/label/form.ejs
+++ b/src/templates/label/form.ejs
@@ -1,12 +1,5 @@
-{% if (!ctx.component.hideLabel && ['button', 'checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
-  <label
-    class="{{ ctx.label.className }}"
-    for="{{ ctx.inputId() }}">
-    {{ ctx.t([`${ctx.component.key}_label`, ctx.component.label]) }}
-    <!--
-    {% if (ctx.component.tooltip) { %}
-      <i ref="tooltip" class="{{ ctx.iconClass('question-sign') }} text-muted"></i>
-    {% } %}
-    -->
+{% if (!ctx.component.hideLabel && ['address', 'button', 'checkbox', 'radio'].indexOf(ctx.component.type) === -1) { %}
+  <label class="{{ ctx.label.className }}" for="{{ ctx.inputId() }}">
+    {{ ctx.tk('label') }}
   </label>
 {% } %}

--- a/src/templates/message/form.ejs
+++ b/src/templates/message/form.ejs
@@ -1,4 +1,4 @@
 <div class="message message-{{ ctx.level }} small my-1">
-  <span class="mr-1" data-icon="{{ ctx.level }}" data-height="15"></span>
+  <span class="d-inline-block v-align-middle mr-1" data-icon="{{ ctx.level }}" data-height="15"></span>
   {{ ctx.message }}
 </div>

--- a/src/templates/radio/form.ejs
+++ b/src/templates/radio/form.ejs
@@ -1,24 +1,28 @@
-<div class="form-group mt-2">
-  <fieldset>
-    {% if (!ctx.component.hideLabel && ctx.component.type !== 'selectboxes') { %}
-    <legend>{{ ctx.t(ctx.component.label) }}</legend>
-    {% } %}
-    <div class="field-wrapper bg-blue-1 round-1">
-      {% ctx.values.forEach(function(item) { %}
-      <label class="d-flex flex-items-center fs-inherit my-2">
-        <div class="flex-shrink-0">
-          <{{ctx.input.type}} class="input-{{ ctx.input.attr.type }} position-relative d-block mr-2 mb-0" ref="input"
-            {% for (var attr in ctx.input.attr) { %} {{attr}}="{{ctx.input.attr[attr]}}" {% } %} value="{{item.value}}"
-            {% if (ctx.value && (ctx.value === item.value || (typeof ctx.value === 'object' && ctx.value.hasOwnProperty(item.value) && ctx.value[item.value]))) { %}
-            checked=true {% } %} {% if (item.disabled) { %} disabled=true {% } %}
-            id="{{ctx.id}}{{ctx.row}}-{{item.value}}">
-        </div>
-        <span class="flex-auto">
-          {{ ctx.t(item.label) }}
-        </span>
-      </label>
-      {% }) %}
-    </div>
-    <div class="help-block with-errors"></div>
-  </fieldset>
-</div>
+<fieldset class="{{ ctx.className }}">
+  {% if (!ctx.component.hideLabel && ctx.component.type !== 'selectboxes') { %}
+    <legend class="f-3 {{ ctx.label.className }}">
+      {{ ctx.tk('label') }}
+    </legend>
+  {% } %}
+
+  {% const desc = ctx.tk('description') %}
+  {% if (desc) { %}
+    <div class="fg-light-slate mb-1">{{ desc }}</div>
+  {% } %}
+
+  {% for (const item of ctx.values) { %}
+    <label class="d-flex flex-items-center fs-inherit mt-2">
+      <div class="flex-shrink-0">
+        <{{ctx.input.type}} class="input-{{ ctx.input.attr.type }} position-relative d-block mr-2 mb-0" ref="input"
+          {% for (var attr in ctx.input.attr) { %} {{attr}}="{{ctx.input.attr[attr]}}" {% } %} value="{{item.value}}"
+          {% if (ctx.value && (ctx.value === item.value || (typeof ctx.value === 'object' && ctx.value.hasOwnProperty(item.value) && ctx.value[item.value]))) { %}
+          checked=true {% } %} {% if (item.disabled) { %} disabled=true {% } %}
+          id="{{ctx.id}}{{ctx.row}}-{{item.value}}">
+      </div>
+      <span class="flex-auto ">
+        {{ ctx.t(item.label) }}
+      </span>
+    </label>
+  {% } %}
+  <div class="help-block with-errors"></div>
+</fieldset>

--- a/src/templates/radio/form.ejs
+++ b/src/templates/radio/form.ejs
@@ -7,7 +7,7 @@
 
   {% const desc = ctx.tk('description') %}
   {% if (desc) { %}
-    <div class="fg-light-slate mb-1">{{ desc }}</div>
+    <div class="f-2 fg-light-slate mb-1">{{ desc }}</div>
   {% } %}
 
   {% for (const item of ctx.values) { %}

--- a/src/templates/well/form.ejs
+++ b/src/templates/well/form.ejs
@@ -1,6 +1,6 @@
-{% var visible = ctx.component.properties.visible !== "false" %}
-<div ref="{{ ctx.nestedKey }}" class="formio-component{% if (visible) { %} formio-component-well bg-blue-1 p-2 round-1{% } %}">
-  {% var desc = ctx.t([`${ctx.component.key}_description`, ctx.component.description]) %}
+{% const visible = ctx.component.properties.visible !== "false" %}
+<div ref="{{ ctx.nestedKey }}" class="{{ visible ? ' bg-blue-1 p-2 round-1' : '' }}">
+  {% const desc = ctx.tk('description') %}
   {% if (desc) { %}
     <p class="description mt-0 mb-1">{{ desc }}</p>
   {% } %}


### PR DESCRIPTION
This is an overhaul of our blue colored backgrounds on form groups signed off on by @nlsfds. I've also taken this opportunity to switch the `address`, `radio`, and `selectboxes` component templates over to use `<fieldset>` + `<legend>` elements, which should improve accessibility. Here are links to the affected component examples:

| Examppe | Before | After | Notes |
| :--- | :--- | :--- | :--- |
| Address | [before](https://formio-sfds.vercel.app/examples/address) | [after](https://formio-sfds-git-nix-blue-bg.sfds.vercel.app/examples/address) | All fields, along with the legend (label) and description, are in a blue box
| Checkbox | [before](https://formio-sfds.vercel.app/examples/checkbox) | [after](https://formio-sfds-git-nix-blue-bg.sfds.vercel.app/examples/checkbox) | More consistent description styling
| Radio | [before](https://formio-sfds.vercel.app/examples/radio) | [after](https://formio-sfds-git-nix-blue-bg.sfds.vercel.app/examples/radio) | No blue box, and improved vertical spacing, and description directly below the label
| Select boxes | [before](https://formio-sfds.vercel.app/examples/selectboxes) | [after](https://formio-sfds-git-nix-blue-bg.sfds.vercel.app/examples/selectboxes) | (Same as Radio, as it uses the same template)
| Kitchen sink | [before](https://formio-sfds.vercel.app/examples/kitchen-sink) | [after](https://formio-sfds-git-nix-blue-bg.sfds.vercel.app/examples/kitchen-sink) | Added descriptions to all examples to demonstrate vertical spacing updates
| File upload | [before](https://formio-sfds.vercel.app/examples/file) | [after](https://formio-sfds-git-nix-blue-bg.sfds.vercel.app/examples/file) | Less space between the label, drop zone, and description

I've also improved some styles for validation error states. Check out the address with errors before and after:

| Before | After |
| :--- | :--- |
| ![address with errors (before)](https://user-images.githubusercontent.com/113896/94605137-e016d300-0255-11eb-8038-1b5739b5c80b.png) | ![image](https://user-images.githubusercontent.com/113896/94605305-28ce8c00-0256-11eb-8dae-e7a864a52bf5.png)
