### PR TITLE
Add HTML snapshot tests

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -1,0 +1,2058 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`component snapshots component "address" scenario: basic matches the snapshot 1`] = `
+<div id="form-address-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="address-basic-1"
+  >
+    <label for="input-address-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-address formio-component-address"
+           id="address-basic-2"
+      >
+        <fieldset class="bg-blue-1 round-1">
+          <div class="p-2">
+            <legend class="f-3">
+              This is a address
+            </legend>
+            <div ref="nested-address">
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+                   id="address-basic-3"
+              >
+                <label for="input-address-basic-3"
+                       class="field-required"
+                >
+                  Address line 1
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line1]"
+                           required
+                           id="input-address-basic-3"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+                   id="address-basic-4"
+              >
+                <label for="input-address-basic-4"
+                       class
+                >
+                  Address line 2
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line2]"
+                           id="input-address-basic-4"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+                   id="address-basic-5"
+              >
+                <label for="input-address-basic-5"
+                       class="field-required"
+                >
+                  City
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value="San Francisco"
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][city]"
+                           required
+                           id="input-address-basic-5"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+                   id="address-basic-6"
+              >
+                <label for="input-address-basic-6"
+                       class="control-label--hidden"
+                >
+                  Columns
+                </label>
+                <div class="d-md-flex mr-md-n2">
+                  <div ref="column-address-basic-6"
+                       class="col-md-6 mr-md-2"
+                  >
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
+                         id="address-basic-7"
+                    >
+                      <label for="input-address-basic-7"
+                             class="field-required"
+                      >
+                        State
+                      </label>
+                      <select lang="en"
+                              class="form-control"
+                              type="text"
+                              name="data[address][state]"
+                              id="input-address-basic-7"
+                              required
+                              ref="selectContainer"
+                      >
+                      </select>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                    </div>
+                  </div>
+                  <div ref="column-address-basic-6"
+                       class="col-md-6 mr-md-2"
+                  >
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
+                         id="address-basic-8"
+                    >
+                      <label for="input-address-basic-8"
+                             class="field-required"
+                      >
+                        ZIP code
+                      </label>
+                      <div ref="element">
+                        <div class="form-input">
+                          <input value
+                                 spellcheck="true"
+                                 lang="en"
+                                 class="form-control"
+                                 type="text"
+                                 name="data[address][zip]"
+                                 required
+                                 id="input-address-basic-8"
+                                 ref="input"
+                          >
+                        </div>
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "address" scenario: required matches the snapshot 1`] = `
+<div id="form-address-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="address-required-1"
+  >
+    <label for="input-address-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-address formio-component-address  required"
+           id="address-required-2"
+      >
+        <fieldset class="bg-blue-1 round-1">
+          <div class="p-2">
+            <legend class="f-3">
+              This is a address
+            </legend>
+            <div ref="nested-address">
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+                   id="address-required-3"
+              >
+                <label for="input-address-required-3"
+                       class="field-required"
+                >
+                  Address line 1
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line1]"
+                           required
+                           id="input-address-required-3"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+                   id="address-required-4"
+              >
+                <label for="input-address-required-4"
+                       class
+                >
+                  Address line 2
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][line2]"
+                           id="input-address-required-4"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+                   id="address-required-5"
+              >
+                <label for="input-address-required-5"
+                       class="field-required"
+                >
+                  City
+                </label>
+                <div ref="element">
+                  <div class="form-input">
+                    <input value="San Francisco"
+                           spellcheck="true"
+                           lang="en"
+                           class="form-control"
+                           type="text"
+                           name="data[address][city]"
+                           required
+                           id="input-address-required-5"
+                           ref="input"
+                    >
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+              <div ref="component"
+                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+                   id="address-required-6"
+              >
+                <label for="input-address-required-6"
+                       class="control-label--hidden"
+                >
+                  Columns
+                </label>
+                <div class="d-md-flex mr-md-n2">
+                  <div ref="column-address-required-6"
+                       class="col-md-6 mr-md-2"
+                  >
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
+                         id="address-required-7"
+                    >
+                      <label for="input-address-required-7"
+                             class="field-required"
+                      >
+                        State
+                      </label>
+                      <select lang="en"
+                              class="form-control"
+                              type="text"
+                              name="data[address][state]"
+                              id="input-address-required-7"
+                              required
+                              ref="selectContainer"
+                      >
+                      </select>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                    </div>
+                  </div>
+                  <div ref="column-address-required-6"
+                       class="col-md-6 mr-md-2"
+                  >
+                    <div ref="component"
+                         class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
+                         id="address-required-8"
+                    >
+                      <label for="input-address-required-8"
+                             class="field-required"
+                      >
+                        ZIP code
+                      </label>
+                      <div ref="element">
+                        <div class="form-input">
+                          <input value
+                                 spellcheck="true"
+                                 lang="en"
+                                 class="form-control"
+                                 type="text"
+                                 name="data[address][zip]"
+                                 required
+                                 id="input-address-required-8"
+                                 ref="input"
+                          >
+                        </div>
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                      <div ref="messageContainer"
+                           class="messages"
+                      >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+                <div ref="messageContainer"
+                     class="messages"
+                >
+                </div>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "button" scenario: basic matches the snapshot 1`] = `
+<div id="form-button-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="button-basic-1"
+  >
+    <label for="input-button-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-button formio-component-submit  form-group"
+           id="button-basic-2"
+      >
+        <button lang="en"
+                type="submit"
+                name="data[submit]"
+                class="btn btn-primary"
+                ref="button"
+        >
+          This is a button
+        </button>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "button" scenario: required matches the snapshot 1`] = `
+<div id="form-button-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="button-required-1"
+  >
+    <label for="input-button-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-button formio-component-submit  required form-group"
+           id="button-required-2"
+      >
+        <button lang="en"
+                type="submit"
+                name="data[submit]"
+                class="btn btn-primary"
+                ref="button"
+        >
+          This is a button
+        </button>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "checkbox" scenario: basic matches the snapshot 1`] = `
+<div id="form-checkbox-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="checkbox-basic-1"
+  >
+    <label for="input-checkbox-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-checkbox formio-component-checkbox"
+           id="checkbox-basic-2"
+      >
+        <div class="form-checkbox">
+          <label class="d-flex flex-items-center fs-inherit fg-inherit">
+            <div class="flex-shrink-0 flex-self-start">
+              <input value="0"
+                     lang="en"
+                     type="checkbox"
+                     name="data[checkbox]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <div class="flex-auto">
+              <span class="label-required">
+                This is a checkbox
+              </span>
+            </div>
+          </label>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "checkbox" scenario: required matches the snapshot 1`] = `
+<div id="form-checkbox-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="checkbox-required-1"
+  >
+    <label for="input-checkbox-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-checkbox formio-component-checkbox  required"
+           id="checkbox-required-2"
+      >
+        <div class="form-checkbox">
+          <label class="d-flex flex-items-center fs-inherit fg-inherit">
+            <div class="flex-shrink-0 flex-self-start">
+              <input value="0"
+                     lang="en"
+                     type="checkbox"
+                     name="data[checkbox]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <div class="flex-auto">
+              <span class="label-required">
+                This is a checkbox
+              </span>
+            </div>
+          </label>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "columns" scenario: basic matches the snapshot 1`] = `
+<div id="form-columns-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="columns-basic-1"
+  >
+    <label for="input-columns-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="row formio-component formio-component-columns formio-component-columns  formio-component-label-hidden"
+           id="columns-basic-2"
+      >
+        <label for="input-columns-basic-2"
+               class="control-label--hidden"
+        >
+          This is a columns
+        </label>
+        <div class="d-md-flex mr-md-n2">
+          <div ref="column-columns-basic-2"
+               class="col-md-6 mr-md-2"
+          >
+          </div>
+          <div ref="column-columns-basic-2"
+               class="col-md-6 mr-md-2"
+          >
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "columns" scenario: required matches the snapshot 1`] = `
+<div id="form-columns-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="columns-required-1"
+  >
+    <label for="input-columns-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="row formio-component formio-component-columns formio-component-columns  formio-component-label-hidden"
+           id="columns-required-2"
+      >
+        <label for="input-columns-required-2"
+               class="control-label--hidden"
+        >
+          This is a columns
+        </label>
+        <div class="d-md-flex mr-md-n2">
+          <div ref="column-columns-required-2"
+               class="col-md-6 mr-md-2"
+          >
+          </div>
+          <div ref="column-columns-required-2"
+               class="col-md-6 mr-md-2"
+          >
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "container" scenario: basic matches the snapshot 1`] = `
+<div id="form-container-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="container-basic-1"
+  >
+    <label for="input-container-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-container formio-component-container  formio-component-label-hidden"
+           id="container-basic-2"
+      >
+        <div ref="nested-container">
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "container" scenario: required matches the snapshot 1`] = `
+<div id="form-container-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="container-required-1"
+  >
+    <label for="input-container-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-container formio-component-container  required formio-component-label-hidden"
+           id="container-required-2"
+      >
+        <div ref="nested-container">
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "day" scenario: basic matches the snapshot 1`] = `
+<div id="form-day-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="day-basic-1"
+  >
+    <label for="input-day-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-day formio-component-day"
+           id="day-basic-2"
+      >
+        <label for="input-day-basic-2"
+               class
+        >
+          This is a day
+        </label>
+        <div class="d-flex">
+          <div class="col-2 pr-1">
+            <label class="fg-slate-65"
+                   for="input-day-basic-2-month"
+            >
+              Month
+            </label>
+            <div>
+              <select lang="en"
+                      name="month"
+                      class="form-control"
+                      id="input-day-basic-2-month"
+                      ref="month"
+              >
+                <option value>
+                </option>
+                <option value="1">
+                  January
+                </option>
+                <option value="2">
+                  February
+                </option>
+                <option value="3">
+                  March
+                </option>
+                <option value="4">
+                  April
+                </option>
+                <option value="5">
+                  May
+                </option>
+                <option value="6">
+                  June
+                </option>
+                <option value="7">
+                  July
+                </option>
+                <option value="8">
+                  August
+                </option>
+                <option value="9">
+                  September
+                </option>
+                <option value="10">
+                  October
+                </option>
+                <option value="11">
+                  November
+                </option>
+                <option value="12">
+                  December
+                </option>
+              </select>
+            </div>
+          </div>
+          <div class="col-2 pr-1">
+            <label class="fg-slate-65"
+                   for="input-day-basic-2-day"
+            >
+              Day
+            </label>
+            <div>
+              <div class="form-input">
+                <input max="31"
+                       min="1"
+                       step="1"
+                       placeholder
+                       type="number"
+                       class="form-control formio-day-component-day"
+                       id="input-day-basic-2-day"
+                       ref="day"
+                >
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <label class="fg-slate-65"
+                   for="input-day-basic-2-year"
+            >
+              Year
+            </label>
+            <div>
+              <div class="form-input">
+                <input max="2030"
+                       min="1900"
+                       step="1"
+                       placeholder
+                       type="number"
+                       class="form-control formio-day-component-year"
+                       id="input-day-basic-2-year"
+                       ref="year"
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+        <input ref="input"
+               value
+               lang="en"
+               class="form-control"
+               type="hidden"
+               name="ctx.data[day]"
+        >
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "day" scenario: required matches the snapshot 1`] = `
+<div id="form-day-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="day-required-1"
+  >
+    <label for="input-day-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-day formio-component-day  required"
+           id="day-required-2"
+      >
+        <label for="input-day-required-2"
+               class="field-required"
+        >
+          This is a day
+        </label>
+        <div class="d-flex">
+          <div class="col-2 pr-1">
+            <label class="fg-slate-65"
+                   for="input-day-required-2-month"
+            >
+              Month
+            </label>
+            <div>
+              <select lang="en"
+                      name="month"
+                      class="form-control"
+                      id="input-day-required-2-month"
+                      required
+                      ref="month"
+              >
+                <option value>
+                </option>
+                <option value="1">
+                  January
+                </option>
+                <option value="2">
+                  February
+                </option>
+                <option value="3">
+                  March
+                </option>
+                <option value="4">
+                  April
+                </option>
+                <option value="5">
+                  May
+                </option>
+                <option value="6">
+                  June
+                </option>
+                <option value="7">
+                  July
+                </option>
+                <option value="8">
+                  August
+                </option>
+                <option value="9">
+                  September
+                </option>
+                <option value="10">
+                  October
+                </option>
+                <option value="11">
+                  November
+                </option>
+                <option value="12">
+                  December
+                </option>
+              </select>
+            </div>
+          </div>
+          <div class="col-2 pr-1">
+            <label class="fg-slate-65"
+                   for="input-day-required-2-day"
+            >
+              Day
+            </label>
+            <div>
+              <div class="form-input">
+                <input max="31"
+                       min="1"
+                       step="1"
+                       placeholder
+                       type="number"
+                       class="form-control formio-day-component-day"
+                       required
+                       id="input-day-required-2-day"
+                       ref="day"
+                >
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <label class="fg-slate-65"
+                   for="input-day-required-2-year"
+            >
+              Year
+            </label>
+            <div>
+              <div class="form-input">
+                <input max="2030"
+                       min="1900"
+                       step="1"
+                       placeholder
+                       type="number"
+                       class="form-control formio-day-component-year"
+                       required
+                       id="input-day-required-2-year"
+                       ref="year"
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+        <input ref="input"
+               value
+               lang="en"
+               class="form-control"
+               type="hidden"
+               name="ctx.data[day]"
+        >
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "html" scenario: basic matches the snapshot 1`] = `
+<div id="form-html-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="html-basic-1"
+  >
+    <label for="input-html-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-html"
+           id="html-basic-2"
+      >
+        Unknown component: html
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "html" scenario: required matches the snapshot 1`] = `
+<div id="form-html-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="html-required-1"
+  >
+    <label for="input-html-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-html  required"
+           id="html-required-2"
+      >
+        Unknown component: html
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "number" scenario: basic matches the snapshot 1`] = `
+<div id="form-number-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="number-basic-1"
+  >
+    <label for="input-number-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-number formio-component-number"
+           id="number-basic-2"
+      >
+        <label for="input-number-basic-2"
+               class
+        >
+          This is a number
+        </label>
+        <div ref="element">
+          <div class="form-input">
+            <input value
+                   inputmode="decimal"
+                   lang="en"
+                   class="form-control"
+                   type="text"
+                   name="data[number]"
+                   id="input-number-basic-2"
+                   ref="input"
+                   pattern="[0-9.]*"
+            >
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "number" scenario: required matches the snapshot 1`] = `
+<div id="form-number-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="number-required-1"
+  >
+    <label for="input-number-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-number formio-component-number  required"
+           id="number-required-2"
+      >
+        <label for="input-number-required-2"
+               class="field-required"
+        >
+          This is a number
+        </label>
+        <div ref="element">
+          <div class="form-input">
+            <input value
+                   inputmode="decimal"
+                   lang="en"
+                   class="form-control"
+                   type="text"
+                   name="data[number]"
+                   required
+                   id="input-number-required-2"
+                   ref="input"
+                   pattern="[0-9.]*"
+            >
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "panel" scenario: basic matches the snapshot 1`] = `
+<div id="form-panel-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="panel-basic-1"
+  >
+    <label for="input-panel-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="formio-component formio-component-panel formio-component-panel"
+           id="panel-basic-2"
+      >
+        <div class="mb-2 card border">
+          <div ref="header"
+               class="card-header bg-default"
+          >
+            <span class="mb-0 card-title">
+              Panel
+            </span>
+          </div>
+          <div ref="nested-panel"
+               class="card-body"
+          >
+            <div ref="component"
+                 class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
+                 id="panel-basic-3"
+            >
+              <label for="input-panel-basic-3"
+                     class
+              >
+                Your name
+              </label>
+              <div ref="element">
+                <div class="form-input">
+                  <input value
+                         spellcheck="true"
+                         lang="en"
+                         class="form-control"
+                         type="text"
+                         name="data[textField]"
+                         id="input-panel-basic-3"
+                         ref="input"
+                  >
+                </div>
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+            </div>
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "panel" scenario: required matches the snapshot 1`] = `
+<div id="form-panel-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="panel-required-1"
+  >
+    <label for="input-panel-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="formio-component formio-component-panel formio-component-panel"
+           id="panel-required-2"
+      >
+        <div class="mb-2 card border">
+          <div ref="header"
+               class="card-header bg-default"
+          >
+            <span class="mb-0 card-title">
+              Panel
+            </span>
+          </div>
+          <div ref="nested-panel"
+               class="card-body"
+          >
+            <div ref="component"
+                 class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
+                 id="panel-basic-3"
+            >
+              <label for="input-panel-basic-3"
+                     class
+              >
+                Your name
+              </label>
+              <div ref="element">
+                <div class="form-input">
+                  <input value
+                         spellcheck="true"
+                         lang="en"
+                         class="form-control"
+                         type="text"
+                         name="data[textField]"
+                         id="input-panel-basic-3"
+                         ref="input"
+                  >
+                </div>
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+            </div>
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "radio" scenario: basic matches the snapshot 1`] = `
+<div id="form-radio-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="radio-basic-1"
+  >
+    <label for="input-radio-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-radio formio-component-radio"
+           id="radio-basic-2"
+      >
+        <fieldset class>
+          <legend class="f-3">
+            This is a radio
+          </legend>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-basic-2-1"
+                     value="1"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-basic-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              One
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-basic-2-2"
+                     value="2"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-basic-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              Two
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-basic-2-3"
+                     value="3"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-basic-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              Three
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "radio" scenario: required matches the snapshot 1`] = `
+<div id="form-radio-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="radio-required-1"
+  >
+    <label for="input-radio-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-radio formio-component-radio  required"
+           id="radio-required-2"
+      >
+        <fieldset class>
+          <legend class="f-3  field-required">
+            This is a radio
+          </legend>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-required-2-1"
+                     value="1"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-required-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              One
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-required-2-2"
+                     value="2"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-required-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              Two
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="radio-required-2-3"
+                     value="3"
+                     lang="en"
+                     type="radio"
+                     name="data[radio][radio-required-2]"
+                     ref="input"
+                     class="input-radio position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              Three
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "selectboxes" scenario: basic matches the snapshot 1`] = `
+<div id="form-selectboxes-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="selectboxes-basic-1"
+  >
+    <label for="input-selectboxes-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-selectboxes formio-component-selectBoxes"
+           id="selectboxes-basic-2"
+      >
+        <label for="input-selectboxes-basic-2"
+               class
+        >
+          This is a selectboxes
+        </label>
+        <fieldset class>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-basic-2-a"
+                     value="a"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              A
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-basic-2-b"
+                     value="b"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              B
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-basic-2-c"
+                     value="c"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              C
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "selectboxes" scenario: required matches the snapshot 1`] = `
+<div id="form-selectboxes-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="selectboxes-required-1"
+  >
+    <label for="input-selectboxes-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-selectboxes formio-component-selectBoxes  required"
+           id="selectboxes-required-2"
+      >
+        <label for="input-selectboxes-required-2"
+               class="field-required"
+        >
+          This is a selectboxes
+        </label>
+        <fieldset class>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-required-2-a"
+                     value="a"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              A
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-required-2-b"
+                     value="b"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              B
+            </span>
+          </label>
+          <label class="d-flex flex-items-center fs-inherit mt-2">
+            <div class="flex-shrink-0">
+              <input id="selectboxes-required-2-c"
+                     value="c"
+                     lang="en"
+                     type="checkbox"
+                     name="data[selectBoxes][]"
+                     ref="input"
+                     class="input-checkbox position-relative d-block mr-2 mb-0"
+              >
+            </div>
+            <span class="flex-auto">
+              C
+            </span>
+          </label>
+          <div class="help-block with-errors">
+          </div>
+        </fieldset>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "textfield" scenario: basic matches the snapshot 1`] = `
+<div id="form-textfield-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="textfield-basic-1"
+  >
+    <label for="input-textfield-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
+           id="textfield-basic-2"
+      >
+        <label for="input-textfield-basic-2"
+               class
+        >
+          This is a textfield
+        </label>
+        <div ref="element">
+          <div class="form-input">
+            <input value
+                   spellcheck="true"
+                   lang="en"
+                   class="form-control"
+                   type="text"
+                   name="data[textField]"
+                   id="input-textfield-basic-2"
+                   ref="input"
+            >
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "textfield" scenario: required matches the snapshot 1`] = `
+<div id="form-textfield-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="textfield-required-1"
+  >
+    <label for="input-textfield-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-textfield formio-component-textField  required"
+           id="textfield-required-2"
+      >
+        <label for="input-textfield-required-2"
+               class="field-required"
+        >
+          This is a textfield
+        </label>
+        <div ref="element">
+          <div class="form-input">
+            <input value
+                   spellcheck="true"
+                   lang="en"
+                   class="form-control"
+                   type="text"
+                   name="data[textField]"
+                   required
+                   id="input-textfield-required-2"
+                   ref="input"
+            >
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;

--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -20,210 +20,176 @@ exports[`component snapshots component "address" scenario: basic matches the sna
            class="form-group has-feedback formio-component formio-component-address formio-component-address"
            id="address-basic-2"
       >
