### PR TITLE
Add fieldset component example, fix CSS

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -30,7 +30,7 @@ exports[`component snapshots component "address" scenario: basic matches the sna
             </div>
             <div ref="nested-address">
               <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1  required"
                    id="address-basic-3"
               >
                 <label for="input-address-basic-3"
@@ -58,7 +58,7 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                 </div>
               </div>
               <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2"
                    id="address-basic-4"
               >
                 <label for="input-address-basic-4"
@@ -85,7 +85,7 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                 </div>
               </div>
               <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city  required"
                    id="address-basic-5"
               >
                 <label for="input-address-basic-5"
@@ -113,7 +113,7 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                 </div>
               </div>
               <div ref="component"
-                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+                   class="row formio-component formio-component-columns formio-component-columns  formio-component-label-hidden"
                    id="address-basic-6"
               >
                 <label for="input-address-basic-6"
@@ -234,7 +234,7 @@ exports[`component snapshots component "address" scenario: required matches the 
             </div>
             <div ref="nested-address">
               <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1 mb-1 required"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line1  required"
                    id="address-required-3"
               >
                 <label for="input-address-required-3"
@@ -262,7 +262,7 @@ exports[`component snapshots component "address" scenario: required matches the 
                 </div>
               </div>
               <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2 mb-1"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-line2"
                    id="address-required-4"
               >
                 <label for="input-address-required-4"
@@ -289,7 +289,7 @@ exports[`component snapshots component "address" scenario: required matches the 
                 </div>
               </div>
               <div ref="component"
-                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city mb-1 required"
+                   class="form-group has-feedback formio-component formio-component-textfield formio-component-city  required"
                    id="address-required-5"
               >
                 <label for="input-address-required-5"
@@ -317,7 +317,7 @@ exports[`component snapshots component "address" scenario: required matches the 
                 </div>
               </div>
               <div ref="component"
-                   class="row formio-component formio-component-columns formio-component-columns mb-0 formio-component-label-hidden"
+                   class="row formio-component formio-component-columns formio-component-columns  formio-component-label-hidden"
                    id="address-required-6"
               >
                 <label for="input-address-required-6"

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -35,27 +35,23 @@ const defaultSchema = {
       key: 'line1',
       type: 'textfield',
       input: true,
-      validate: { required: true },
-      customClass: 'mb-1'
+      validate: { required: true }
     },
     {
       label: 'Address line 2',
       key: 'line2',
       type: 'textfield',
-      input: true,
-      customClass: 'mb-1'
+      input: true
     },
     {
       label: 'City',
       key: 'city',
       type: 'textfield',
       validate: { required: true },
-      defaultValue: 'San Francisco',
-      customClass: 'mb-1'
+      defaultValue: 'San Francisco'
     },
     {
       type: 'columns',
-      customClass: 'mb-0',
       columns: [
         {
           width: 6,

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -141,6 +141,38 @@
             key: age
             label: Your age
 
+- id: well
+  title: Well
+  form:
+    components:
+      - type: well
+        label: This is the well label
+        description: This is the well description
+        components:
+          - type: textfield
+            key: name
+            label: Your name
+          - type: number
+            key: age
+            label: Your age
+
+- id: fieldest-well
+  title: Fieldset in a well
+  form:
+    components:
+      - type: fieldset
+        legend: This is the legend
+        description: This is the description
+        components:
+          - type: well
+            components:
+              - type: textfield
+                key: name
+                label: Your name
+              - type: number
+                key: age
+                label: Your age
+
 - id: review
   title: Review (custom component)
   options:

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -126,6 +126,21 @@
         description: This is the description
         tooltip: And this is the tooltip
 
+- id: fieldest
+  title: Fieldset
+  form:
+    components:
+      - type: fieldset
+        legend: This is the legend
+        description: This is the description
+        components:
+          - type: textfield
+            key: name
+            label: Your name
+          - type: number
+            key: age
+            label: Your age
+
 - id: review
   title: Review (custom component)
   options:

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -160,11 +160,11 @@
   title: Fieldset in a well
   form:
     components:
-      - type: fieldset
-        legend: This is the legend
-        description: This is the description
+      - type: well
         components:
-          - type: well
+          - type: fieldset
+            legend: This is the fieldset legend
+            description: This is the fieldset description
             components:
               - type: textfield
                 key: name

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -126,7 +126,7 @@
         description: This is the description
         tooltip: And this is the tooltip
 
-- id: fieldest
+- id: fieldset
   title: Fieldset
   form:
     components:
@@ -156,7 +156,7 @@
             key: age
             label: Your age
 
-- id: fieldest-well
+- id: fieldset-well
   title: Fieldset in a well
   form:
     components:

--- a/src/scss/forms/_fieldsets.scss
+++ b/src/scss/forms/_fieldsets.scss
@@ -1,5 +1,4 @@
-fieldset,
-.well {
+fieldset {
   border: 0;
   margin: 0;
   padding: 0.01em 0 0 0;
@@ -9,7 +8,10 @@ fieldset,
     display: table;
     padding: 0;
   }
+}
 
+fieldset,
+.well {
   * label {
     font-size: 16px;
   }

--- a/src/scss/forms/_fieldsets.scss
+++ b/src/scss/forms/_fieldsets.scss
@@ -1,4 +1,5 @@
-fieldset {
+fieldset,
+.well {
   border: 0;
   margin: 0;
   padding: 0.01em 0 0 0;
@@ -9,7 +10,7 @@ fieldset {
     padding: 0;
   }
 
-  label {
+  * label {
     font-size: 16px;
   }
 

--- a/src/scss/forms/_fieldsets.scss
+++ b/src/scss/forms/_fieldsets.scss
@@ -12,6 +12,14 @@ fieldset {
   label {
     font-size: 16px;
   }
+
+  .formio-component {
+    margin-bottom: spacer(2);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .formio-component-radio {

--- a/src/templates/fieldset/form.ejs
+++ b/src/templates/fieldset/form.ejs
@@ -6,7 +6,7 @@
 
     {% const desc = ctx.tk('description') %}
     {% if (desc) { %}
-      <div class="f-2 fg-light-slate mb-1">{{ desc }}</div>
+      <div class="f-2 mb-1">{{ desc }}</div>
     {% } %}
 
     <div ref="{{ctx.nestedKey}}">

--- a/src/templates/fieldset/form.ejs
+++ b/src/templates/fieldset/form.ejs
@@ -1,16 +1,14 @@
-<fieldset class="bg-blue-1 round-1">
-  <div class="p-2">
-    <legend class="f-3" ref="header">
-      {{ ctx.tk('legend') }}
-    </legend>
+<fieldset>
+  <legend class="f-3" ref="header">
+    {{ ctx.tk('legend') }}
+  </legend>
 
-    {% const desc = ctx.tk('description') %}
-    {% if (desc) { %}
-      <div class="f-2 mb-1">{{ desc }}</div>
-    {% } %}
+  {% const desc = ctx.tk('description') %}
+  {% if (desc) { %}
+    <div class="f-2 mb-1">{{ desc }}</div>
+  {% } %}
 
-    <div ref="{{ctx.nestedKey}}">
-      {{ctx.children}}
-    </div>
+  <div ref="{{ctx.nestedKey}}">
+    {{ctx.children}}
   </div>
 </fieldset>

--- a/src/templates/message/form.ejs
+++ b/src/templates/message/form.ejs
@@ -1,4 +1,4 @@
-<div class="message message-{{ ctx.level }} small my-1">
+<div class="message message-{{ ctx.level }} small mt-1">
   <span class="d-inline-block v-align-middle mr-1" data-icon="{{ ctx.level }}" data-height="15"></span>
   {{ ctx.message }}
 </div>

--- a/src/templates/well/form.ejs
+++ b/src/templates/well/form.ejs
@@ -1,8 +1,16 @@
 {% const visible = ctx.component.properties.visible !== "false" %}
-<div ref="{{ ctx.nestedKey }}" class="{{ visible ? ' bg-blue-1 p-2 round-1' : '' }}">
+<div aria-labelledby="label-{{ ctx.id }}" ref="{{ ctx.nestedKey }}" class="well{{ visible ? ' bg-blue-1 round-1 p-2' : '' }}">
+  {% const label = ctx.tk('label') %}
+  {% if (label) { %}
+    <label class="f-3" id="label-{{ ctx.id }}">
+      {{ label }}
+    </label>
+  {% } %}
+
   {% const desc = ctx.tk('description') %}
   {% if (desc) { %}
-    <p class="description mt-0 mb-1">{{ desc }}</p>
+    <div class="mb-1">{{ desc }}</div>
   {% } %}
+
   {{ ctx.children }}
 </div>


### PR DESCRIPTION
This removes the blue background from the `fieldset` components, and adds a couple of new component examples to demo on the site:

1. One for the [`fieldset` component](https://formio-sfds-git-fieldset-example.sfds.vercel.app/examples/fieldset)
2. Another for the [`well` component](https://formio-sfds-git-fieldset-example.sfds.vercel.app/examples/well)
3. And yet another demonstrating how to [wrap a `fieldset` in a `well`](https://formio-sfds-git-fieldset-example.sfds.vercel.app/examples/fieldset-well) to give it the blue background

Currently, only the `well` and `address` components get the blue background out of the box.