### PR TITLE
Add preview (proxy) endpoint

### DIFF
--- a/api/preview.js
+++ b/api/preview.js
@@ -9,7 +9,6 @@ const envUrls = {
   test: 'https://test-sfgov.pantheonsite.io'
 }
 
-const scriptSource = readFileSync('./dist/formio-sfds.standalone.js', 'utf8')
 const banner = '/** injected by formio-sfds proxy */'
 const footer = banner
 
@@ -42,6 +41,7 @@ module.exports = (req, res) => {
           script.setAttribute('src', script.src.replace(/formio-sfds@[^/]+/, `formio-sfds@${version}`))
         } else {
           script.removeAttribute('src')
+          const scriptSource = readFileSync('./dist/formio-sfds.standalone.js', 'utf8')
           script.textContent = `${banner}${scriptSource}${footer}`
         }
       } else {

--- a/api/preview.js
+++ b/api/preview.js
@@ -81,13 +81,12 @@ module.exports = (req, res) => {
                 <dt><b>Fetched URL</b></dt>
                 <dd class="mb-1 ml-2">
                   <a href="${fetchUrl}"><code>${fetchUrl}</code></a>
+                  ${env ? `(via <code>env=${env}</code>)` : ''}
                 </dd>
 
                 <dt><b>Form URL</b></dt>
                 <dd class="mb-1 ml-2">${
                   source ? `<a href="${source}"><code>${source}</code></a>` : 'not provided'
-                } ${
-                  env ? `(via <code>env=${env}</code>)` : ''
                 }</dd>
 
                 <dt><b>Theme version</b></dt>

--- a/api/preview.js
+++ b/api/preview.js
@@ -1,0 +1,105 @@
+const fetch = require('node-fetch')
+const { URL } = require('url')
+const { JSDOM } = require('jsdom')
+const { readFileSync } = require('fs')
+
+const LIVE_URL = 'https://sf.gov'
+
+const envUrls = {
+  test: 'https://test-sfgov.pantheonsite.io'
+}
+
+const scriptSource = readFileSync(require.resolve('../dist/formio-sfds.standalone.js'), 'utf8')
+const banner = '/** injected by formio-sfds proxy */'
+const footer = banner
+
+module.exports = (req, res) => {
+  const { host, protocol = 'https', url } = req
+  const proxyUrl = new URL(`${protocol}://${host}${url}`)
+
+  const {
+    form: source,
+    options,
+    version,
+    env
+  } = req.query
+
+  res.setHeader('Content-Type', 'text/html')
+
+  const baseUrl = (env ? envUrls[env] : null) || LIVE_URL
+  const fetchUrl = `${baseUrl}/feedback`
+
+  fetch(fetchUrl)
+    .then(fetched => fetched.text())
+    .then(body => {
+      const dom = new JSDOM(body)
+      const { document } = dom.window
+
+      const script = document.querySelector('script[src*=formio-sfds]')
+      if (script) {
+        if (version) {
+          script.setAttribute('src', script.src.replace(/formio-sfds@[^/]+/, `formio-sfds@${version}`))
+        } else {
+          script.removeAttribute('src')
+          script.textContent = `${banner}${scriptSource}${footer}`
+        }
+      } else {
+        console.warn(
+          'no formio-sfds <script> found in:',
+          Array.from(document.querySelectorAll('script')).map(el => el.src)
+        )
+      }
+
+      const div = document.querySelector('[data-source]')
+      if (div) {
+        if (source) {
+          div.setAttribute('data-source', source)
+        }
+        if (options) {
+          div.setAttribute('data-options', options)
+        }
+        const header = document.createElement('div')
+        header.classList.add('formio-sfds')
+        header.innerHTML = `
+          <details>
+            <summary class="m-0">⚠️ This is a preview of your form</summary>
+            <div class="bg-red-1 p-2 border-1 border-bright-blue round-bottom-1">
+              <p class="mt-0 mb-1">
+                You are viewing this form in a simulated sf.gov environment.
+                The form should function as expected, and styles should reflect
+                what you will see when this version of <code>formio-sfds</code>
+                is used on sf.gov. Some additional information is listed below.
+              </p>
+              <ul class="m-0 pl-2">
+                <li><b>This URL</b>: <a href="${proxyUrl}"><code>${proxyUrl}</code></a></li>
+                <li><b>Fetched URL</b>: <a href="${fetchUrl}"><code>${fetchUrl}</code></a></li>
+                <li><b>Form URL</b>: ${
+                  source ? `<a href="${source}"><code>${source}</code></a>` : 'not provided'
+                } ${
+                  env ? `(via env "${env}")` : ''
+                }</li>
+                <li><b>formio-sfds version</b>: ${
+                  version ? `<code>${version}</code>` : 'not provided (injected built JS)'
+                }</li>
+              </ul>
+            </div>
+          </details>
+        `.trim()
+        div.parentNode.insertBefore(header, div)
+      } else {
+        console.warn('no [data-source] form element found!')
+      }
+
+      const base = document.createElement('base')
+      base.setAttribute('href', baseUrl)
+      document.head.insertBefore(base, document.head.firstChild)
+
+      const html = dom.serialize()
+      res.setHeader('Content-Length', Buffer.byteLength(html))
+      res.end(html, 'utf8')
+    })
+    .catch(error => {
+      res.statusCode = 500
+      res.end(`Sorry, there was an error: <pre>${error.message}</pre>`)
+    })
+}

--- a/api/preview.js
+++ b/api/preview.js
@@ -41,8 +41,7 @@ module.exports = (req, res) => {
           script.textContent = `
             var script = document.createElement('script')
             var baseUrl = [
-              location.protocol, '/',
-              location.hostname,
+              location.protocol, '//', location.hostname,
               location.port ? ':' + location.port : ''
             ].join('')
             script.src = baseUrl + '/dist/formio-sfds.standalone.js'

--- a/api/preview.js
+++ b/api/preview.js
@@ -9,7 +9,7 @@ const envUrls = {
   test: 'https://test-sfgov.pantheonsite.io'
 }
 
-const scriptSource = readFileSync(require.resolve('../dist/formio-sfds.standalone.js'), 'utf8')
+const scriptSource = readFileSync('./dist/formio-sfds.standalone.js', 'utf8')
 const banner = '/** injected by formio-sfds proxy */'
 const footer = banner
 
@@ -21,13 +21,14 @@ module.exports = (req, res) => {
     form: source,
     options,
     version,
-    env
+    env,
+    path = '/feedback'
   } = req.query
 
   res.setHeader('Content-Type', 'text/html')
 
   const baseUrl = (env ? envUrls[env] : null) || LIVE_URL
-  const fetchUrl = `${baseUrl}/feedback`
+  const fetchUrl = `${baseUrl}${path}`
 
   fetch(fetchUrl)
     .then(fetched => fetched.text())


### PR DESCRIPTION
This adds a preview API endpoint to our Vercel deployment that allows us to _proxy_ sf.gov (or test-sfgov) and, at request time:

* Change the form.io data source URL (via the `form` query string parameter, e.g. `form=https://sfds.form.io/somedatasource`)
* Inject a different version of formio-sfds, either via the `version` query string parameter or (by default) replacing the `src` attribute of the `<script>` tag that imports it with the URL of the JS built in this deployment
* Add or change the formio render options JSON via the `options` query string parameter
* Change the path of the URL that's proxied via `path` in the query string (by default it's `/feedback`, but we may wish to change this later)

The HTML that it returns includes an accordion above the form alerting you that you're not looking at a "real" environment, and providing some other information about what's different in the proxied version:

![image](https://user-images.githubusercontent.com/113896/95270656-d6124880-07f0-11eb-8b04-98cffd5617de.png)

You can see it in action at [api/preview](https://formio-sfds-git-proxy-preview.sfds.vercel.app/api/preview) 🎉 