-        <fieldset class="bg-blue-1 round-1">
-          <div class="p-2">
-            <legend class="f-3">
-              This is a address
-            </legend>
-            <div ref="nested-address">
-              <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
-                   id="address-basic-3"
-              >
-                <label for="input-address-basic-3"
-                       class="field-required"
+        <label for="input-address-basic-2"
+               class
+        >
+          This is a address
+        </label>
+        <div ref="nested-address">
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+               id="address-basic-3"
+          >
+            <label for="input-address-basic-3"
+                   class="field-required"
+            >
+              Address line 1
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[address][line1]"
+                       required
+                       id="input-address-basic-3"
+                       ref="input"
                 >
-                  Address line 1
-                </label>
-                <div ref="element">
-                  <div class="form-input">
-                    <input value
-                           spellcheck="true"
-                           lang="en"
-                           class="form-control"
-                           type="text"
-                           name="data[address][line1]"
-                           required
-                           id="input-address-basic-3"
-                           ref="input"
-                    >
-                  </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
-              <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
-                   id="address-basic-4"
-              >
-                <label for="input-address-basic-4"
-                       class
+            </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
+          </div>
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+               id="address-basic-4"
+          >
+            <label for="input-address-basic-4"
+                   class
+            >
+              Address line 2
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[address][line2]"
+                       id="input-address-basic-4"
+                       ref="input"
                 >
