### PR TITLE
fix syntax error in standalone.html view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "The Form.io theme for sf.gov",
   "module": "src/index.js",
   "browser": "dist/formio-sfds.standalone.js",

--- a/views/standalone.html
+++ b/views/standalone.html
@@ -35,7 +35,7 @@
         unlockNavigation: params.get('nav') !== 'false',
         i18n: tryParse(params.get('i18n')),
         googleTranslate: params.get('googleTranslate') === 'true',
-        prefill: params
+        prefill: params,
         properties: tryParse(params.get('properties'))
       }
 


### PR DESCRIPTION
This is a hotfix for the "standalone" view of the Vercel app. No JS or CSS is changing in the library itself!