### PR TITLE
Fix well validation issues

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -1562,46 +1562,40 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
            class="formio-component formio-component-panel formio-component-panel"
            id="panel-basic-2"
       >
-        <div class="mb-2 card border">
-          <div ref="header"
-               class="card-header bg-default"
+        <section class="border-1 border-grey-2 p-2 round-1 mb-4"
+                 id="panel-panel"
+        >
+          <h1 class="d1 mt-0 mb-4">
+            Panel
+          </h1>
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
+               id="panel-basic-3"
           >
-            <span class="mb-0 card-title">
-              Panel
-            </span>
-          </div>
-          <div ref="nested-panel"
-               class="card-body"
-          >
-            <div ref="component"
-                 class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
-                 id="panel-basic-3"
+            <label for="input-panel-basic-3"
+                   class
             >
-              <label for="input-panel-basic-3"
-                     class
-              >
-                Your name
-              </label>
-              <div ref="element">
-                <div class="form-input">
-                  <input value
-                         spellcheck="true"
-                         lang="en"
-                         class="form-control"
-                         type="text"
-                         name="data[textField]"
-                         id="input-panel-basic-3"
-                         ref="input"
-                  >
-                </div>
-              </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
+              Your name
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[textField]"
+                       id="input-panel-basic-3"
+                       ref="input"
+                >
               </div>
             </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
           </div>
-        </div>
+        </section>
         <div ref="messageContainer"
              class="messages"
         >