-                  Address line 2
-                </label>
-                <div ref="element">
-                  <div class="form-input">
-                    <input value
-                           spellcheck="true"
-                           lang="en"
-                           class="form-control"
-                           type="text"
-                           name="data[address][line2]"
-                           id="input-address-basic-4"
-                           ref="input"
-                    >
-                  </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
-              <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
-                   id="address-basic-5"
-              >
-                <label for="input-address-basic-5"
-                       class="field-required"
+            </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
+          </div>
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+               id="address-basic-5"
+          >
+            <label for="input-address-basic-5"
+                   class="field-required"
+            >
+              City
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value="San Francisco"
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[address][city]"
+                       required
+                       id="input-address-basic-5"
+                       ref="input"
                 >
-                  City
-                </label>
-                <div ref="element">
-                  <div class="form-input">
-                    <input value="San Francisco"
-                           spellcheck="true"
-                           lang="en"
-                           class="form-control"
-                           type="text"
-                           name="data[address][city]"
-                           required
-                           id="input-address-basic-5"
-                           ref="input"
-                    >
-                  </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
-              <div ref="component"
-                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
-                   id="address-basic-6"
+            </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
+          </div>
+          <div ref="component"
+               class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+               id="address-basic-6"
+          >
+            <label for="input-address-basic-6"
+                   class="control-label--hidden"
+            >
+              Columns
+            </label>
+            <div class="d-md-flex mr-md-n2">
+              <div ref="column-address-basic-6"
+                   class="col-md-6 mr-md-2"
               >
-                <label for="input-address-basic-6"
-                       class="control-label--hidden"
+                <div ref="component"
+                     class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
+                     id="address-basic-7"
                 >
-                  Columns
-                </label>
-                <div class="d-md-flex mr-md-n2">
-                  <div ref="column-address-basic-6"
-                       class="col-md-6 mr-md-2"
+                  <label for="input-address-basic-7"
+                         class="field-required"
                   >
-                    <div ref="component"
-                         class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
-                         id="address-basic-7"
-                    >
-                      <label for="input-address-basic-7"
-                             class="field-required"
+                    State
+                  </label>
+                  <select lang="en"
+                          class="form-control"
+                          type="text"
+                          name="data[address][state]"
+                          id="input-address-basic-7"
+                          required
+                          ref="selectContainer"
+                  >
+                  </select>
+                  <div ref="messageContainer"
+                       class="messages"
+                  >
+                  </div>
+                </div>
+              </div>
+              <div ref="column-address-basic-6"
+                   class="col-md-6 mr-md-2"
+              >
+                <div ref="component"
+                     class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
+                     id="address-basic-8"
+                >
+                  <label for="input-address-basic-8"
+                         class="field-required"
+                  >
+                    ZIP code
+                  </label>
+                  <div ref="element">
+                    <div class="form-input">
+                      <input value
+                             spellcheck="true"
+                             lang="en"
+                             class="form-control"
+                             type="text"
+                             name="data[address][zip]"
+                             required
+                             id="input-address-basic-8"
+                             ref="input"
                       >
-                        State
-                      </label>
-                      <select lang="en"
-                              class="form-control"
-                              type="text"
-                              name="data[address][state]"
-                              id="input-address-basic-7"
-                              required
-                              ref="selectContainer"
-                      >
-                      </select>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
                     </div>
                   </div>
-                  <div ref="column-address-basic-6"
-                       class="col-md-6 mr-md-2"
+                  <div ref="messageContainer"
+                       class="messages"
                   >
-                    <div ref="component"
-                         class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
-                         id="address-basic-8"
-                    >
-                      <label for="input-address-basic-8"
-                             class="field-required"
-                      >
-                        ZIP code
-                      </label>
-                      <div ref="element">
-                        <div class="form-input">
-                          <input value
-                                 spellcheck="true"
-                                 lang="en"
-                                 class="form-control"
-                                 type="text"
-                                 name="data[address][zip]"
-                                 required
-                                 id="input-address-basic-8"
-                                 ref="input"
-                          >
-                        </div>
-                      </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
-                    </div>
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
               </div>
             </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
           </div>
