### PR TITLE
Release 6.4.2

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -122,7 +122,7 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                      class="col-md-6 mr-md-2"
                 >
                   <div ref="component"
-                       class="form-group has-feedback formio-component formio-component-state formio-component-state  required"
+                       class="form-group has-feedback formio-component formio-component-state formio-component-state mb-sm-2 required"
                        id="address-basic-7"
                   >
                     <label for="input-address-basic-7"
@@ -317,7 +317,7 @@ exports[`component snapshots component "address" scenario: required matches the 
                      class="col-md-6 mr-md-2"
                 >
                   <div ref="component"
-                       class="form-group has-feedback formio-component formio-component-state formio-component-state  required"
+                       class="form-group has-feedback formio-component formio-component-state formio-component-state mb-sm-2 required"
                        id="address-required-7"
                   >
                     <label for="input-address-required-7"

--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -122,7 +122,7 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                      class="col-md-6 mr-md-2"
                 >
                   <div ref="component"
-                       class="form-group has-feedback formio-component formio-component-state formio-component-state mb-sm-2 required"
+                       class="form-group has-feedback formio-component formio-component-state formio-component-state mb-2 mb-md-0 required"
                        id="address-basic-7"
                   >
                     <label for="input-address-basic-7"
@@ -317,7 +317,7 @@ exports[`component snapshots component "address" scenario: required matches the 
                      class="col-md-6 mr-md-2"
                 >
                   <div ref="component"
-                       class="form-group has-feedback formio-component formio-component-state formio-component-state mb-sm-2 required"
+                       class="form-group has-feedback formio-component formio-component-state formio-component-state mb-2 mb-md-0 required"
                        id="address-required-7"
                   >
                     <label for="input-address-required-7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio-sfds",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "The Form.io theme for sf.gov",
   "module": "src/index.js",
   "browser": "dist/formio-sfds.standalone.js",

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -86,6 +86,7 @@ const defaultSchema = {
               key: 'state',
               type: 'state',
               input: true,
+              customClass: 'mb-sm-2',
               validate: { required: true }
             }
           ]

--- a/src/components/address.js
+++ b/src/components/address.js
@@ -86,7 +86,7 @@ const defaultSchema = {
               key: 'state',
               type: 'state',
               input: true,
-              customClass: 'mb-sm-2',
+              customClass: 'mb-2 mb-md-0',
               validate: { required: true }
             }
           ]

--- a/src/scss/flexbox/index.scss
+++ b/src/scss/flexbox/index.scss
@@ -43,7 +43,7 @@ $FLEX-JUSTIFY-CONTENT: (
     }
 
     @each $wrap in $FLEX-WRAPS {
-      .flex#{$variant}-#{$wrap} { flex-direction: #{$wrap} !important; }
+      .flex#{$variant}-#{$wrap} { flex-wrap: #{$wrap} !important; }
     }
 
     @each $key, $value in $FLEX-ALIGN-ITEMS {

--- a/src/scss/utilities/_display.scss
+++ b/src/scss/utilities/_display.scss
@@ -1,6 +1,6 @@
-@each $display in (block, flex, inline, inline-block, inline-flex, none) {
-  @each $variant, $threshold in $breakpoint-variants {
-    @include breakpoint($threshold) {
+@each $variant, $threshold in $breakpoint-variants {
+  @include breakpoint($threshold) {
+    @each $display in (block, flex, inline, inline-block, inline-flex, none) {
       .d#{$variant}-#{$display + ""} { display: $display !important; }
     }
   }

--- a/src/scss/utilities/_position.scss
+++ b/src/scss/utilities/_position.scss
@@ -1,5 +1,7 @@
-@each $position in (relative, absolute, fixed, sticky) {
-  @each $variant, $threshold in $breakpoint-variants {
-    .position#{$variant}-#{$position} { position: $position !important; }
+@each $variant, $threshold in $breakpoint-variants {
+  @include breakpoint($threshold) {
+    @each $position in (relative, absolute, fixed, sticky) {
+      .position#{$variant}-#{$position} { position: $position !important; }
+    }
   }
 }

--- a/src/scss/utilities/_spacing.scss
+++ b/src/scss/utilities/_spacing.scss
@@ -1,8 +1,8 @@
-@each $index, $space in $spacers {
-  @each $variant, $threshold in $breakpoint-variants {
-    $suffix: "#{$variant}-#{$index}";
+@each $variant, $threshold in $breakpoint-variants {
+  @include breakpoint($threshold) {
+    @each $index, $space in $spacers {
+      $suffix: "#{$variant}-#{$index}";
 
-    @include breakpoint($threshold) {
       .m#{$suffix} { margin: $space !important; }
       .p#{$suffix} { padding: $space !important; }
 

--- a/views/portal.html
+++ b/views/portal.html
@@ -11,6 +11,8 @@
   <body>
     <div class="p-4">
       <div id="builder"></div>
+
+      <pre id="schema-json" class="bg-grey-1 p-2 mt-2"></pre>
     </div>
 
     <script src="https://unpkg.com/formiojs@latest/dist/formio.full.min.js"></script>
@@ -19,10 +21,14 @@
       (() => {
 
         const root = document.getElementById('builder')
+        const schemaJSON = document.getElementById('schema-json')
         const params = new URLSearchParams(window.location.search)
         const resource = params.get('res') || {}
 
         Formio.builder(root, resource, {}).then(builder => {
+          builder.on('saveComponent', () => {
+            schemaJSON.textContent = JSON.stringify(builder.schema, null, 2)
+          })
         })
 
       })()


### PR DESCRIPTION
### 🐛  Bug fixes
- Fixes an issue with the state and ZIP code inputs being too close to one another on smaller screens, as reported by @nlsfds:

    ![image](https://user-images.githubusercontent.com/113896/96624560-c3ecdb80-12c1-11eb-87ce-925543f4da33.png)

- Fixes the output order of many of our responsive CSS utility classes. Previously, each _value_ was output sequentially, which gave precedence to classes with higher values. (For instance, `mb-2` was output after `mb-*-0`, so it was impossible to use `mb-2 mb-md-0`.) Now, we output breakpoint media queries sequentially, _then_ values, so that responsive utilities have precedence over non-responsive ones. This is what allows `mb-2 mb-md-0` ("bottom margin 2 by default, 0 at the medium breakpoint and above") to work.