@@ -1636,46 +1630,40 @@ exports[`component snapshots component "panel" scenario: required matches the sn
            class="formio-component formio-component-panel formio-component-panel"
            id="panel-required-2"
       >
-        <div class="mb-2 card border">
-          <div ref="header"
-               class="card-header bg-default"
+        <section class="border-1 border-grey-2 p-2 round-1 mb-4"
+                 id="panel-panel"
+        >
+          <h1 class="d1 mt-0 mb-4">
+            Panel
+          </h1>
+          <div ref="component"
+               class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
+               id="panel-basic-3"
           >
-            <span class="mb-0 card-title">
-              Panel
-            </span>
-          </div>
-          <div ref="nested-panel"
-               class="card-body"
-          >
-            <div ref="component"
-                 class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
-                 id="panel-basic-3"
+            <label for="input-panel-basic-3"
+                   class
             >
-              <label for="input-panel-basic-3"
-                     class
-              >
-                Your name
-              </label>
-              <div ref="element">
-                <div class="form-input">
-                  <input value
-                         spellcheck="true"
-                         lang="en"
-                         class="form-control"
-                         type="text"
-                         name="data[textField]"
-                         id="input-panel-basic-3"
-                         ref="input"
-                  >
-                </div>
-              </div>
-              <div ref="messageContainer"
-                   class="messages"
-              >
+              Your name
+            </label>
+            <div ref="element">
+              <div class="form-input">
+                <input value
+                       spellcheck="true"
+                       lang="en"
+                       class="form-control"
+                       type="text"
+                       name="data[textField]"
+                       id="input-panel-basic-3"
+                       ref="input"
+                >
               </div>
             </div>
+            <div ref="messageContainer"
+                 class="messages"
+            >
+            </div>
           </div>
-        </div>
+        </section>
         <div ref="messageContainer"
              class="messages"
         >

--- a/api/preview.js
+++ b/api/preview.js
@@ -9,11 +9,14 @@ const envUrls = {
 
 module.exports = (req, res) => {
   const {
-    form: source,
-    options,
     version,
     env,
     path = '/feedback'
+  } = req.query
+
+  let {
+    form: source,
+    options
   } = req.query
 
   res.setHeader('Content-Type', 'text/html')
@@ -61,9 +64,13 @@ module.exports = (req, res) => {
       if (div) {
         if (source) {
           div.setAttribute('data-source', source)
+        } else {
+          source = div.getAttribute('data-source')
         }
         if (options) {
           div.setAttribute('data-options', options)
+        } else {
+          options = div.getAttribute('data-options')
         }
         const header = document.createElement('div')
         header.classList.add('formio-sfds')
@@ -84,14 +91,19 @@ module.exports = (req, res) => {
                   ${env ? `(via <code>env=${env}</code>)` : ''}
                 </dd>
 
-                <dt><b>Form URL</b></dt>
+                <dt><b>Theme version</b></dt>
+                <dd class="mb-0 ml-2">${
+                  version ? `version <code>${version}</code>` : 'not provided (injected <a id="formio-sfds-url">built JS</a>)'
+                }</dd>
+
+                <dt><b>Form data source URL</b></dt>
                 <dd class="mb-1 ml-2">${
                   source ? `<a href="${source}"><code>${source}</code></a>` : 'not provided'
                 }</dd>
 
-                <dt><b>Theme version</b></dt>
-                <dd class="mb-0 ml-2">${
-                  version ? `version <code>${version}</code>` : 'not provided (injected <a id="formio-sfds-url">built JS</a>)'
+                <dt><b>Form options</b></dt>
+                <dd class="mb-1 ml-2">${
+                  options ? `<pre>${JSON.stringify(JSON.parse(options), null, 2)}</pre>` : 'none provided'
                 }</dd>
               </ul>
             </div>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "update-translations": "script/get-translations > src/i18n/translations.json",
     "watch": "run-s build-css watch-all",
-    "watch-all": "run-p watch-{css,js,html}",
+    "watch-all": "run-p watch-css watch-js watch-views",
     "watch-css": "watchy -w 'src/scss/**/*.scss' -- npm run build-css",
     "watch-js": "rollup -c --watch",
     "watch-views": "watchy -w 'views/*' -w src/examples.yml -w script/render-views -- npm run build-views",

--- a/src/patch.js
+++ b/src/patch.js
@@ -300,9 +300,13 @@ function patchDateTimeLabels () {
       const { id } = el
       const labelId = `label-${id}`
       const label = el.querySelector(`label[for="input-${id}"]`)
+      if (label) {
+        label.setAttribute('id', labelId)
+      }
       const input = el.querySelector('input.form-control[type=text]')
-      label.setAttribute('id', labelId)
-      input.setAttribute('aria-labelledby', labelId)
+      if (input) {
+        input.setAttribute('aria-labelledby', labelId)
+      }
     }
   })
 }

--- a/src/scss/forms/_fieldsets.scss
+++ b/src/scss/forms/_fieldsets.scss
@@ -1,12 +1,13 @@
 fieldset {
+  padding: 0.01em 0 0 0;
   border: 0;
   margin: 0;
-  padding: 0.01em 0 0 0;
   min-width: 0;
 
   legend {
     display: table;
     padding: 0;
+    margin: 0;
   }
 }
 

--- a/src/scss/forms/_fieldsets.scss
+++ b/src/scss/forms/_fieldsets.scss
@@ -17,12 +17,8 @@ fieldset,
     font-size: 16px;
   }
 
-  .formio-component {
-    margin-bottom: spacer(2);
-
-    &:last-child {
-      margin-bottom: 0;
-    }
+  .formio-component + .formio-component:not(.formio-hidden) {
+    margin-top: spacer(2);
   }
 }
 

--- a/src/scss/forms/_hacks.scss
+++ b/src/scss/forms/_hacks.scss
@@ -14,3 +14,8 @@ textarea:disabled {
   border-color: $grey-4 !important;
   background-color: $grey-1 !important;
 }
+
+select {
+  // undoes the linear-gradient(#fff, #fff) in drupal.css
+  background-image: none;
+}

--- a/src/scss/forms/index.scss
+++ b/src/scss/forms/index.scss
@@ -37,23 +37,10 @@
   }
 }
 
-.formio-component {
-  margin-bottom: spacer(3);
-}
-
-.formio-component-content,
-.formio-component-htmlelement {
-  margin-bottom: 0;
-}
-
-.formio-component-well .formio-component {
-  margin-bottom: spacer(1);
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
 .alert.alert-success {
   display: none;
+}
+
+.formio-component + .formio-component:not(.formio-hidden) {
+  margin-top: spacer(3);
 }

--- a/src/templates/component/form.ejs
+++ b/src/templates/component/form.ejs
@@ -1,6 +1,6 @@
 <div
   id="{{ ctx.id }}"
-  class="{{ ctx.classes }}"
+  class="{{ ctx.classes || (ctx.visible && ctx.component.type === 'well' ? 'formio-component formio-component-well' : '') }}"
   {% if (ctx.styles) { %} style="{{ ctx.styles }}"{% } %}
   ref="component"
 >

--- a/src/templates/panel/form.ejs
+++ b/src/templates/panel/form.ejs
@@ -1,18 +1,8 @@
-<div class="mb-2 card border">
-  <div class="card-header {{ctx.transform('class', 'bg-' + ctx.component.theme)}}" ref="header">
-    <span class="mb-0 card-title">
-      {% if (ctx.component.collapsible) { %}
-        <i class="formio-collapse-icon {{ctx.iconClass(ctx.collapsed ? 'plus-square-o' : 'minus-square-o')}} text-muted" data-title="Collapse Panel"></i>
-      {% } %}
-      {{ctx.t(ctx.component.title)}}
-      {% if (ctx.component.tooltip) { %}
-        <i ref="tooltip" class="{{ctx.iconClass('question-sign')}} text-muted"></i>
-      {% } %}
-    </span>
-  </div>
+<section id="panel-{{ ctx.component.key }}" class="border-1 border-grey-2 p-2 round-1 mb-4">
+  <h1 class="d1 mt-0 mb-4">
+    {{ ctx.tk('title') }}
+  </h1>
   {% if (!ctx.collapsed || ctx.builder) { %}
-  <div class="card-body" ref="{{ctx.nestedKey}}">
     {{ctx.children}}
-  </div>
   {% } %}
-</div>
+</section>

--- a/src/templates/well/form.ejs
+++ b/src/templates/well/form.ejs
@@ -1,11 +1,11 @@
 {% const visible = ctx.component.properties.visible !== "false" %}
-<div aria-labelledby="label-{{ ctx.id }}" ref="{{ ctx.nestedKey }}" class="well{{ visible ? ' bg-blue-1 round-1 p-2' : '' }}">
-  {% if (ctx.component.properties.showLabel === "true") { %}
+<section ref="{{ ctx.nestedKey }}" class="well{{ visible ? ' bg-blue-1 round-1 p-2' : '' }}">
+  {% if (ctx.component.properties.showLabel !== "false") { %}
     {% const label = ctx.tk('label') %}
     {% if (label) { %}
-      <label class="f-3" id="label-{{ ctx.id }}">
+      <h2 class="h4 my-0" id="label-{{ ctx.id }}">
         {{ label }}
-      </label>
+      </h2>
     {% } %}
   {% } %}
 
@@ -15,4 +15,4 @@
   {% } %}
 
   {{ ctx.children }}
-</div>
+</section>

--- a/src/templates/well/form.ejs
+++ b/src/templates/well/form.ejs
@@ -1,10 +1,12 @@
 {% const visible = ctx.component.properties.visible !== "false" %}
 <div aria-labelledby="label-{{ ctx.id }}" ref="{{ ctx.nestedKey }}" class="well{{ visible ? ' bg-blue-1 round-1 p-2' : '' }}">
-  {% const label = ctx.tk('label') %}
-  {% if (label) { %}
-    <label class="f-3" id="label-{{ ctx.id }}">
-      {{ label }}
-    </label>
+  {% if (ctx.component.properties.showLabel === "true") { %}
+    {% const label = ctx.tk('label') %}
+    {% if (label) { %}
+      <label class="f-3" id="label-{{ ctx.id }}">
+        {{ label }}
+      </label>
+    {% } %}
   {% } %}
 
   {% const desc = ctx.tk('description') %}

--- a/src/templates/wizard/form.ejs
+++ b/src/templates/wizard/form.ejs
@@ -1,6 +1,5 @@
-{% var panel = ctx.panels[ctx.currentPage] %}
-
-<div class="{{ ctx.className }} mb-3">
+{% const panel = ctx.panels[ctx.currentPage] %}
+<div class="{{ ctx.className }} mb-4">
   <div class="d-flex flex-column flex-md-row flex-md-auto flex-justify-between">
     <div class="col-md-2">
       {% if (!panel.properties.hideSidebar || panel.properties.hideSidebar !== "true") { %}
@@ -9,13 +8,11 @@
     </div>
     <div class="col-md-4">
       <div class="mb-3">
-        <div class="mb-4">
-          {% if (panel) { %}
-          <h1 class="d1 mr-n2">
+        {% if (panel) { %}
+          <h1 class="d1 mb-4 mr-n2">
             {{ ctx.t(panel.properties.displayTitle || panel.title) }}
           </h1>
-          {% } %}
-        </div>
+        {% } %}
         <div class="components" ref="{{ ctx.wizardKey }}">
           {{ ctx.components }}
         </div>


### PR DESCRIPTION
@nlsfds and I discovered a very strange issue when testing the 6.3.0 release with [this form](https://portal.form.io/#/project/5e6febe6392a752112cf954a/form/5eb091762855d945d60bd5c7/edit). To reproduce it:

1. Load up the [proxy preview of 6.3.0 with the form](https://formio-sfds-git-proxy-preview.sfds.vercel.app/api/preview?form=https://sfds.form.io/stagingbuildingpermitapplication&version=6.3.0)
2. On the "About you" page, select "Attorney in fact" (or, I believe, any option _except_ "Owner")
3. Fill in the remaining required fields to proceed to the next page
4. On the "Project team" page, click the "Next" button. You should see an odd state in which none of the fields are marked as invalid, but the error list appears below:

    ![image](https://user-images.githubusercontent.com/113896/95922488-3280e500-0d68-11eb-98da-1e554a2dff86.png)

I don't know why this is happening, but my _hunch_ is that we're rendering improperly nested HTML in one or more of our templates, and changing `well` components to render `<section>` elements provides a better "hint" to HTML parsers that the element is closed.