-        </fieldset>
-        <div ref="messageContainer"
-             class="messages"
-        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -253,210 +219,176 @@ exports[`component snapshots component "address" scenario: required matches the 
            class="form-group has-feedback formio-component formio-component-address formio-component-address  required"
            id="address-required-2"
       >
-        <fieldset class="bg-blue-1 round-1">
-          <div class="p-2">
-            <legend class="f-3">
-              This is a address
-            </legend>
-            <div ref="nested-address">
-              <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
-                   id="address-required-3"
-              >
-                <label for="input-address-required-3"
-                       class="field-required"
+        <label for="input-address-required-2"
+               class="field-required"
+        >
+          This is a address
+        </label>
+        <div ref="nested-address">
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+               id="address-required-3"
+          >
+            <label for="input-address-required-3"
+                   class="field-required"
+            >
+              Address line 1
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[address][line1]"
+                       required
+                       id="input-address-required-3"
+                       ref="input"
                 >
-                  Address line 1
-                </label>
-                <div ref="element">
-                  <div class="form-input">
-                    <input value
-                           spellcheck="true"
-                           lang="en"
-                           class="form-control"
-                           type="text"
-                           name="data[address][line1]"
-                           required
-                           id="input-address-required-3"
-                           ref="input"
-                    >
-                  </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
-              <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
-                   id="address-required-4"
-              >
-                <label for="input-address-required-4"
-                       class
+            </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
+          </div>
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+               id="address-required-4"
+          >
+            <label for="input-address-required-4"
+                   class
+            >
+              Address line 2
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[address][line2]"
+                       id="input-address-required-4"
+                       ref="input"
                 >
-                  Address line 2
-                </label>
-                <div ref="element">
-                  <div class="form-input">
-                    <input value
-                           spellcheck="true"
-                           lang="en"
-                           class="form-control"
-                           type="text"
-                           name="data[address][line2]"
-                           id="input-address-required-4"
-                           ref="input"
-                    >
-                  </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
-              <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
-                   id="address-required-5"
-              >
-                <label for="input-address-required-5"
-                       class="field-required"
+            </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
+          </div>
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+               id="address-required-5"
+          >
+            <label for="input-address-required-5"
+                   class="field-required"
+            >
+              City
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value="San Francisco"
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[address][city]"
+                       required
+                       id="input-address-required-5"
+                       ref="input"
                 >
-                  City
-                </label>
-                <div ref="element">
-                  <div class="form-input">
-                    <input value="San Francisco"
-                           spellcheck="true"
-                           lang="en"
-                           class="form-control"
-                           type="text"
-                           name="data[address][city]"
-                           required
-                           id="input-address-required-5"
-                           ref="input"
-                    >
-                  </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
               </div>
-              <div ref="component"
-                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
-                   id="address-required-6"
+            </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
+          </div>
+          <div ref="component"
+               class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+               id="address-required-6"
+          >
+            <label for="input-address-required-6"
+                   class="control-label--hidden"
+            >
+              Columns
+            </label>
+            <div class="d-md-flex mr-md-n2">
+              <div ref="column-address-required-6"
+                   class="col-md-6 mr-md-2"
               >
-                <label for="input-address-required-6"
-                       class="control-label--hidden"
+                <div ref="component"
+                     class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
+                     id="address-required-7"
                 >
-                  Columns
-                </label>
-                <div class="d-md-flex mr-md-n2">
-                  <div ref="column-address-required-6"
-                       class="col-md-6 mr-md-2"
+                  <label for="input-address-required-7"
+                         class="field-required"
                   >
-                    <div ref="component"
-                         class="form-group has-feedback formio-component formio-component-state formio-component-state mb-0 required"
-                         id="address-required-7"
-                    >
-                      <label for="input-address-required-7"
-                             class="field-required"
+                    State
+                  </label>
+                  <select lang="en"
+                          class="form-control"
+                          type="text"
+                          name="data[address][state]"
+                          id="input-address-required-7"
+                          required
+                          ref="selectContainer"
+                  >
+                  </select>
+                  <div ref="messageContainer"
+                       class="messages"
+                  >
+                  </div>
+                </div>
+              </div>
+              <div ref="column-address-required-6"
+                   class="col-md-6 mr-md-2"
+              >
+                <div ref="component"
+                     class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
+                     id="address-required-8"
+                >
+                  <label for="input-address-required-8"
+                         class="field-required"
+                  >
+                    ZIP code
+                  </label>
+                  <div ref="element">
+                    <div class="form-input">
+                      <input value
+                             spellcheck="true"
+                             lang="en"
+                             class="form-control"
+                             type="text"
+                             name="data[address][zip]"
+                             required
+                             id="input-address-required-8"
+                             ref="input"
                       >
-                        State
-                      </label>
-                      <select lang="en"
-                              class="form-control"
-                              type="text"
-                              name="data[address][state]"
-                              id="input-address-required-7"
-                              required
-                              ref="selectContainer"
-                      >
-                      </select>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
                     </div>
                   </div>
-                  <div ref="column-address-required-6"
-                       class="col-md-6 mr-md-2"
+                  <div ref="messageContainer"
+                       class="messages"
                   >
-                    <div ref="component"
-                         class="form-group has-feedback formio-component formio-component-zip formio-component-zip mb-0 required"
-                         id="address-required-8"
-                    >
-                      <label for="input-address-required-8"
-                             class="field-required"
-                      >
-                        ZIP code
-                      </label>
-                      <div ref="element">
-                        <div class="form-input">
-                          <input value
-                                 spellcheck="true"
-                                 lang="en"
-                                 class="form-control"
-                                 type="text"
-                                 name="data[address][zip]"
-                                 required
-                                 id="input-address-required-8"
-                                 ref="input"
-                          >
-                        </div>
-                      </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
-                      <div ref="messageContainer"
-                           class="messages"
-                      >
-                      </div>
-                    </div>
                   </div>
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
-                </div>
-                <div ref="messageContainer"
-                     class="messages"
-                >
                 </div>
               </div>
             </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
           </div>
-        </fieldset>
-        <div ref="messageContainer"
-             class="messages"
-        >
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -498,15 +430,7 @@ exports[`component snapshots component "button" scenario: basic matches the snap
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -548,15 +472,7 @@ exports[`component snapshots component "button" scenario: required matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -608,15 +524,7 @@ exports[`component snapshots component "checkbox" scenario: basic matches the sn
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -668,15 +576,7 @@ exports[`component snapshots component "checkbox" scenario: required matches the
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -741,10 +641,6 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
           <div ref="column-columns-basic-2"
@@ -776,10 +672,6 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -787,15 +679,7 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -860,10 +744,6 @@ exports[`component snapshots component "columns" scenario: required matches the 
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
           <div ref="column-columns-required-2"
@@ -895,10 +775,6 @@ exports[`component snapshots component "columns" scenario: required matches the 
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -906,15 +782,7 @@ exports[`component snapshots component "columns" scenario: required matches the 
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -950,15 +818,7 @@ exports[`component snapshots component "container" scenario: basic matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -994,15 +854,7 @@ exports[`component snapshots component "container" scenario: required matches th
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1082,15 +934,7 @@ exports[`component snapshots component "datetime" scenario: basic matches the sn
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1172,15 +1016,7 @@ exports[`component snapshots component "datetime" scenario: required matches the
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1322,15 +1158,7 @@ exports[`component snapshots component "day" scenario: basic matches the snapsho
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1475,15 +1303,7 @@ exports[`component snapshots component "day" scenario: required matches the snap
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1524,10 +1344,6 @@ exports[`component snapshots component "html" scenario: basic matches the snapsh
          class="messages"
     >
     </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
-    </div>
   </div>
 </div>
 `;
@@ -1558,10 +1374,6 @@ exports[`component snapshots component "html" scenario: required matches the sna
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1614,15 +1426,7 @@ exports[`component snapshots component "number" scenario: basic matches the snap
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1676,15 +1480,7 @@ exports[`component snapshots component "number" scenario: required matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1751,10 +1547,6 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -1763,10 +1555,6 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1833,10 +1621,6 @@ exports[`component snapshots component "panel" scenario: required matches the sn
                    class="messages"
               >
               </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
-              </div>
             </div>
           </div>
         </div>
@@ -1845,10 +1629,6 @@ exports[`component snapshots component "panel" scenario: required matches the sn
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1878,71 +1658,67 @@ exports[`component snapshots component "radio" scenario: basic matches the snaps
            class="form-group has-feedback formio-component formio-component-radio formio-component-radio"
            id="radio-basic-2"
       >
-        <fieldset class>
-          <legend class="f-3">
-            This is a radio
-          </legend>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="radio-basic-2-1"
-                     value="1"
-                     lang="en"
-                     type="radio"
-                     name="data[radio][radio-basic-2]"
-                     ref="input"
-                     class="input-radio position-relative d-block mr-2 mb-0"
-              >
+        <div class="form-group mt-2">
+          <fieldset>
+            <legend>
+              This is a radio
+            </legend>
+            <div class="field-wrapper bg-blue-1 round-1">
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="radio-basic-2-1"
+                         value="1"
+                         lang="en"
+                         type="radio"
+                         name="data[radio][radio-basic-2]"
+                         ref="input"
+                         class="input-radio position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  One
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="radio-basic-2-2"
+                         value="2"
+                         lang="en"
+                         type="radio"
+                         name="data[radio][radio-basic-2]"
+                         ref="input"
+                         class="input-radio position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  Two
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="radio-basic-2-3"
+                         value="3"
+                         lang="en"
+                         type="radio"
+                         name="data[radio][radio-basic-2]"
+                         ref="input"
+                         class="input-radio position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  Three
+                </span>
+              </label>
             </div>
-            <span class="flex-auto">
-              One
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="radio-basic-2-2"
-                     value="2"
-                     lang="en"
-                     type="radio"
-                     name="data[radio][radio-basic-2]"
-                     ref="input"
-                     class="input-radio position-relative d-block mr-2 mb-0"
-              >
+            <div class="help-block with-errors">
             </div>
-            <span class="flex-auto">
-              Two
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="radio-basic-2-3"
-                     value="3"
-                     lang="en"
-                     type="radio"
-                     name="data[radio][radio-basic-2]"
-                     ref="input"
-                     class="input-radio position-relative d-block mr-2 mb-0"
-              >
-            </div>
-            <span class="flex-auto">
-              Three
-            </span>
-          </label>
-          <div class="help-block with-errors">
-          </div>
-        </fieldset>
-        <div ref="messageContainer"
-             class="messages"
-        >
+          </fieldset>
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -1972,71 +1748,67 @@ exports[`component snapshots component "radio" scenario: required matches the sn
            class="form-group has-feedback formio-component formio-component-radio formio-component-radio  required"
            id="radio-required-2"
       >
-        <fieldset class>
-          <legend class="f-3  field-required">
-            This is a radio
-          </legend>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="radio-required-2-1"
-                     value="1"
-                     lang="en"
-                     type="radio"
-                     name="data[radio][radio-required-2]"
-                     ref="input"
-                     class="input-radio position-relative d-block mr-2 mb-0"
-              >
+        <div class="form-group mt-2">
+          <fieldset>
+            <legend>
+              This is a radio
+            </legend>
+            <div class="field-wrapper bg-blue-1 round-1">
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="radio-required-2-1"
+                         value="1"
+                         lang="en"
+                         type="radio"
+                         name="data[radio][radio-required-2]"
+                         ref="input"
+                         class="input-radio position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  One
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="radio-required-2-2"
+                         value="2"
+                         lang="en"
+                         type="radio"
+                         name="data[radio][radio-required-2]"
+                         ref="input"
+                         class="input-radio position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  Two
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="radio-required-2-3"
+                         value="3"
+                         lang="en"
+                         type="radio"
+                         name="data[radio][radio-required-2]"
+                         ref="input"
+                         class="input-radio position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  Three
+                </span>
+              </label>
             </div>
-            <span class="flex-auto">
-              One
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="radio-required-2-2"
-                     value="2"
-                     lang="en"
-                     type="radio"
-                     name="data[radio][radio-required-2]"
-                     ref="input"
-                     class="input-radio position-relative d-block mr-2 mb-0"
-              >
+            <div class="help-block with-errors">
             </div>
-            <span class="flex-auto">
-              Two
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="radio-required-2-3"
-                     value="3"
-                     lang="en"
-                     type="radio"
-                     name="data[radio][radio-required-2]"
-                     ref="input"
-                     class="input-radio position-relative d-block mr-2 mb-0"
-              >
-            </div>
-            <span class="flex-auto">
-              Three
-            </span>
-          </label>
-          <div class="help-block with-errors">
-          </div>
-        </fieldset>
-        <div ref="messageContainer"
-             class="messages"
-        >
+          </fieldset>
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2071,68 +1843,64 @@ exports[`component snapshots component "selectboxes" scenario: basic matches the
         >
           This is a selectboxes
         </label>
-        <fieldset class>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="selectboxes-basic-2-a"
-                     value="a"
-                     lang="en"
-                     type="checkbox"
-                     name="data[selectBoxes][]"
-                     ref="input"
-                     class="input-checkbox position-relative d-block mr-2 mb-0"
-              >
+        <div class="form-group mt-2">
+          <fieldset>
+            <div class="field-wrapper bg-blue-1 round-1">
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="selectboxes-basic-2-a"
+                         value="a"
+                         lang="en"
+                         type="checkbox"
+                         name="data[selectBoxes][]"
+                         ref="input"
+                         class="input-checkbox position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  A
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="selectboxes-basic-2-b"
+                         value="b"
+                         lang="en"
+                         type="checkbox"
+                         name="data[selectBoxes][]"
+                         ref="input"
+                         class="input-checkbox position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  B
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="selectboxes-basic-2-c"
+                         value="c"
+                         lang="en"
+                         type="checkbox"
+                         name="data[selectBoxes][]"
+                         ref="input"
+                         class="input-checkbox position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  C
+                </span>
+              </label>
             </div>
-            <span class="flex-auto">
-              A
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="selectboxes-basic-2-b"
-                     value="b"
-                     lang="en"
-                     type="checkbox"
-                     name="data[selectBoxes][]"
-                     ref="input"
-                     class="input-checkbox position-relative d-block mr-2 mb-0"
-              >
+            <div class="help-block with-errors">
             </div>
-            <span class="flex-auto">
-              B
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="selectboxes-basic-2-c"
-                     value="c"
-                     lang="en"
-                     type="checkbox"
-                     name="data[selectBoxes][]"
-                     ref="input"
-                     class="input-checkbox position-relative d-block mr-2 mb-0"
-              >
-            </div>
-            <span class="flex-auto">
-              C
-            </span>
-          </label>
-          <div class="help-block with-errors">
-          </div>
-        </fieldset>
-        <div ref="messageContainer"
-             class="messages"
-        >
+          </fieldset>
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2167,68 +1935,64 @@ exports[`component snapshots component "selectboxes" scenario: required matches 
         >
           This is a selectboxes
         </label>
-        <fieldset class>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="selectboxes-required-2-a"
-                     value="a"
-                     lang="en"
-                     type="checkbox"
-                     name="data[selectBoxes][]"
-                     ref="input"
-                     class="input-checkbox position-relative d-block mr-2 mb-0"
-              >
+        <div class="form-group mt-2">
+          <fieldset>
+            <div class="field-wrapper bg-blue-1 round-1">
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="selectboxes-required-2-a"
+                         value="a"
+                         lang="en"
+                         type="checkbox"
+                         name="data[selectBoxes][]"
+                         ref="input"
+                         class="input-checkbox position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  A
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="selectboxes-required-2-b"
+                         value="b"
+                         lang="en"
+                         type="checkbox"
+                         name="data[selectBoxes][]"
+                         ref="input"
+                         class="input-checkbox position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  B
+                </span>
+              </label>
+              <label class="d-flex flex-items-center fs-inherit my-2">
+                <div class="flex-shrink-0">
+                  <input id="selectboxes-required-2-c"
+                         value="c"
+                         lang="en"
+                         type="checkbox"
+                         name="data[selectBoxes][]"
+                         ref="input"
+                         class="input-checkbox position-relative d-block mr-2 mb-0"
+                  >
+                </div>
+                <span class="flex-auto">
+                  C
+                </span>
+              </label>
             </div>
-            <span class="flex-auto">
-              A
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="selectboxes-required-2-b"
-                     value="b"
-                     lang="en"
-                     type="checkbox"
-                     name="data[selectBoxes][]"
-                     ref="input"
-                     class="input-checkbox position-relative d-block mr-2 mb-0"
-              >
+            <div class="help-block with-errors">
             </div>
-            <span class="flex-auto">
-              B
-            </span>
-          </label>
-          <label class="d-flex flex-items-center fs-inherit mt-2">
-            <div class="flex-shrink-0">
-              <input id="selectboxes-required-2-c"
-                     value="c"
-                     lang="en"
-                     type="checkbox"
-                     name="data[selectBoxes][]"
-                     ref="input"
-                     class="input-checkbox position-relative d-block mr-2 mb-0"
-              >
-            </div>
-            <span class="flex-auto">
-              C
-            </span>
-          </label>
-          <div class="help-block with-errors">
-          </div>
-        </fieldset>
-        <div ref="messageContainer"
-             class="messages"
-        >
+          </fieldset>
         </div>
         <div ref="messageContainer"
              class="messages"
         >
         </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2280,15 +2044,7 @@ exports[`component snapshots component "textfield" scenario: basic matches the s
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"
@@ -2341,15 +2097,7 @@ exports[`component snapshots component "textfield" scenario: required matches th
              class="messages"
         >
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
-    </div>
-    <div ref="messageContainer"
-         class="messages"
-    >
     </div>
     <div ref="messageContainer"
          class="messages"

--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -713,12 +713,74 @@ exports[`component snapshots component "columns" scenario: basic matches the sna
         </label>
         <div class="d-md-flex mr-md-n2">
           <div ref="column-columns-basic-2"
-               class="col-md-6 mr-md-2"
+               class="col-md-3 mr-md-2"
           >
+            <div ref="component"
+                 class="form-group has-feedback formio-component formio-component-textfield formio-component-left"
+                 id="columns-basic-3"
+            >
+              <label for="input-columns-basic-3"
+                     class
+              >
+                Left
+              </label>
+              <div ref="element">
+                <div class="form-input">
+                  <input value
+                         spellcheck="true"
+                         lang="en"
+                         class="form-control"
+                         type="text"
+                         name="data[left]"
+                         id="input-columns-basic-3"
+                         ref="input"
+                  >
+                </div>
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+            </div>
           </div>
           <div ref="column-columns-basic-2"
-               class="col-md-6 mr-md-2"
+               class="col-md-3 mr-md-2"
           >
+            <div ref="component"
+                 class="form-group has-feedback formio-component formio-component-textfield formio-component-right"
+                 id="columns-basic-4"
+            >
+              <label for="input-columns-basic-4"
+                     class
+              >
+                Right
+              </label>
+              <div ref="element">
+                <div class="form-input">
+                  <input value
+                         spellcheck="true"
+                         lang="en"
+                         class="form-control"
+                         type="text"
+                         name="data[right]"
+                         id="input-columns-basic-4"
+                         ref="input"
+                  >
+                </div>
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+            </div>
           </div>
         </div>
         <div ref="messageContainer"
@@ -770,12 +832,74 @@ exports[`component snapshots component "columns" scenario: required matches the 
         </label>
         <div class="d-md-flex mr-md-n2">
           <div ref="column-columns-required-2"
-               class="col-md-6 mr-md-2"
+               class="col-md-3 mr-md-2"
           >
+            <div ref="component"
+                 class="form-group has-feedback formio-component formio-component-textfield formio-component-left"
+                 id="columns-basic-3"
+            >
+              <label for="input-columns-basic-3"
+                     class
+              >
+                Left
+              </label>
+              <div ref="element">
+                <div class="form-input">
+                  <input value
+                         spellcheck="true"
+                         lang="en"
+                         class="form-control"
+                         type="text"
+                         name="data[left]"
+                         id="input-columns-basic-3"
+                         ref="input"
+                  >
+                </div>
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+            </div>
           </div>
           <div ref="column-columns-required-2"
-               class="col-md-6 mr-md-2"
+               class="col-md-3 mr-md-2"
           >
+            <div ref="component"
+                 class="form-group has-feedback formio-component formio-component-textfield formio-component-right"
+                 id="columns-basic-4"
+            >
+              <label for="input-columns-basic-4"
+                     class
+              >
+                Right
+              </label>
+              <div ref="element">
+                <div class="form-input">
+                  <input value
+                         spellcheck="true"
+                         lang="en"
+                         class="form-control"
+                         type="text"
+                         name="data[right]"
+                         id="input-columns-basic-4"
+                         ref="input"
+                  >
+                </div>
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+              <div ref="messageContainer"
+                   class="messages"
+              >
+              </div>
+            </div>
           </div>
         </div>
         <div ref="messageContainer"
@@ -865,6 +989,184 @@ exports[`component snapshots component "container" scenario: required matches th
            id="container-required-2"
       >
         <div ref="nested-container">
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "datetime" scenario: basic matches the snapshot 1`] = `
+<div id="form-datetime-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="datetime-basic-1"
+  >
+    <label for="input-datetime-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-datetime formio-component-dateTime"
+           id="datetime-basic-2"
+      >
+        <label for="input-datetime-basic-2"
+               class
+               id="label-datetime-basic-2"
+        >
+          This is a datetime
+        </label>
+        <div ref="element">
+          <div class="input-group">
+            <div ref="suffix"
+                 class="input-group-prepend"
+            >
+              <span class="input-group-text">
+                <i style
+                   class="d-flex notranslate"
+                   ref="icon"
+                   data-icon="calendar"
+                >
+                  <svg viewbox="0 0 20 20"
+                       fill="currentColor"
+                       height="20"
+                  >
+                    <path d="M20 9.25v-5A1.244 1.244 0 0018.75 3H16V1.5a1.25 1.25 0 00-2.5 0V3h-7V1.5a1.25 1.25 0 00-2.5 0V3H1.25a1.275 1.275 0 00-.885.365A1.275 1.275 0 000 4.25v14.5c.002.331.133.649.365.885.236.232.554.363.885.365h17.5A1.244 1.244 0 0020 18.75v-9.5zM17.5 5.5V8h-15V5.5h15zm-15 5h15v7h-15v-7z">
+                    </path>
+                  </svg>
+                </i>
+              </span>
+            </div>
+            <div class="form-input">
+              <input value
+                     lang="en"
+                     class="form-control flatpickr-input"
+                     type="hidden"
+                     name="data[dateTime]"
+                     id="input-datetime-basic-2"
+                     ref="input"
+                     placeholder="yyyy-MM-dd hh:mm a"
+              >
+              <input class="form-control form-control input"
+                     placeholder="yyyy-MM-dd hh:mm a"
+                     tabindex="0"
+                     type="text"
+                     aria-labelledby="label-datetime-basic-2"
+              >
+            </div>
+          </div>
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "datetime" scenario: required matches the snapshot 1`] = `
+<div id="form-datetime-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="datetime-required-1"
+  >
+    <label for="input-datetime-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-datetime formio-component-dateTime  required"
+           id="datetime-required-2"
+      >
+        <label for="input-datetime-required-2"
+               class="field-required"
+               id="label-datetime-required-2"
+        >
+          This is a datetime
+        </label>
+        <div ref="element">
+          <div class="input-group">
+            <div ref="suffix"
+                 class="input-group-prepend"
+            >
+              <span class="input-group-text">
+                <i style
+                   class="d-flex notranslate"
+                   ref="icon"
+                   data-icon="calendar"
+                >
+                  <svg viewbox="0 0 20 20"
+                       fill="currentColor"
+                       height="20"
+                  >
+                    <path d="M20 9.25v-5A1.244 1.244 0 0018.75 3H16V1.5a1.25 1.25 0 00-2.5 0V3h-7V1.5a1.25 1.25 0 00-2.5 0V3H1.25a1.275 1.275 0 00-.885.365A1.275 1.275 0 000 4.25v14.5c.002.331.133.649.365.885.236.232.554.363.885.365h17.5A1.244 1.244 0 0020 18.75v-9.5zM17.5 5.5V8h-15V5.5h15zm-15 5h15v7h-15v-7z">
+                    </path>
+                  </svg>
+                </i>
+              </span>
+            </div>
+            <div class="form-input">
+              <input value
+                     lang="en"
+                     class="form-control flatpickr-input"
+                     type="hidden"
+                     name="data[dateTime]"
+                     required
+                     id="input-datetime-required-2"
+                     ref="input"
+                     placeholder="yyyy-MM-dd hh:mm a"
+              >
+              <input class="form-control form-control input"
+                     placeholder="yyyy-MM-dd hh:mm a"
+                     required
+                     tabindex="0"
+                     type="text"
+                     aria-labelledby="label-datetime-required-2"
+              >
+            </div>
+          </div>
         </div>
         <div ref="messageContainer"
              class="messages"

--- a/__tests__/snapshots.js
+++ b/__tests__/snapshots.js
@@ -4,41 +4,54 @@ import '../dist/formio-sfds.standalone.js'
 
 const { FormioUtils } = window
 
-describe('component snapshots', () => {
-  const components = [
-    { type: 'address' },
-    { type: 'button' },
-    { type: 'checkbox' },
-    { type: 'columns' },
-    { type: 'container' },
-    { type: 'day' },
-    { type: 'html', tag: 'h1', content: 'Hello, world!' },
-    { type: 'number' },
-    {
-      type: 'radio',
-      values: [
-        { label: 'One', value: 1 },
-        { label: 'Two', value: 2 },
-        { label: 'Three', value: 3 }
-      ]
-    },
-    {
-      type: 'selectboxes',
-      values: [
-        { label: 'A', value: 'a' },
-        { label: 'B', value: 'b' },
-        { label: 'C', value: 'c' }
-      ]
-    },
-    { type: 'textfield' },
-    {
-      type: 'panel',
-      components: [
-        { type: 'textfield', label: 'Your name' }
-      ]
-    }
-  ]
+const components = [
+  { type: 'address' },
+  { type: 'button' },
+  { type: 'checkbox' },
+  {
+    type: 'columns',
+    columns: [
+      {
+        width: 3,
+        components: [{ type: 'textfield', key: 'left', label: 'Left' }]
+      },
+      {
+        width: 3,
+        components: [{ type: 'textfield', key: 'right', label: 'Right' }]
+      }
+    ]
+  },
+  { type: 'container' },
+  { type: 'day' },
+  { type: 'datetime' },
+  { type: 'html', tag: 'h1', content: 'Hello, world!' },
+  { type: 'number' },
+  {
+    type: 'radio',
+    values: [
+      { label: 'One', value: 1 },
+      { label: 'Two', value: 2 },
+      { label: 'Three', value: 3 }
+    ]
+  },
+  {
+    type: 'selectboxes',
+    values: [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' }
+    ]
+  },
+  { type: 'textfield' },
+  {
+    type: 'panel',
+    components: [
+      { type: 'textfield', label: 'Your name' }
+    ]
+  }
+]
 
+describe('component snapshots', () => {
   const scenarios = {
     basic: {},
     required: {

--- a/__tests__/snapshots.js
+++ b/__tests__/snapshots.js
@@ -1,0 +1,83 @@
+/* eslint-env jest */
+import { createForm, destroyForm } from '../lib/test-helpers'
+import '../dist/formio-sfds.standalone.js'
+
+const { FormioUtils } = window
+
+describe('component snapshots', () => {
+  const components = [
+    { type: 'address' },
+    { type: 'button' },
+    { type: 'checkbox' },
+    { type: 'columns' },
+    { type: 'container' },
+    { type: 'day' },
+    { type: 'html', tag: 'h1', content: 'Hello, world!' },
+    { type: 'number' },
+    {
+      type: 'radio',
+      values: [
+        { label: 'One', value: 1 },
+        { label: 'Two', value: 2 },
+        { label: 'Three', value: 3 }
+      ]
+    },
+    {
+      type: 'selectboxes',
+      values: [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+        { label: 'C', value: 'c' }
+      ]
+    },
+    { type: 'textfield' },
+    {
+      type: 'panel',
+      components: [
+        { type: 'textfield', label: 'Your name' }
+      ]
+    }
+  ]
+
+  const scenarios = {
+    basic: {},
+    required: {
+      validate: {
+        required: true
+      }
+    }
+  }
+
+  const { getRandomComponentId } = FormioUtils
+
+  for (const comp of components) {
+    describe(`component "${comp.type}"`, () => {
+      for (const [name, props] of Object.entries(scenarios)) {
+        describe(`scenario: ${name}`, () => {
+          it('matches the snapshot', async () => {
+            let i = 0
+            FormioUtils.getRandomComponentId = () => `${comp.type}-${name}-${i++}`
+
+            const form = await createForm({
+              components: [
+                Object.assign(
+                  { label: `This is a ${comp.type}` },
+                  comp,
+                  props
+                )
+              ]
+            })
+
+            form.element.id = `form-${comp.type}-${name}`
+            const html = form.element.outerHTML
+            expect(html).toMatchSnapshot()
+
+            destroyForm(form)
+
+            FormioUtils.getRandomComponentId = getRandomComponentId
+          })
+        })
+      }
+    })
+  }
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  setupFiles: ['<rootDir>/lib/test-setup.js']
+  setupFiles: ['<rootDir>/lib/test-setup.js'],
+  snapshotSerializers: ['jest-serializer-html']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5240,6 +5240,15 @@
       "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
       "dev": true
     },
+    "diffable-html": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/diffable-html/-/diffable-html-4.0.0.tgz",
+      "integrity": "sha512-keJdgy2qBkdrrnwP1YE6e834d4Y+mV0aRFzk8w7WzyAJVbQVfcJltSmUWB3r/NOoO/0jt7RdJlvy5ioyqvmQcw==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.9.2"
+      }
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -8896,6 +8905,15 @@
           "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         }
+      }
+    },
+    "jest-serializer-html": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer-html/-/jest-serializer-html-7.0.0.tgz",
+      "integrity": "sha512-o3S2j/5yA9emV8+QRHqJ41SznW5cZ1PXIAk+aSToJffdhuaiSoDsa4IgqV8lNOHPp4cP0LNT7k5KjXjD+l6SGg==",
+      "dev": true,
+      "requires": {
+        "diffable-html": "^4.0.0"
       }
     },
     "jest-snapshot": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2672,15 +2672,16 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
-      "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
+      "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^26.1.0",
-        "jest-util": "^26.1.0",
+        "jest-message-util": "^26.3.0",
+        "jest-util": "^26.3.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -2732,9 +2733,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2743,33 +2744,34 @@
       }
     },
     "@jest/core": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.1.0.tgz",
-      "integrity": "sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
+      "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/reporters": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.3.0",
+        "@jest/reporters": "^26.4.1",
+        "@jest/test-result": "^26.3.0",
+        "@jest/transform": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^26.1.0",
-        "jest-config": "^26.1.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-message-util": "^26.1.0",
+        "jest-changed-files": "^26.3.0",
+        "jest-config": "^26.4.2",
+        "jest-haste-map": "^26.3.0",
+        "jest-message-util": "^26.3.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.1.0",
-        "jest-resolve-dependencies": "^26.1.0",
-        "jest-runner": "^26.1.0",
-        "jest-runtime": "^26.1.0",
-        "jest-snapshot": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-validate": "^26.1.0",
-        "jest-watcher": "^26.1.0",
+        "jest-resolve": "^26.4.0",
+        "jest-resolve-dependencies": "^26.4.2",
+        "jest-runner": "^26.4.2",
+        "jest-runtime": "^26.4.2",
+        "jest-snapshot": "^26.4.2",
+        "jest-util": "^26.3.0",
+        "jest-validate": "^26.4.2",
+        "jest-watcher": "^26.3.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -2850,9 +2852,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2861,51 +2863,53 @@
       }
     },
     "@jest/environment": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
-      "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+      "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "jest-mock": "^26.1.0"
+        "@jest/fake-timers": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
+        "jest-mock": "^26.3.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
-      "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+      "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "@sinonjs/fake-timers": "^6.0.1",
-        "jest-message-util": "^26.1.0",
-        "jest-mock": "^26.1.0",
-        "jest-util": "^26.1.0"
+        "@types/node": "*",
+        "jest-message-util": "^26.3.0",
+        "jest-mock": "^26.3.0",
+        "jest-util": "^26.3.0"
       }
     },
     "@jest/globals": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.1.0.tgz",
-      "integrity": "sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
+      "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "expect": "^26.1.0"
+        "@jest/environment": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "expect": "^26.4.2"
       }
     },
     "@jest/reporters": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.1.0.tgz",
-      "integrity": "sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
+      "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.3.0",
+        "@jest/test-result": "^26.3.0",
+        "@jest/transform": "^26.3.0",
+        "@jest/types": "^26.3.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -2916,16 +2920,16 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^26.1.0",
-        "jest-resolve": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-worker": "^26.1.0",
-        "node-notifier": "^7.0.0",
+        "jest-haste-map": "^26.3.0",
+        "jest-resolve": "^26.4.0",
+        "jest-util": "^26.3.0",
+        "jest-worker": "^26.3.0",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^4.1.3"
+        "v8-to-istanbul": "^5.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2975,16 +2979,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-worker": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
-          "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
-          "dev": true,
-          "requires": {
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2998,9 +2992,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -3009,9 +3003,9 @@
       }
     },
     "@jest/source-map": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.1.0.tgz",
-      "integrity": "sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
+      "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -3040,28 +3034,28 @@
       }
     },
     "@jest/test-result": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
-      "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
+      "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.3.0",
+        "@jest/types": "^26.3.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.1.0.tgz",
-      "integrity": "sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
+      "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.1.0",
+        "@jest/test-result": "^26.3.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.1.0",
-        "jest-runner": "^26.1.0",
-        "jest-runtime": "^26.1.0"
+        "jest-haste-map": "^26.3.0",
+        "jest-runner": "^26.4.2",
+        "jest-runtime": "^26.4.2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -3073,21 +3067,21 @@
       }
     },
     "@jest/transform": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.1.0.tgz",
-      "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
+      "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.1.0",
+        "jest-haste-map": "^26.3.0",
         "jest-regex-util": "^26.0.0",
-        "jest-util": "^26.1.0",
+        "jest-util": "^26.3.0",
         "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -3165,9 +3159,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -3176,13 +3170,14 @@
       }
     },
     "@jest/types": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-      "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+      "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0"
       },
@@ -3229,9 +3224,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -3384,9 +3379,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-      "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+      "version": "7.1.10",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+      "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -3397,18 +3392,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+      "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -3416,9 +3411,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-      "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+      "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -3461,12 +3456,11 @@
       }
     },
     "@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
     },
@@ -3495,9 +3489,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
-      "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
       "dev": true
     },
     "@types/q": {
@@ -3528,9 +3522,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "15.0.5",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-      "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+      "integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -3549,9 +3543,9 @@
       "dev": true
     },
     "abab": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
     "abort-controller": {
@@ -3857,9 +3851,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
     "axios": {
@@ -3872,16 +3866,16 @@
       }
     },
     "babel-jest": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.1.0.tgz",
-      "integrity": "sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
+      "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/transform": "^26.3.0",
+        "@jest/types": "^26.3.0",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.1.0",
+        "babel-preset-jest": "^26.3.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -3941,9 +3935,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -3974,9 +3968,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.1.0.tgz",
-      "integrity": "sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+      "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -4018,13 +4012,13 @@
       }
     },
     "babel-preset-jest": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.1.0.tgz",
-      "integrity": "sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
+      "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^26.1.0",
-        "babel-preset-current-node-syntax": "^0.1.2"
+        "babel-plugin-jest-hoist": "^26.2.0",
+        "babel-preset-current-node-syntax": "^0.1.3"
       }
     },
     "bail": {
@@ -5065,9 +5059,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
       "dev": true
     },
     "decode-uri-component": {
@@ -5235,9 +5229,9 @@
       "integrity": "sha512-DVYazl3klQtPjs4dOzDTOt4uQ8cRDfu8EBhoY81ISmH0fbrMvYuaethcQ9UevmF9kAaLnBJ0O5eDUnZ7QalArA=="
     },
     "diff-sequences": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
-      "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+      "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
       "dev": true
     },
     "diffable-html": {
@@ -5390,6 +5384,12 @@
       "version": "1.3.378",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
       "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw==",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+      "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -5988,16 +5988,16 @@
       }
     },
     "expect": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.1.0.tgz",
-      "integrity": "sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+      "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "ansi-styles": "^4.0.0",
-        "jest-get-type": "^26.0.0",
-        "jest-matcher-utils": "^26.1.0",
-        "jest-message-util": "^26.1.0",
+        "jest-get-type": "^26.3.0",
+        "jest-matcher-utils": "^26.4.2",
+        "jest-message-util": "^26.3.0",
         "jest-regex-util": "^26.0.0"
       },
       "dependencies": {
@@ -6725,13 +6725,27 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "hard-rejection": {
@@ -7391,9 +7405,9 @@
       "dev": true
     },
     "is-docker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
       "dev": true,
       "optional": true
     },
@@ -7681,9 +7695,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -7721,14 +7735,14 @@
       }
     },
     "jest": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.1.0.tgz",
-      "integrity": "sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
+      "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.1.0",
+        "@jest/core": "^26.4.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.1.0"
+        "jest-cli": "^26.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7779,30 +7793,30 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.1.0.tgz",
-          "integrity": "sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
+          "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.1.0",
-            "@jest/test-result": "^26.1.0",
-            "@jest/types": "^26.1.0",
+            "@jest/core": "^26.4.2",
+            "@jest/test-result": "^26.3.0",
+            "@jest/types": "^26.3.0",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.1.0",
-            "jest-util": "^26.1.0",
-            "jest-validate": "^26.1.0",
+            "jest-config": "^26.4.2",
+            "jest-util": "^26.3.0",
+            "jest-validate": "^26.4.2",
             "prompts": "^2.0.1",
             "yargs": "^15.3.1"
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -7811,12 +7825,12 @@
       }
     },
     "jest-changed-files": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.1.0.tgz",
-      "integrity": "sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
+      "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "execa": "^4.0.0",
         "throat": "^5.0.0"
       },
@@ -7850,9 +7864,9 @@
           }
         },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -7900,29 +7914,29 @@
       }
     },
     "jest-config": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.1.0.tgz",
-      "integrity": "sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
+      "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "babel-jest": "^26.1.0",
+        "@jest/test-sequencer": "^26.4.2",
+        "@jest/types": "^26.3.0",
+        "babel-jest": "^26.3.0",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-environment-jsdom": "^26.1.0",
-        "jest-environment-node": "^26.1.0",
-        "jest-get-type": "^26.0.0",
-        "jest-jasmine2": "^26.1.0",
+        "jest-environment-jsdom": "^26.3.0",
+        "jest-environment-node": "^26.3.0",
+        "jest-get-type": "^26.3.0",
+        "jest-jasmine2": "^26.4.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-validate": "^26.1.0",
+        "jest-resolve": "^26.4.0",
+        "jest-util": "^26.3.0",
+        "jest-validate": "^26.4.2",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.1.0"
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7983,9 +7997,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -7994,15 +8008,15 @@
       }
     },
     "jest-diff": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.1.0.tgz",
-      "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+      "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^26.0.0",
-        "jest-get-type": "^26.0.0",
-        "pretty-format": "^26.1.0"
+        "diff-sequences": "^26.3.0",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8047,9 +8061,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8067,16 +8081,16 @@
       }
     },
     "jest-each": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.1.0.tgz",
-      "integrity": "sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
+      "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^26.0.0",
-        "jest-util": "^26.1.0",
-        "pretty-format": "^26.1.0"
+        "jest-get-type": "^26.3.0",
+        "jest-util": "^26.3.0",
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8121,9 +8135,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8132,57 +8146,60 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.1.0.tgz",
-      "integrity": "sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
+      "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.1.0",
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "jest-mock": "^26.1.0",
-        "jest-util": "^26.1.0",
+        "@jest/environment": "^26.3.0",
+        "@jest/fake-timers": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
+        "jest-mock": "^26.3.0",
+        "jest-util": "^26.3.0",
         "jsdom": "^16.2.2"
       }
     },
     "jest-environment-node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.1.0.tgz",
-      "integrity": "sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
+      "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.1.0",
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "jest-mock": "^26.1.0",
-        "jest-util": "^26.1.0"
+        "@jest/environment": "^26.3.0",
+        "@jest/fake-timers": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
+        "jest-mock": "^26.3.0",
+        "jest-util": "^26.3.0"
       }
     },
     "jest-get-type": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
-      "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.1.0.tgz",
-      "integrity": "sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
+      "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-serializer": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-worker": "^26.1.0",
+        "jest-regex-util": "^26.0.0",
+        "jest-serializer": "^26.3.0",
+        "jest-util": "^26.3.0",
+        "jest-worker": "^26.3.0",
         "micromatch": "^4.0.2",
         "sane": "^4.0.3",
-        "walker": "^1.0.7",
-        "which": "^2.0.2"
+        "walker": "^1.0.7"
       },
       "dependencies": {
         "graceful-fs": {
@@ -8190,22 +8207,6 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
           "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-worker": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
-          "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
-          "dev": true,
-          "requires": {
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
         },
         "micromatch": {
           "version": "4.0.2",
@@ -8216,49 +8217,32 @@
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
           }
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },
     "jest-jasmine2": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.1.0.tgz",
-      "integrity": "sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
+      "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.1.0",
-        "@jest/source-map": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/environment": "^26.3.0",
+        "@jest/source-map": "^26.3.0",
+        "@jest/test-result": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.1.0",
+        "expect": "^26.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.1.0",
-        "jest-matcher-utils": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-runtime": "^26.1.0",
-        "jest-snapshot": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "pretty-format": "^26.1.0",
+        "jest-each": "^26.4.2",
+        "jest-matcher-utils": "^26.4.2",
+        "jest-message-util": "^26.3.0",
+        "jest-runtime": "^26.4.2",
+        "jest-snapshot": "^26.4.2",
+        "jest-util": "^26.3.0",
+        "pretty-format": "^26.4.2",
         "throat": "^5.0.0"
       },
       "dependencies": {
@@ -8304,9 +8288,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8315,25 +8299,25 @@
       }
     },
     "jest-leak-detector": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.1.0.tgz",
-      "integrity": "sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
+      "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^26.0.0",
-        "pretty-format": "^26.1.0"
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.4.2"
       }
     },
     "jest-matcher-utils": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.1.0.tgz",
-      "integrity": "sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+      "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^26.1.0",
-        "jest-get-type": "^26.0.0",
-        "pretty-format": "^26.1.0"
+        "jest-diff": "^26.4.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8378,9 +8362,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8389,13 +8373,13 @@
       }
     },
     "jest-message-util": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.1.0.tgz",
-      "integrity": "sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+      "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "@types/stack-utils": "^1.0.1",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -8468,9 +8452,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8479,12 +8463,13 @@
       }
     },
     "jest-mock": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.1.0.tgz",
-      "integrity": "sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+      "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0"
+        "@jest/types": "^26.3.0",
+        "@types/node": "*"
       }
     },
     "jest-pnp-resolver": {
@@ -8500,16 +8485,16 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.1.0.tgz",
-      "integrity": "sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
+      "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-pnp-resolver": "^1.2.1",
-        "jest-util": "^26.1.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^26.3.0",
         "read-pkg-up": "^7.0.1",
         "resolve": "^1.17.0",
         "slash": "^3.0.0"
@@ -8606,14 +8591,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-          "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -8670,9 +8655,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8681,39 +8666,40 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.1.0.tgz",
-      "integrity": "sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
+      "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.1.0"
+        "jest-snapshot": "^26.4.2"
       }
     },
     "jest-runner": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.1.0.tgz",
-      "integrity": "sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
+      "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/environment": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.3.0",
+        "@jest/environment": "^26.3.0",
+        "@jest/test-result": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
+        "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.1.0",
+        "jest-config": "^26.4.2",
         "jest-docblock": "^26.0.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-jasmine2": "^26.1.0",
-        "jest-leak-detector": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-resolve": "^26.1.0",
-        "jest-runtime": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-worker": "^26.1.0",
+        "jest-haste-map": "^26.3.0",
+        "jest-leak-detector": "^26.4.2",
+        "jest-message-util": "^26.3.0",
+        "jest-resolve": "^26.4.0",
+        "jest-runtime": "^26.4.2",
+        "jest-util": "^26.3.0",
+        "jest-worker": "^26.3.0",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
       },
@@ -8765,20 +8751,10 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-worker": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
-          "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
-          "dev": true,
-          "requires": {
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8787,34 +8763,34 @@
       }
     },
     "jest-runtime": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.1.0.tgz",
-      "integrity": "sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
+      "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/environment": "^26.1.0",
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/globals": "^26.1.0",
-        "@jest/source-map": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.3.0",
+        "@jest/environment": "^26.3.0",
+        "@jest/fake-timers": "^26.3.0",
+        "@jest/globals": "^26.4.2",
+        "@jest/source-map": "^26.3.0",
+        "@jest/test-result": "^26.3.0",
+        "@jest/transform": "^26.3.0",
+        "@jest/types": "^26.3.0",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.1.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-mock": "^26.1.0",
+        "jest-config": "^26.4.2",
+        "jest-haste-map": "^26.3.0",
+        "jest-message-util": "^26.3.0",
+        "jest-mock": "^26.3.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.1.0",
-        "jest-snapshot": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-validate": "^26.1.0",
+        "jest-resolve": "^26.4.0",
+        "jest-snapshot": "^26.4.2",
+        "jest-util": "^26.3.0",
+        "jest-validate": "^26.4.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^15.3.1"
@@ -8880,9 +8856,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8891,11 +8867,12 @@
       }
     },
     "jest-serializer": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.1.0.tgz",
-      "integrity": "sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
+      "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
       "dev": true,
       "requires": {
+        "@types/node": "*",
         "graceful-fs": "^4.2.4"
       },
       "dependencies": {
@@ -8917,25 +8894,25 @@
       }
     },
     "jest-snapshot": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.1.0.tgz",
-      "integrity": "sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
+      "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "@types/prettier": "^2.0.0",
         "chalk": "^4.0.0",
-        "expect": "^26.1.0",
+        "expect": "^26.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^26.1.0",
-        "jest-get-type": "^26.0.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-matcher-utils": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-resolve": "^26.1.0",
+        "jest-diff": "^26.4.2",
+        "jest-get-type": "^26.3.0",
+        "jest-haste-map": "^26.3.0",
+        "jest-matcher-utils": "^26.4.2",
+        "jest-message-util": "^26.3.0",
+        "jest-resolve": "^26.4.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^26.1.0",
+        "pretty-format": "^26.4.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
@@ -8993,9 +8970,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -9004,12 +8981,13 @@
       }
     },
     "jest-util": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.1.0.tgz",
-      "integrity": "sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+      "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "is-ci": "^2.0.0",
@@ -9074,9 +9052,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -9085,17 +9063,17 @@
       }
     },
     "jest-validate": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.1.0.tgz",
-      "integrity": "sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+      "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "camelcase": "^6.0.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^26.0.0",
+        "jest-get-type": "^26.3.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.1.0"
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9146,9 +9124,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -9157,16 +9135,17 @@
       }
     },
     "jest-watcher": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.1.0.tgz",
-      "integrity": "sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
+      "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/test-result": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^26.1.0",
+        "jest-util": "^26.3.0",
         "string-length": "^4.0.1"
       },
       "dependencies": {
@@ -9212,9 +9191,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -9272,9 +9251,9 @@
       "dev": true
     },
     "jsdom": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.3.0.tgz",
-      "integrity": "sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+      "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
       "dev": true,
       "requires": {
         "abab": "^2.0.3",
@@ -9329,6 +9308,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema": {
@@ -10156,9 +10141,9 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.2.tgz",
-      "integrity": "sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+      "integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -10166,7 +10151,7 @@
         "is-wsl": "^2.2.0",
         "semver": "^7.3.2",
         "shellwords": "^0.1.1",
-        "uuid": "^8.2.0",
+        "uuid": "^8.3.0",
         "which": "^2.0.2"
       },
       "dependencies": {
@@ -10174,6 +10159,13 @@
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
           "dev": true,
           "optional": true
         },
@@ -11760,12 +11752,12 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-      "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+      "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.3.0",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^4.0.0",
         "react-is": "^16.12.0"
@@ -12260,14 +12252,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.19"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-          "dev": true
-        }
       }
     },
     "request-promise-native": {
@@ -13839,9 +13823,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -14460,9 +14444,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
-      "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
+      "integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -14621,22 +14605,14 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
-      "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.3.0.tgz",
+      "integrity": "sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",
-        "webidl-conversions": "^5.0.0"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-          "dev": true
-        }
+        "webidl-conversions": "^6.1.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "globby": "^11.0.1",
     "google-spreadsheet": "^3.0.11",
     "i18next": "19.7.0",
-    "jest": "^26.1.0",
+    "jest": "^26.4.2",
     "jest-serializer-html": "^7.0.0",
     "js-yaml": "^3.14.0",
     "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "google-spreadsheet": "^3.0.11",
     "i18next": "19.7.0",
     "jest": "^26.1.0",
+    "jest-serializer-html": "^7.0.0",
     "js-yaml": "^3.14.0",
     "mkdirp": "^1.0.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
This adds [jest-serializer-html](https://github.com/rayrutjes/jest-serializer-html) to serialize HTML snapshots in a way that's easier to diff, and introduces a new "snapshots" test suite that generates HTML for a bunch of different form component types and scenarios (required, for instance).

The idea here is that if you break a snapshot, you will need to run `npx jest -u` to update it, then inspect the diff of `__tests__/__snapshots__/snapshots.js.snap` to **make sure that the diff is acceptable before committing**.