### PR TITLE
Include U.S. territories in "state" component

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -145,258 +145,156 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                       <option value
                               selected="selected"
                       >
-                        <span>
-                        </span>
                       </option>
                       <option value="AL">
-                        <span>
-                          Alabama
-                        </span>
+                        Alabama
                       </option>
                       <option value="AK">
-                        <span>
-                          Alaska
-                        </span>
+                        Alaska
                       </option>
                       <option value="AZ">
-                        <span>
-                          Arizona
-                        </span>
+                        Arizona
                       </option>
                       <option value="AR">
-                        <span>
-                          Arkansas
-                        </span>
+                        Arkansas
                       </option>
                       <option value="CA">
-                        <span>
-                          California
-                        </span>
+                        California
                       </option>
                       <option value="CO">
-                        <span>
-                          Colorado
-                        </span>
+                        Colorado
                       </option>
                       <option value="CT">
-                        <span>
-                          Connecticut
-                        </span>
+                        Connecticut
                       </option>
                       <option value="DE">
-                        <span>
-                          Delaware
-                        </span>
+                        Delaware
                       </option>
                       <option value="FL">
-                        <span>
-                          Florida
-                        </span>
+                        Florida
                       </option>
                       <option value="GA">
-                        <span>
-                          Georgia
-                        </span>
+                        Georgia
                       </option>
                       <option value="HI">
-                        <span>
-                          Hawaii
-                        </span>
+                        Hawaii
                       </option>
                       <option value="ID">
-                        <span>
-                          Idaho
-                        </span>
+                        Idaho
                       </option>
                       <option value="IL">
-                        <span>
-                          Illinois
-                        </span>
+                        Illinois
                       </option>
                       <option value="IN">
-                        <span>
-                          Indiana
-                        </span>
+                        Indiana
                       </option>
                       <option value="IA">
-                        <span>
-                          Iowa
-                        </span>
+                        Iowa
                       </option>
                       <option value="KS">
-                        <span>
-                          Kansas
-                        </span>
+                        Kansas
                       </option>
                       <option value="KY">
-                        <span>
-                          Kentucky
-                        </span>
+                        Kentucky
                       </option>
                       <option value="LA">
-                        <span>
-                          Louisiana
-                        </span>
+                        Louisiana
                       </option>
                       <option value="ME">
-                        <span>
-                          Maine
-                        </span>
+                        Maine
                       </option>
                       <option value="MD">
-                        <span>
-                          Maryland
-                        </span>
+                        Maryland
                       </option>
                       <option value="MA">
-                        <span>
-                          Massachusetts
-                        </span>
+                        Massachusetts
                       </option>
                       <option value="MI">
-                        <span>
-                          Michigan
-                        </span>
+                        Michigan
                       </option>
                       <option value="MN">
-                        <span>
-                          Minnesota
-                        </span>
+                        Minnesota
                       </option>
                       <option value="MS">
-                        <span>
-                          Mississippi
-                        </span>
+                        Mississippi
                       </option>
                       <option value="MO">
-                        <span>
-                          Missouri
-                        </span>
+                        Missouri
                       </option>
                       <option value="MT">
-                        <span>
-                          Montana
-                        </span>
+                        Montana
                       </option>
                       <option value="NE">
-                        <span>
-                          Nebraska
-                        </span>
+                        Nebraska
                       </option>
                       <option value="NV">
-                        <span>
-                          Nevada
-                        </span>
+                        Nevada
                       </option>
                       <option value="NH">
-                        <span>
-                          New Hampshire
-                        </span>
+                        New Hampshire
                       </option>
                       <option value="NJ">
-                        <span>
-                          New Jersey
-                        </span>
+                        New Jersey
                       </option>
                       <option value="NM">
-                        <span>
-                          New Mexico
-                        </span>
+                        New Mexico
                       </option>
                       <option value="NY">
-                        <span>
-                          New York
-                        </span>
+                        New York
                       </option>
                       <option value="NC">
-                        <span>
-                          North Carolina
-                        </span>
+                        North Carolina
                       </option>
                       <option value="ND">
-                        <span>
-                          North Dakota
-                        </span>
+                        North Dakota
                       </option>
                       <option value="OH">
-                        <span>
-                          Ohio
-                        </span>
+                        Ohio
                       </option>
                       <option value="OK">
-                        <span>
-                          Oklahoma
-                        </span>
+                        Oklahoma
                       </option>
                       <option value="OR">
-                        <span>
-                          Oregon
-                        </span>
+                        Oregon
                       </option>
                       <option value="PA">
-                        <span>
-                          Pennsylvania
-                        </span>
+                        Pennsylvania
                       </option>
                       <option value="RI">
-                        <span>
-                          Rhode Island
-                        </span>
+                        Rhode Island
                       </option>
                       <option value="SC">
-                        <span>
-                          South Carolina
-                        </span>
+                        South Carolina
                       </option>
                       <option value="SD">
-                        <span>
-                          South Dakota
-                        </span>
+                        South Dakota
                       </option>
                       <option value="TN">
-                        <span>
-                          Tennessee
-                        </span>
+                        Tennessee
                       </option>
                       <option value="TX">
-                        <span>
-                          Texas
-                        </span>
+                        Texas
                       </option>
                       <option value="UT">
-                        <span>
-                          Utah
-                        </span>
+                        Utah
                       </option>
                       <option value="VT">
-                        <span>
-                          Vermont
-                        </span>
+                        Vermont
                       </option>
                       <option value="VA">
-                        <span>
-                          Virginia
-                        </span>
+                        Virginia
                       </option>
                       <option value="WA">
-                        <span>
-                          Washington
-                        </span>
+                        Washington
                       </option>
                       <option value="WV">
-                        <span>
-                          West Virginia
-                        </span>
+                        West Virginia
                       </option>
                       <option value="WI">
-                        <span>
-                          Wisconsin
-                        </span>
+                        Wisconsin
                       </option>
                       <option value="WY">
-                        <span>
-                          Wyoming
-                        </span>
+                        Wyoming
                       </option>
                     </select>
                     <div ref="messageContainer"
@@ -600,258 +498,156 @@ exports[`component snapshots component "address" scenario: required matches the 
                       <option value
                               selected="selected"
                       >
-                        <span>
-                        </span>
                       </option>
                       <option value="AL">
-                        <span>
-                          Alabama
-                        </span>
+                        Alabama
                       </option>
                       <option value="AK">
-                        <span>
-                          Alaska
-                        </span>
+                        Alaska
                       </option>
                       <option value="AZ">
-                        <span>
-                          Arizona
-                        </span>
+                        Arizona
                       </option>
                       <option value="AR">
-                        <span>
-                          Arkansas
-                        </span>
+                        Arkansas
                       </option>
                       <option value="CA">
-                        <span>
-                          California
-                        </span>
+                        California
                       </option>
                       <option value="CO">
-                        <span>
-                          Colorado
-                        </span>
+                        Colorado
                       </option>
                       <option value="CT">
-                        <span>
-                          Connecticut
-                        </span>
+                        Connecticut
                       </option>
                       <option value="DE">
-                        <span>
-                          Delaware
-                        </span>
+                        Delaware
                       </option>
                       <option value="FL">
-                        <span>
-                          Florida
-                        </span>
+                        Florida
                       </option>
                       <option value="GA">
-                        <span>
-                          Georgia
-                        </span>
+                        Georgia
                       </option>
                       <option value="HI">
-                        <span>
-                          Hawaii
-                        </span>
+                        Hawaii
                       </option>
                       <option value="ID">
-                        <span>
-                          Idaho
-                        </span>
+                        Idaho
                       </option>
                       <option value="IL">
-                        <span>
-                          Illinois
-                        </span>
+                        Illinois
                       </option>
                       <option value="IN">
-                        <span>
-                          Indiana
-                        </span>
+                        Indiana
                       </option>
                       <option value="IA">
-                        <span>
-                          Iowa
-                        </span>
+                        Iowa
                       </option>
                       <option value="KS">
-                        <span>
-                          Kansas
-                        </span>
+                        Kansas
                       </option>
                       <option value="KY">
-                        <span>
-                          Kentucky
-                        </span>
+                        Kentucky
                       </option>
                       <option value="LA">
-                        <span>
-                          Louisiana
-                        </span>
+                        Louisiana
                       </option>
                       <option value="ME">
-                        <span>
-                          Maine
-                        </span>
+                        Maine
                       </option>
                       <option value="MD">
-                        <span>
-                          Maryland
-                        </span>
+                        Maryland
                       </option>
                       <option value="MA">
-                        <span>
-                          Massachusetts
-                        </span>
+                        Massachusetts
                       </option>
                       <option value="MI">
-                        <span>
-                          Michigan
-                        </span>
+                        Michigan
                       </option>
                       <option value="MN">
-                        <span>
-                          Minnesota
-                        </span>
+                        Minnesota
                       </option>
                       <option value="MS">
-                        <span>
-                          Mississippi
-                        </span>
+                        Mississippi
                       </option>
                       <option value="MO">
-                        <span>
-                          Missouri
-                        </span>
+                        Missouri
                       </option>
                       <option value="MT">
-                        <span>
-                          Montana
-                        </span>
+                        Montana
                       </option>
                       <option value="NE">
-                        <span>
-                          Nebraska
-                        </span>
+                        Nebraska
                       </option>
                       <option value="NV">
-                        <span>
-                          Nevada
-                        </span>
+                        Nevada
                       </option>
                       <option value="NH">
-                        <span>
-                          New Hampshire
-                        </span>
+                        New Hampshire
                       </option>
                       <option value="NJ">
-                        <span>
-                          New Jersey
-                        </span>
+                        New Jersey
                       </option>
                       <option value="NM">
-                        <span>
-                          New Mexico
-                        </span>
+                        New Mexico
                       </option>
                       <option value="NY">
-                        <span>
-                          New York
-                        </span>
+                        New York
                       </option>
                       <option value="NC">
-                        <span>
-                          North Carolina
-                        </span>
+                        North Carolina
                       </option>
                       <option value="ND">
-                        <span>
-                          North Dakota
-                        </span>
+                        North Dakota
                       </option>
                       <option value="OH">
-                        <span>
-                          Ohio
-                        </span>
+                        Ohio
                       </option>
                       <option value="OK">
-                        <span>
-                          Oklahoma
-                        </span>
+                        Oklahoma
                       </option>
                       <option value="OR">
-                        <span>
-                          Oregon
-                        </span>
+                        Oregon
                       </option>
                       <option value="PA">
-                        <span>
-                          Pennsylvania
-                        </span>
+                        Pennsylvania
                       </option>
                       <option value="RI">
-                        <span>
-                          Rhode Island
-                        </span>
+                        Rhode Island
                       </option>
                       <option value="SC">
-                        <span>
-                          South Carolina
-                        </span>
+                        South Carolina
                       </option>
                       <option value="SD">
-                        <span>
-                          South Dakota
-                        </span>
+                        South Dakota
                       </option>
                       <option value="TN">
-                        <span>
-                          Tennessee
-                        </span>
+                        Tennessee
                       </option>
                       <option value="TX">
-                        <span>
-                          Texas
-                        </span>
+                        Texas
                       </option>
                       <option value="UT">
-                        <span>
-                          Utah
-                        </span>
+                        Utah
                       </option>
                       <option value="VT">
-                        <span>
-                          Vermont
-                        </span>
+                        Vermont
                       </option>
                       <option value="VA">
-                        <span>
-                          Virginia
-                        </span>
+                        Virginia
                       </option>
                       <option value="WA">
-                        <span>
-                          Washington
-                        </span>
+                        Washington
                       </option>
                       <option value="WV">
-                        <span>
-                          West Virginia
-                        </span>
+                        West Virginia
                       </option>
                       <option value="WI">
-                        <span>
-                          Wisconsin
-                        </span>
+                        Wisconsin
                       </option>
                       <option value="WY">
-                        <span>
-                          Wyoming
-                        </span>
+                        Wyoming
                       </option>
                     </select>
                     <div ref="messageContainer"
@@ -2665,258 +2461,156 @@ exports[`component snapshots component "state" scenario: basic matches the snaps
           <option value
                   selected="selected"
           >
-            <span>
-            </span>
           </option>
           <option value="AL">
-            <span>
-              Alabama
-            </span>
+            Alabama
           </option>
           <option value="AK">
-            <span>
-              Alaska
-            </span>
+            Alaska
           </option>
           <option value="AZ">
-            <span>
-              Arizona
-            </span>
+            Arizona
           </option>
           <option value="AR">
-            <span>
-              Arkansas
-            </span>
+            Arkansas
           </option>
           <option value="CA">
-            <span>
-              California
-            </span>
+            California
           </option>
           <option value="CO">
-            <span>
-              Colorado
-            </span>
+            Colorado
           </option>
           <option value="CT">
-            <span>
-              Connecticut
-            </span>
+            Connecticut
           </option>
           <option value="DE">
-            <span>
-              Delaware
-            </span>
+            Delaware
           </option>
           <option value="FL">
-            <span>
-              Florida
-            </span>
+            Florida
           </option>
           <option value="GA">
-            <span>
-              Georgia
-            </span>
+            Georgia
           </option>
           <option value="HI">
-            <span>
-              Hawaii
-            </span>
+            Hawaii
           </option>
           <option value="ID">
-            <span>
-              Idaho
-            </span>
+            Idaho
           </option>
           <option value="IL">
-            <span>
-              Illinois
-            </span>
+            Illinois
           </option>
           <option value="IN">
-            <span>
-              Indiana
-            </span>
+            Indiana
           </option>
           <option value="IA">
-            <span>
-              Iowa
-            </span>
+            Iowa
           </option>
           <option value="KS">
-            <span>
-              Kansas
-            </span>
+            Kansas
           </option>
           <option value="KY">
-            <span>
-              Kentucky
-            </span>
+            Kentucky
           </option>
           <option value="LA">
-            <span>
-              Louisiana
-            </span>
+            Louisiana
           </option>
           <option value="ME">
-            <span>
-              Maine
-            </span>
+            Maine
           </option>
           <option value="MD">
-            <span>
-              Maryland
-            </span>
+            Maryland
           </option>
           <option value="MA">
-            <span>
-              Massachusetts
-            </span>
+            Massachusetts
           </option>
           <option value="MI">
-            <span>
-              Michigan
-            </span>
+            Michigan
           </option>
           <option value="MN">
-            <span>
-              Minnesota
-            </span>
+            Minnesota
           </option>
           <option value="MS">
-            <span>
-              Mississippi
-            </span>
+            Mississippi
           </option>
           <option value="MO">
-            <span>
-              Missouri
-            </span>
+            Missouri
           </option>
           <option value="MT">
-            <span>
-              Montana
-            </span>
+            Montana
           </option>
           <option value="NE">
-            <span>
-              Nebraska
-            </span>
+            Nebraska
           </option>
           <option value="NV">
-            <span>
-              Nevada
-            </span>
+            Nevada
           </option>
           <option value="NH">
-            <span>
-              New Hampshire
-            </span>
+            New Hampshire
           </option>
           <option value="NJ">
-            <span>
-              New Jersey
-            </span>
+            New Jersey
           </option>
           <option value="NM">
-            <span>
-              New Mexico
-            </span>
+            New Mexico
           </option>
           <option value="NY">
-            <span>
-              New York
-            </span>
+            New York
           </option>
           <option value="NC">
-            <span>
-              North Carolina
-            </span>
+            North Carolina
           </option>
           <option value="ND">
-            <span>
-              North Dakota
-            </span>
+            North Dakota
           </option>
           <option value="OH">
-            <span>
-              Ohio
-            </span>
+            Ohio
           </option>
           <option value="OK">
-            <span>
-              Oklahoma
-            </span>
+            Oklahoma
           </option>
           <option value="OR">
-            <span>
-              Oregon
-            </span>
+            Oregon
           </option>
           <option value="PA">
-            <span>
-              Pennsylvania
-            </span>
+            Pennsylvania
           </option>
           <option value="RI">
-            <span>
-              Rhode Island
-            </span>
+            Rhode Island
           </option>
           <option value="SC">
-            <span>
-              South Carolina
-            </span>
+            South Carolina
           </option>
           <option value="SD">
-            <span>
-              South Dakota
-            </span>
+            South Dakota
           </option>
           <option value="TN">
-            <span>
-              Tennessee
-            </span>
+            Tennessee
           </option>
           <option value="TX">
-            <span>
-              Texas
-            </span>
+            Texas
           </option>
           <option value="UT">
-            <span>
-              Utah
-            </span>
+            Utah
           </option>
           <option value="VT">
-            <span>
-              Vermont
-            </span>
+            Vermont
           </option>
           <option value="VA">
-            <span>
-              Virginia
-            </span>
+            Virginia
           </option>
           <option value="WA">
-            <span>
-              Washington
-            </span>
+            Washington
           </option>
           <option value="WV">
-            <span>
-              West Virginia
-            </span>
+            West Virginia
           </option>
           <option value="WI">
-            <span>
-              Wisconsin
-            </span>
+            Wisconsin
           </option>
           <option value="WY">
-            <span>
-              Wyoming
-            </span>
+            Wyoming
           </option>
         </select>
         <div class="fg-light-slate mt-1">
@@ -2976,258 +2670,156 @@ exports[`component snapshots component "state" scenario: required matches the sn
           <option value
                   selected="selected"
           >
-            <span>
-            </span>
           </option>
           <option value="AL">
-            <span>
-              Alabama
-            </span>
+            Alabama
           </option>
           <option value="AK">
-            <span>
-              Alaska
-            </span>
+            Alaska
           </option>
           <option value="AZ">
-            <span>
-              Arizona
-            </span>
+            Arizona
           </option>
           <option value="AR">
-            <span>
-              Arkansas
-            </span>
+            Arkansas
           </option>
           <option value="CA">
-            <span>
-              California
-            </span>
+            California
           </option>
           <option value="CO">
-            <span>
-              Colorado
-            </span>
+            Colorado
           </option>
           <option value="CT">
-            <span>
-              Connecticut
-            </span>
+            Connecticut
           </option>
           <option value="DE">
-            <span>
-              Delaware
-            </span>
+            Delaware
           </option>
           <option value="FL">
-            <span>
-              Florida
-            </span>
+            Florida
           </option>
           <option value="GA">
-            <span>
-              Georgia
-            </span>
+            Georgia
           </option>
           <option value="HI">
-            <span>
-              Hawaii
-            </span>
+            Hawaii
           </option>
           <option value="ID">
-            <span>
-              Idaho
-            </span>
+            Idaho
           </option>
           <option value="IL">
-            <span>
-              Illinois
-            </span>
+            Illinois
           </option>
           <option value="IN">
-            <span>
-              Indiana
-            </span>
+            Indiana
           </option>
           <option value="IA">
-            <span>
-              Iowa
-            </span>
+            Iowa
           </option>
           <option value="KS">
-            <span>
-              Kansas
-            </span>
+            Kansas
           </option>
           <option value="KY">
-            <span>
-              Kentucky
-            </span>
+            Kentucky
           </option>
           <option value="LA">
-            <span>
-              Louisiana
-            </span>
+            Louisiana
           </option>
           <option value="ME">
-            <span>
-              Maine
-            </span>
+            Maine
           </option>
           <option value="MD">
-            <span>
-              Maryland
-            </span>
+            Maryland
           </option>
           <option value="MA">
-            <span>
-              Massachusetts
-            </span>
+            Massachusetts
           </option>
           <option value="MI">
-            <span>
-              Michigan
-            </span>
+            Michigan
           </option>
           <option value="MN">
-            <span>
-              Minnesota
-            </span>
+            Minnesota
           </option>
           <option value="MS">
-            <span>
-              Mississippi
-            </span>
+            Mississippi
           </option>
           <option value="MO">
-            <span>
-              Missouri
-            </span>
+            Missouri
           </option>
           <option value="MT">
-            <span>
-              Montana
-            </span>
+            Montana
           </option>
           <option value="NE">
-            <span>
-              Nebraska
-            </span>
+            Nebraska
           </option>
           <option value="NV">
-            <span>
-              Nevada
-            </span>
+            Nevada
           </option>
           <option value="NH">
-            <span>
-              New Hampshire
-            </span>
+            New Hampshire
           </option>
           <option value="NJ">
-            <span>
-              New Jersey
-            </span>
+            New Jersey
           </option>
           <option value="NM">
-            <span>
-              New Mexico
-            </span>
+            New Mexico
           </option>
           <option value="NY">
-            <span>
-              New York
-            </span>
+            New York
           </option>
           <option value="NC">
-            <span>
-              North Carolina
-            </span>
+            North Carolina
           </option>
           <option value="ND">
-            <span>
-              North Dakota
-            </span>
+            North Dakota
           </option>
           <option value="OH">
-            <span>
-              Ohio
-            </span>
+            Ohio
           </option>
           <option value="OK">
-            <span>
-              Oklahoma
-            </span>
+            Oklahoma
           </option>
           <option value="OR">
-            <span>
-              Oregon
-            </span>
+            Oregon
           </option>
           <option value="PA">
-            <span>
-              Pennsylvania
-            </span>
+            Pennsylvania
           </option>
           <option value="RI">
-            <span>
-              Rhode Island
-            </span>
+            Rhode Island
           </option>
           <option value="SC">
-            <span>
-              South Carolina
-            </span>
+            South Carolina
           </option>
           <option value="SD">
-            <span>
-              South Dakota
-            </span>
+            South Dakota
           </option>
           <option value="TN">
-            <span>
-              Tennessee
-            </span>
+            Tennessee
           </option>
           <option value="TX">
-            <span>
-              Texas
-            </span>
+            Texas
           </option>
           <option value="UT">
-            <span>
-              Utah
-            </span>
+            Utah
           </option>
           <option value="VT">
-            <span>
-              Vermont
-            </span>
+            Vermont
           </option>
           <option value="VA">
-            <span>
-              Virginia
-            </span>
+            Virginia
           </option>
           <option value="WA">
-            <span>
-              Washington
-            </span>
+            Washington
           </option>
           <option value="WV">
-            <span>
-              West Virginia
-            </span>
+            West Virginia
           </option>
           <option value="WI">
-            <span>
-              Wisconsin
-            </span>
+            Wisconsin
           </option>
           <option value="WY">
-            <span>
-              Wyoming
-            </span>
+            Wyoming
           </option>
         </select>
         <div class="fg-light-slate mt-1">

--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -152,6 +152,9 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                       <option value="AK">
                         Alaska
                       </option>
+                      <option value="AS">
+                        American Samoa
+                      </option>
                       <option value="AZ">
                         Arizona
                       </option>
@@ -170,11 +173,17 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                       <option value="DE">
                         Delaware
                       </option>
+                      <option value="DC">
+                        District of Columbia
+                      </option>
                       <option value="FL">
                         Florida
                       </option>
                       <option value="GA">
                         Georgia
+                      </option>
+                      <option value="GU">
+                        Guam
                       </option>
                       <option value="HI">
                         Hawaii
@@ -248,6 +257,9 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                       <option value="ND">
                         North Dakota
                       </option>
+                      <option value="MP">
+                        Northern Mariana Islands
+                      </option>
                       <option value="OH">
                         Ohio
                       </option>
@@ -259,6 +271,9 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                       </option>
                       <option value="PA">
                         Pennsylvania
+                      </option>
+                      <option value="PR">
+                        Puerto Rico
                       </option>
                       <option value="RI">
                         Rhode Island
@@ -280,6 +295,9 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                       </option>
                       <option value="VT">
                         Vermont
+                      </option>
+                      <option value="VI">
+                        Virgin Islands
                       </option>
                       <option value="VA">
                         Virginia
@@ -505,6 +523,9 @@ exports[`component snapshots component "address" scenario: required matches the 
                       <option value="AK">
                         Alaska
                       </option>
+                      <option value="AS">
+                        American Samoa
+                      </option>
                       <option value="AZ">
                         Arizona
                       </option>
@@ -523,11 +544,17 @@ exports[`component snapshots component "address" scenario: required matches the 
                       <option value="DE">
                         Delaware
                       </option>
+                      <option value="DC">
+                        District of Columbia
+                      </option>
                       <option value="FL">
                         Florida
                       </option>
                       <option value="GA">
                         Georgia
+                      </option>
+                      <option value="GU">
+                        Guam
                       </option>
                       <option value="HI">
                         Hawaii
@@ -601,6 +628,9 @@ exports[`component snapshots component "address" scenario: required matches the 
                       <option value="ND">
                         North Dakota
                       </option>
+                      <option value="MP">
+                        Northern Mariana Islands
+                      </option>
                       <option value="OH">
                         Ohio
                       </option>
@@ -612,6 +642,9 @@ exports[`component snapshots component "address" scenario: required matches the 
                       </option>
                       <option value="PA">
                         Pennsylvania
+                      </option>
+                      <option value="PR">
+                        Puerto Rico
                       </option>
                       <option value="RI">
                         Rhode Island
@@ -633,6 +666,9 @@ exports[`component snapshots component "address" scenario: required matches the 
                       </option>
                       <option value="VT">
                         Vermont
+                      </option>
+                      <option value="VI">
+                        Virgin Islands
                       </option>
                       <option value="VA">
                         Virginia
@@ -2468,6 +2504,9 @@ exports[`component snapshots component "state" scenario: basic matches the snaps
           <option value="AK">
             Alaska
           </option>
+          <option value="AS">
+            American Samoa
+          </option>
           <option value="AZ">
             Arizona
           </option>
@@ -2486,11 +2525,17 @@ exports[`component snapshots component "state" scenario: basic matches the snaps
           <option value="DE">
             Delaware
           </option>
+          <option value="DC">
+            District of Columbia
+          </option>
           <option value="FL">
             Florida
           </option>
           <option value="GA">
             Georgia
+          </option>
+          <option value="GU">
+            Guam
           </option>
           <option value="HI">
             Hawaii
@@ -2564,6 +2609,9 @@ exports[`component snapshots component "state" scenario: basic matches the snaps
           <option value="ND">
             North Dakota
           </option>
+          <option value="MP">
+            Northern Mariana Islands
+          </option>
           <option value="OH">
             Ohio
           </option>
@@ -2575,6 +2623,9 @@ exports[`component snapshots component "state" scenario: basic matches the snaps
           </option>
           <option value="PA">
             Pennsylvania
+          </option>
+          <option value="PR">
+            Puerto Rico
           </option>
           <option value="RI">
             Rhode Island
@@ -2596,6 +2647,9 @@ exports[`component snapshots component "state" scenario: basic matches the snaps
           </option>
           <option value="VT">
             Vermont
+          </option>
+          <option value="VI">
+            Virgin Islands
           </option>
           <option value="VA">
             Virginia
@@ -2677,6 +2731,9 @@ exports[`component snapshots component "state" scenario: required matches the sn
           <option value="AK">
             Alaska
           </option>
+          <option value="AS">
+            American Samoa
+          </option>
           <option value="AZ">
             Arizona
           </option>
@@ -2695,11 +2752,17 @@ exports[`component snapshots component "state" scenario: required matches the sn
           <option value="DE">
             Delaware
           </option>
+          <option value="DC">
+            District of Columbia
+          </option>
           <option value="FL">
             Florida
           </option>
           <option value="GA">
             Georgia
+          </option>
+          <option value="GU">
+            Guam
           </option>
           <option value="HI">
             Hawaii
@@ -2773,6 +2836,9 @@ exports[`component snapshots component "state" scenario: required matches the sn
           <option value="ND">
             North Dakota
           </option>
+          <option value="MP">
+            Northern Mariana Islands
+          </option>
           <option value="OH">
             Ohio
           </option>
@@ -2784,6 +2850,9 @@ exports[`component snapshots component "state" scenario: required matches the sn
           </option>
           <option value="PA">
             Pennsylvania
+          </option>
+          <option value="PR">
+            Puerto Rico
           </option>
           <option value="RI">
             Rhode Island
@@ -2805,6 +2874,9 @@ exports[`component snapshots component "state" scenario: required matches the sn
           </option>
           <option value="VT">
             Vermont
+          </option>
+          <option value="VI">
+            Virgin Islands
           </option>
           <option value="VA">
             Virginia

--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -138,6 +138,266 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                             required
                             ref="selectContainer"
                     >
+                      <option value
+                              selected="selected"
+                      >
+                      </option>
+                      <option value
+                              selected="selected"
+                      >
+                        <span>
+                        </span>
+                      </option>
+                      <option value="AL">
+                        <span>
+                          Alabama
+                        </span>
+                      </option>
+                      <option value="AK">
+                        <span>
+                          Alaska
+                        </span>
+                      </option>
+                      <option value="AZ">
+                        <span>
+                          Arizona
+                        </span>
+                      </option>
+                      <option value="AR">
+                        <span>
+                          Arkansas
+                        </span>
+                      </option>
+                      <option value="CA">
+                        <span>
+                          California
+                        </span>
+                      </option>
+                      <option value="CO">
+                        <span>
+                          Colorado
+                        </span>
+                      </option>
+                      <option value="CT">
+                        <span>
+                          Connecticut
+                        </span>
+                      </option>
+                      <option value="DE">
+                        <span>
+                          Delaware
+                        </span>
+                      </option>
+                      <option value="FL">
+                        <span>
+                          Florida
+                        </span>
+                      </option>
+                      <option value="GA">
+                        <span>
+                          Georgia
+                        </span>
+                      </option>
+                      <option value="HI">
+                        <span>
+                          Hawaii
+                        </span>
+                      </option>
+                      <option value="ID">
+                        <span>
+                          Idaho
+                        </span>
+                      </option>
+                      <option value="IL">
+                        <span>
+                          Illinois
+                        </span>
+                      </option>
+                      <option value="IN">
+                        <span>
+                          Indiana
+                        </span>
+                      </option>
+                      <option value="IA">
+                        <span>
+                          Iowa
+                        </span>
+                      </option>
+                      <option value="KS">
+                        <span>
+                          Kansas
+                        </span>
+                      </option>
+                      <option value="KY">
+                        <span>
+                          Kentucky
+                        </span>
+                      </option>
+                      <option value="LA">
+                        <span>
+                          Louisiana
+                        </span>
+                      </option>
+                      <option value="ME">
+                        <span>
+                          Maine
+                        </span>
+                      </option>
+                      <option value="MD">
+                        <span>
+                          Maryland
+                        </span>
+                      </option>
+                      <option value="MA">
+                        <span>
+                          Massachusetts
+                        </span>
+                      </option>
+                      <option value="MI">
+                        <span>
+                          Michigan
+                        </span>
+                      </option>
+                      <option value="MN">
+                        <span>
+                          Minnesota
+                        </span>
+                      </option>
+                      <option value="MS">
+                        <span>
+                          Mississippi
+                        </span>
+                      </option>
+                      <option value="MO">
+                        <span>
+                          Missouri
+                        </span>
+                      </option>
+                      <option value="MT">
+                        <span>
+                          Montana
+                        </span>
+                      </option>
+                      <option value="NE">
+                        <span>
+                          Nebraska
+                        </span>
+                      </option>
+                      <option value="NV">
+                        <span>
+                          Nevada
+                        </span>
+                      </option>
+                      <option value="NH">
+                        <span>
+                          New Hampshire
+                        </span>
+                      </option>
+                      <option value="NJ">
+                        <span>
+                          New Jersey
+                        </span>
+                      </option>
+                      <option value="NM">
+                        <span>
+                          New Mexico
+                        </span>
+                      </option>
+                      <option value="NY">
+                        <span>
+                          New York
+                        </span>
+                      </option>
+                      <option value="NC">
+                        <span>
+                          North Carolina
+                        </span>
+                      </option>
+                      <option value="ND">
+                        <span>
+                          North Dakota
+                        </span>
+                      </option>
+                      <option value="OH">
+                        <span>
+                          Ohio
+                        </span>
+                      </option>
+                      <option value="OK">
+                        <span>
+                          Oklahoma
+                        </span>
+                      </option>
+                      <option value="OR">
+                        <span>
+                          Oregon
+                        </span>
+                      </option>
+                      <option value="PA">
+                        <span>
+                          Pennsylvania
+                        </span>
+                      </option>
+                      <option value="RI">
+                        <span>
+                          Rhode Island
+                        </span>
+                      </option>
+                      <option value="SC">
+                        <span>
+                          South Carolina
+                        </span>
+                      </option>
+                      <option value="SD">
+                        <span>
+                          South Dakota
+                        </span>
+                      </option>
+                      <option value="TN">
+                        <span>
+                          Tennessee
+                        </span>
+                      </option>
+                      <option value="TX">
+                        <span>
+                          Texas
+                        </span>
+                      </option>
+                      <option value="UT">
+                        <span>
+                          Utah
+                        </span>
+                      </option>
+                      <option value="VT">
+                        <span>
+                          Vermont
+                        </span>
+                      </option>
+                      <option value="VA">
+                        <span>
+                          Virginia
+                        </span>
+                      </option>
+                      <option value="WA">
+                        <span>
+                          Washington
+                        </span>
+                      </option>
+                      <option value="WV">
+                        <span>
+                          West Virginia
+                        </span>
+                      </option>
+                      <option value="WI">
+                        <span>
+                          Wisconsin
+                        </span>
+                      </option>
+                      <option value="WY">
+                        <span>
+                          Wyoming
+                        </span>
+                      </option>
                     </select>
                     <div ref="messageContainer"
                          class="messages"
@@ -333,6 +593,266 @@ exports[`component snapshots component "address" scenario: required matches the 
                             required
                             ref="selectContainer"
                     >
+                      <option value
+                              selected="selected"
+                      >
+                      </option>
+                      <option value
+                              selected="selected"
+                      >
+                        <span>
+                        </span>
+                      </option>
+                      <option value="AL">
+                        <span>
+                          Alabama
+                        </span>
+                      </option>
+                      <option value="AK">
+                        <span>
+                          Alaska
+                        </span>
+                      </option>
+                      <option value="AZ">
+                        <span>
+                          Arizona
+                        </span>
+                      </option>
+                      <option value="AR">
+                        <span>
+                          Arkansas
+                        </span>
+                      </option>
+                      <option value="CA">
+                        <span>
+                          California
+                        </span>
+                      </option>
+                      <option value="CO">
+                        <span>
+                          Colorado
+                        </span>
+                      </option>
+                      <option value="CT">
+                        <span>
+                          Connecticut
+                        </span>
+                      </option>
+                      <option value="DE">
+                        <span>
+                          Delaware
+                        </span>
+                      </option>
+                      <option value="FL">
+                        <span>
+                          Florida
+                        </span>
+                      </option>
+                      <option value="GA">
+                        <span>
+                          Georgia
+                        </span>
+                      </option>
+                      <option value="HI">
+                        <span>
+                          Hawaii
+                        </span>
+                      </option>
+                      <option value="ID">
+                        <span>
+                          Idaho
+                        </span>
+                      </option>
+                      <option value="IL">
+                        <span>
+                          Illinois
+                        </span>
+                      </option>
+                      <option value="IN">
+                        <span>
+                          Indiana
+                        </span>
+                      </option>
+                      <option value="IA">
+                        <span>
+                          Iowa
+                        </span>
+                      </option>
+                      <option value="KS">
+                        <span>
+                          Kansas
+                        </span>
+                      </option>
+                      <option value="KY">
+                        <span>
+                          Kentucky
+                        </span>
+                      </option>
+                      <option value="LA">
+                        <span>
+                          Louisiana
+                        </span>
+                      </option>
+                      <option value="ME">
+                        <span>
+                          Maine
+                        </span>
+                      </option>
+                      <option value="MD">
+                        <span>
+                          Maryland
+                        </span>
+                      </option>
+                      <option value="MA">
+                        <span>
+                          Massachusetts
+                        </span>
+                      </option>
+                      <option value="MI">
+                        <span>
+                          Michigan
+                        </span>
+                      </option>
+                      <option value="MN">
+                        <span>
+                          Minnesota
+                        </span>
+                      </option>
+                      <option value="MS">
+                        <span>
+                          Mississippi
+                        </span>
+                      </option>
+                      <option value="MO">
+                        <span>
+                          Missouri
+                        </span>
+                      </option>
+                      <option value="MT">
+                        <span>
+                          Montana
+                        </span>
+                      </option>
+                      <option value="NE">
+                        <span>
+                          Nebraska
+                        </span>
+                      </option>
+                      <option value="NV">
+                        <span>
+                          Nevada
+                        </span>
+                      </option>
+                      <option value="NH">
+                        <span>
+                          New Hampshire
+                        </span>
+                      </option>
+                      <option value="NJ">
+                        <span>
+                          New Jersey
+                        </span>
+                      </option>
+                      <option value="NM">
+                        <span>
+                          New Mexico
+                        </span>
+                      </option>
+                      <option value="NY">
+                        <span>
+                          New York
+                        </span>
+                      </option>
+                      <option value="NC">
+                        <span>
+                          North Carolina
+                        </span>
+                      </option>
+                      <option value="ND">
+                        <span>
+                          North Dakota
+                        </span>
+                      </option>
+                      <option value="OH">
+                        <span>
+                          Ohio
+                        </span>
+                      </option>
+                      <option value="OK">
+                        <span>
+                          Oklahoma
+                        </span>
+                      </option>
+                      <option value="OR">
+                        <span>
+                          Oregon
+                        </span>
+                      </option>
+                      <option value="PA">
+                        <span>
+                          Pennsylvania
+                        </span>
+                      </option>
+                      <option value="RI">
+                        <span>
+                          Rhode Island
+                        </span>
+                      </option>
+                      <option value="SC">
+                        <span>
+                          South Carolina
+                        </span>
+                      </option>
+                      <option value="SD">
+                        <span>
+                          South Dakota
+                        </span>
+                      </option>
+                      <option value="TN">
+                        <span>
+                          Tennessee
+                        </span>
+                      </option>
+                      <option value="TX">
+                        <span>
+                          Texas
+                        </span>
+                      </option>
+                      <option value="UT">
+                        <span>
+                          Utah
+                        </span>
+                      </option>
+                      <option value="VT">
+                        <span>
+                          Vermont
+                        </span>
+                      </option>
+                      <option value="VA">
+                        <span>
+                          Virginia
+                        </span>
+                      </option>
+                      <option value="WA">
+                        <span>
+                          Washington
+                        </span>
+                      </option>
+                      <option value="WV">
+                        <span>
+                          West Virginia
+                        </span>
+                      </option>
+                      <option value="WI">
+                        <span>
+                          Wisconsin
+                        </span>
+                      </option>
+                      <option value="WY">
+                        <span>
+                          Wyoming
+                        </span>
+                      </option>
                     </select>
                     <div ref="messageContainer"
                          class="messages"
@@ -2106,6 +2626,627 @@ exports[`component snapshots component "selectboxes" scenario: required matches 
 </div>
 `;
 
+exports[`component snapshots component "state" scenario: basic matches the snapshot 1`] = `
+<div id="form-state-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="state-basic-1"
+  >
+    <label for="input-state-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-state formio-component-state"
+           id="state-basic-2"
+      >
+        <label for="input-state-basic-2"
+               class
+        >
+          This is the state label
+        </label>
+        <select lang="en"
+                class="form-control"
+                type="text"
+                name="data[state]"
+                id="input-state-basic-2"
+                ref="selectContainer"
+        >
+          <option value
+                  selected="selected"
+          >
+          </option>
+          <option value
+                  selected="selected"
+          >
+            <span>
+            </span>
+          </option>
+          <option value="AL">
+            <span>
+              Alabama
+            </span>
+          </option>
+          <option value="AK">
+            <span>
+              Alaska
+            </span>
+          </option>
+          <option value="AZ">
+            <span>
+              Arizona
+            </span>
+          </option>
+          <option value="AR">
+            <span>
+              Arkansas
+            </span>
+          </option>
+          <option value="CA">
+            <span>
+              California
+            </span>
+          </option>
+          <option value="CO">
+            <span>
+              Colorado
+            </span>
+          </option>
+          <option value="CT">
+            <span>
+              Connecticut
+            </span>
+          </option>
+          <option value="DE">
+            <span>
+              Delaware
+            </span>
+          </option>
+          <option value="FL">
+            <span>
+              Florida
+            </span>
+          </option>
+          <option value="GA">
+            <span>
+              Georgia
+            </span>
+          </option>
+          <option value="HI">
+            <span>
+              Hawaii
+            </span>
+          </option>
+          <option value="ID">
+            <span>
+              Idaho
+            </span>
+          </option>
+          <option value="IL">
+            <span>
+              Illinois
+            </span>
+          </option>
+          <option value="IN">
+            <span>
+              Indiana
+            </span>
+          </option>
+          <option value="IA">
+            <span>
+              Iowa
+            </span>
+          </option>
+          <option value="KS">
+            <span>
+              Kansas
+            </span>
+          </option>
+          <option value="KY">
+            <span>
+              Kentucky
+            </span>
+          </option>
+          <option value="LA">
+            <span>
+              Louisiana
+            </span>
+          </option>
+          <option value="ME">
+            <span>
+              Maine
+            </span>
+          </option>
+          <option value="MD">
+            <span>
+              Maryland
+            </span>
+          </option>
+          <option value="MA">
+            <span>
+              Massachusetts
+            </span>
+          </option>
+          <option value="MI">
+            <span>
+              Michigan
+            </span>
+          </option>
+          <option value="MN">
+            <span>
+              Minnesota
+            </span>
+          </option>
+          <option value="MS">
+            <span>
+              Mississippi
+            </span>
+          </option>
+          <option value="MO">
+            <span>
+              Missouri
+            </span>
+          </option>
+          <option value="MT">
+            <span>
+              Montana
+            </span>
+          </option>
+          <option value="NE">
+            <span>
+              Nebraska
+            </span>
+          </option>
+          <option value="NV">
+            <span>
+              Nevada
+            </span>
+          </option>
+          <option value="NH">
+            <span>
+              New Hampshire
+            </span>
+          </option>
+          <option value="NJ">
+            <span>
+              New Jersey
+            </span>
+          </option>
+          <option value="NM">
+            <span>
+              New Mexico
+            </span>
+          </option>
+          <option value="NY">
+            <span>
+              New York
+            </span>
+          </option>
+          <option value="NC">
+            <span>
+              North Carolina
+            </span>
+          </option>
+          <option value="ND">
+            <span>
+              North Dakota
+            </span>
+          </option>
+          <option value="OH">
+            <span>
+              Ohio
+            </span>
+          </option>
+          <option value="OK">
+            <span>
+              Oklahoma
+            </span>
+          </option>
+          <option value="OR">
+            <span>
+              Oregon
+            </span>
+          </option>
+          <option value="PA">
+            <span>
+              Pennsylvania
+            </span>
+          </option>
+          <option value="RI">
+            <span>
+              Rhode Island
+            </span>
+          </option>
+          <option value="SC">
+            <span>
+              South Carolina
+            </span>
+          </option>
+          <option value="SD">
+            <span>
+              South Dakota
+            </span>
+          </option>
+          <option value="TN">
+            <span>
+              Tennessee
+            </span>
+          </option>
+          <option value="TX">
+            <span>
+              Texas
+            </span>
+          </option>
+          <option value="UT">
+            <span>
+              Utah
+            </span>
+          </option>
+          <option value="VT">
+            <span>
+              Vermont
+            </span>
+          </option>
+          <option value="VA">
+            <span>
+              Virginia
+            </span>
+          </option>
+          <option value="WA">
+            <span>
+              Washington
+            </span>
+          </option>
+          <option value="WV">
+            <span>
+              West Virginia
+            </span>
+          </option>
+          <option value="WI">
+            <span>
+              Wisconsin
+            </span>
+          </option>
+          <option value="WY">
+            <span>
+              Wyoming
+            </span>
+          </option>
+        </select>
+        <div class="fg-light-slate mt-1">
+          This is the state description
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "state" scenario: required matches the snapshot 1`] = `
+<div id="form-state-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="state-required-1"
+  >
+    <label for="input-state-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-state formio-component-state  required"
+           id="state-required-2"
+      >
+        <label for="input-state-required-2"
+               class="field-required"
+        >
+          This is the state label
+        </label>
+        <select lang="en"
+                class="form-control"
+                type="text"
+                name="data[state]"
+                id="input-state-required-2"
+                required
+                ref="selectContainer"
+        >
+          <option value
+                  selected="selected"
+          >
+          </option>
+          <option value
+                  selected="selected"
+          >
+            <span>
+            </span>
+          </option>
+          <option value="AL">
+            <span>
+              Alabama
+            </span>
+          </option>
+          <option value="AK">
+            <span>
+              Alaska
+            </span>
+          </option>
+          <option value="AZ">
+            <span>
+              Arizona
+            </span>
+          </option>
+          <option value="AR">
+            <span>
+              Arkansas
+            </span>
+          </option>
+          <option value="CA">
+            <span>
+              California
+            </span>
+          </option>
+          <option value="CO">
+            <span>
+              Colorado
+            </span>
+          </option>
+          <option value="CT">
+            <span>
+              Connecticut
+            </span>
+          </option>
+          <option value="DE">
+            <span>
+              Delaware
+            </span>
+          </option>
+          <option value="FL">
+            <span>
+              Florida
+            </span>
+          </option>
+          <option value="GA">
+            <span>
+              Georgia
+            </span>
+          </option>
+          <option value="HI">
+            <span>
+              Hawaii
+            </span>
+          </option>
+          <option value="ID">
+            <span>
+              Idaho
+            </span>
+          </option>
+          <option value="IL">
+            <span>
+              Illinois
+            </span>
+          </option>
+          <option value="IN">
+            <span>
+              Indiana
+            </span>
+          </option>
+          <option value="IA">
+            <span>
+              Iowa
+            </span>
+          </option>
+          <option value="KS">
+            <span>
+              Kansas
+            </span>
+          </option>
+          <option value="KY">
+            <span>
+              Kentucky
+            </span>
+          </option>
+          <option value="LA">
+            <span>
+              Louisiana
+            </span>
+          </option>
+          <option value="ME">
+            <span>
+              Maine
+            </span>
+          </option>
+          <option value="MD">
+            <span>
+              Maryland
+            </span>
+          </option>
+          <option value="MA">
+            <span>
+              Massachusetts
+            </span>
+          </option>
+          <option value="MI">
+            <span>
+              Michigan
+            </span>
+          </option>
+          <option value="MN">
+            <span>
+              Minnesota
+            </span>
+          </option>
+          <option value="MS">
+            <span>
+              Mississippi
+            </span>
+          </option>
+          <option value="MO">
+            <span>
+              Missouri
+            </span>
+          </option>
+          <option value="MT">
+            <span>
+              Montana
+            </span>
+          </option>
+          <option value="NE">
+            <span>
+              Nebraska
+            </span>
+          </option>
+          <option value="NV">
+            <span>
+              Nevada
+            </span>
+          </option>
+          <option value="NH">
+            <span>
+              New Hampshire
+            </span>
+          </option>
+          <option value="NJ">
+            <span>
+              New Jersey
+            </span>
+          </option>
+          <option value="NM">
+            <span>
+              New Mexico
+            </span>
+          </option>
+          <option value="NY">
+            <span>
+              New York
+            </span>
+          </option>
+          <option value="NC">
+            <span>
+              North Carolina
+            </span>
+          </option>
+          <option value="ND">
+            <span>
+              North Dakota
+            </span>
+          </option>
+          <option value="OH">
+            <span>
+              Ohio
+            </span>
+          </option>
+          <option value="OK">
+            <span>
+              Oklahoma
+            </span>
+          </option>
+          <option value="OR">
+            <span>
+              Oregon
+            </span>
+          </option>
+          <option value="PA">
+            <span>
+              Pennsylvania
+            </span>
+          </option>
+          <option value="RI">
+            <span>
+              Rhode Island
+            </span>
+          </option>
+          <option value="SC">
+            <span>
+              South Carolina
+            </span>
+          </option>
+          <option value="SD">
+            <span>
+              South Dakota
+            </span>
+          </option>
+          <option value="TN">
+            <span>
+              Tennessee
+            </span>
+          </option>
+          <option value="TX">
+            <span>
+              Texas
+            </span>
+          </option>
+          <option value="UT">
+            <span>
+              Utah
+            </span>
+          </option>
+          <option value="VT">
+            <span>
+              Vermont
+            </span>
+          </option>
+          <option value="VA">
+            <span>
+              Virginia
+            </span>
+          </option>
+          <option value="WA">
+            <span>
+              Washington
+            </span>
+          </option>
+          <option value="WV">
+            <span>
+              West Virginia
+            </span>
+          </option>
+          <option value="WI">
+            <span>
+              Wisconsin
+            </span>
+          </option>
+          <option value="WY">
+            <span>
+              Wyoming
+            </span>
+          </option>
+        </select>
+        <div class="fg-light-slate mt-1">
+          This is the state description
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
 exports[`component snapshots component "textfield" scenario: basic matches the snapshot 1`] = `
 <div id="form-textfield-basic"
      class="d-flex flex-column-reverse mb-4"
@@ -2202,6 +3343,118 @@ exports[`component snapshots component "textfield" scenario: required matches th
         </div>
         <div class="fg-light-slate mt-1">
           This is the textfield description
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "zip" scenario: basic matches the snapshot 1`] = `
+<div id="form-zip-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="zip-basic-1"
+  >
+    <label for="input-zip-basic-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-zip formio-component-zip  required"
+           id="zip-basic-2"
+      >
+        <label for="input-zip-basic-2"
+               class="field-required"
+        >
+          This is the zip label
+        </label>
+        <div ref="element">
+          <div class="form-input">
+            <input value
+                   spellcheck="true"
+                   lang="en"
+                   class="form-control"
+                   type="text"
+                   name="data[zip]"
+                   required
+                   id="input-zip-basic-2"
+                   ref="input"
+            >
+          </div>
+        </div>
+        <div class="fg-light-slate mt-1">
+          This is the zip description
+        </div>
+        <div ref="messageContainer"
+             class="messages"
+        >
+        </div>
+      </div>
+    </div>
+    <div ref="messageContainer"
+         class="messages"
+    >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "zip" scenario: required matches the snapshot 1`] = `
+<div id="form-zip-required"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div ref="component"
+       class="formio-component formio-component-form  formio-component-label-hidden"
+       id="zip-required-1"
+  >
+    <label for="input-zip-required-1"
+           class="control-label--hidden"
+    >
+    </label>
+    <div novalidate
+         ref="webform"
+         class="formio-form"
+    >
+      <div ref="component"
+           class="form-group has-feedback formio-component formio-component-zip formio-component-zip  required"
+           id="zip-required-2"
+      >
+        <label for="input-zip-required-2"
+               class="field-required"
+        >
+          This is the zip label
+        </label>
+        <div ref="element">
+          <div class="form-input">
+            <input value
+                   spellcheck="true"
+                   lang="en"
+                   class="form-control"
+                   type="text"
+                   name="data[zip]"
+                   required
+                   id="input-zip-required-2"
+                   ref="input"
+            >
+          </div>
+        </div>
+        <div class="fg-light-slate mt-1">
+          This is the zip description
         </div>
         <div ref="messageContainer"
              class="messages"

--- a/__tests__/snapshots.js
+++ b/__tests__/snapshots.js
@@ -1,8 +1,8 @@
 /* eslint-env jest */
-import { createForm, destroyForm } from '../lib/test-helpers'
+import { createForm, destroyForm, sleep } from '../lib/test-helpers'
 import '../dist/formio-sfds.standalone.js'
 
-const { FormioUtils } = window
+const { Event, FormioUtils } = window
 
 const components = [
   { type: 'address' },
@@ -49,7 +49,9 @@ const components = [
     components: [
       { type: 'textfield', label: 'Your name' }
     ]
-  }
+  },
+  { type: 'state' },
+  { type: 'zip' }
 ]
 
 describe('component snapshots', () => {
@@ -84,6 +86,13 @@ describe('component snapshots', () => {
                 )
               ]
             })
+
+            const select = form.element.querySelector('select:empty')
+            if (select) {
+              select.focus()
+              select.dispatchEvent(new Event('change'))
+              await sleep(100)
+            }
 
             form.element.id = `form-${comp.type}-${name}`
             const html = form.element.outerHTML

--- a/data/states.json
+++ b/data/states.json
@@ -1,202 +1,226 @@
 [
   {
-    "name": "Alabama",
-    "code": "AL"
+    "label": "Alabama",
+    "value": "AL"
   },
   {
-    "name": "Alaska",
-    "code": "AK"
+    "label": "Alaska",
+    "value": "AK"
   },
   {
-    "name": "Arizona",
-    "code": "AZ"
+    "label": "American Samoa",
+    "value": "AS"
   },
   {
-    "name": "Arkansas",
-    "code": "AR"
+    "label": "Arizona",
+    "value": "AZ"
   },
   {
-    "name": "California",
-    "code": "CA"
+    "label": "Arkansas",
+    "value": "AR"
   },
   {
-    "name": "Colorado",
-    "code": "CO"
+    "label": "California",
+    "value": "CA"
   },
   {
-    "name": "Connecticut",
-    "code": "CT"
+    "label": "Colorado",
+    "value": "CO"
   },
   {
-    "name": "Delaware",
-    "code": "DE"
+    "label": "Connecticut",
+    "value": "CT"
   },
   {
-    "name": "Florida",
-    "code": "FL"
+    "label": "Delaware",
+    "value": "DE"
   },
   {
-    "name": "Georgia",
-    "code": "GA"
+    "label": "District of Columbia",
+    "value": "DC"
   },
   {
-    "name": "Hawaii",
-    "code": "HI"
+    "label": "Florida",
+    "value": "FL"
   },
   {
-    "name": "Idaho",
-    "code": "ID"
+    "label": "Georgia",
+    "value": "GA"
   },
   {
-    "name": "Illinois",
-    "code": "IL"
+    "label": "Guam",
+    "value": "GU"
   },
   {
-    "name": "Indiana",
-    "code": "IN"
+    "label": "Hawaii",
+    "value": "HI"
   },
   {
-    "name": "Iowa",
-    "code": "IA"
+    "label": "Idaho",
+    "value": "ID"
   },
   {
-    "name": "Kansas",
-    "code": "KS"
+    "label": "Illinois",
+    "value": "IL"
   },
   {
-    "name": "Kentucky",
-    "code": "KY"
+    "label": "Indiana",
+    "value": "IN"
   },
   {
-    "name": "Louisiana",
-    "code": "LA"
+    "label": "Iowa",
+    "value": "IA"
   },
   {
-    "name": "Maine",
-    "code": "ME"
+    "label": "Kansas",
+    "value": "KS"
   },
   {
-    "name": "Maryland",
-    "code": "MD"
+    "label": "Kentucky",
+    "value": "KY"
   },
   {
-    "name": "Massachusetts",
-    "code": "MA"
+    "label": "Louisiana",
+    "value": "LA"
   },
   {
-    "name": "Michigan",
-    "code": "MI"
+    "label": "Maine",
+    "value": "ME"
   },
   {
-    "name": "Minnesota",
-    "code": "MN"
+    "label": "Maryland",
+    "value": "MD"
   },
   {
-    "name": "Mississippi",
-    "code": "MS"
+    "label": "Massachusetts",
+    "value": "MA"
   },
   {
-    "name": "Missouri",
-    "code": "MO"
+    "label": "Michigan",
+    "value": "MI"
   },
   {
-    "name": "Montana",
-    "code": "MT"
+    "label": "Minnesota",
+    "value": "MN"
   },
   {
-    "name": "Nebraska",
-    "code": "NE"
+    "label": "Mississippi",
+    "value": "MS"
   },
   {
-    "name": "Nevada",
-    "code": "NV"
+    "label": "Missouri",
+    "value": "MO"
   },
   {
-    "name": "New Hampshire",
-    "code": "NH"
+    "label": "Montana",
+    "value": "MT"
   },
   {
-    "name": "New Jersey",
-    "code": "NJ"
+    "label": "Nebraska",
+    "value": "NE"
   },
   {
-    "name": "New Mexico",
-    "code": "NM"
+    "label": "Nevada",
+    "value": "NV"
   },
   {
-    "name": "New York",
-    "code": "NY"
+    "label": "New Hampshire",
+    "value": "NH"
   },
   {
-    "name": "North Carolina",
-    "code": "NC"
+    "label": "New Jersey",
+    "value": "NJ"
   },
   {
-    "name": "North Dakota",
-    "code": "ND"
+    "label": "New Mexico",
+    "value": "NM"
   },
   {
-    "name": "Ohio",
-    "code": "OH"
+    "label": "New York",
+    "value": "NY"
   },
   {
-    "name": "Oklahoma",
-    "code": "OK"
+    "label": "North Carolina",
+    "value": "NC"
   },
   {
-    "name": "Oregon",
-    "code": "OR"
+    "label": "North Dakota",
+    "value": "ND"
   },
   {
-    "name": "Pennsylvania",
-    "code": "PA"
+    "label": "Northern Mariana Islands",
+    "value": "MP"
   },
   {
-    "name": "Rhode Island",
-    "code": "RI"
+    "label": "Ohio",
+    "value": "OH"
   },
   {
-    "name": "South Carolina",
-    "code": "SC"
+    "label": "Oklahoma",
+    "value": "OK"
   },
   {
-    "name": "South Dakota",
-    "code": "SD"
+    "label": "Oregon",
+    "value": "OR"
   },
   {
-    "name": "Tennessee",
-    "code": "TN"
+    "label": "Pennsylvania",
+    "value": "PA"
   },
   {
-    "name": "Texas",
-    "code": "TX"
+    "label": "Puerto Rico",
+    "value": "PR"
   },
   {
-    "name": "Utah",
-    "code": "UT"
+    "label": "Rhode Island",
+    "value": "RI"
   },
   {
-    "name": "Vermont",
-    "code": "VT"
+    "label": "South Carolina",
+    "value": "SC"
   },
   {
-    "name": "Virginia",
-    "code": "VA"
+    "label": "South Dakota",
+    "value": "SD"
   },
   {
-    "name": "Washington",
-    "code": "WA"
+    "label": "Tennessee",
+    "value": "TN"
   },
   {
-    "name": "West Virginia",
-    "code": "WV"
+    "label": "Texas",
+    "value": "TX"
   },
   {
-    "name": "Wisconsin",
-    "code": "WI"
+    "label": "Utah",
+    "value": "UT"
   },
   {
-    "name": "Wyoming",
-    "code": "WY"
+    "label": "Vermont",
+    "value": "VT"
+  },
+  {
+    "label": "Virgin Islands",
+    "value": "VI"
+  },
+  {
+    "label": "Virginia",
+    "value": "VA"
+  },
+  {
+    "label": "Washington",
+    "value": "WA"
+  },
+  {
+    "label": "West Virginia",
+    "value": "WV"
+  },
+  {
+    "label": "Wisconsin",
+    "value": "WI"
+  },
+  {
+    "label": "Wyoming",
+    "value": "WY"
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14408,6 +14408,12 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "us": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/us/-/us-2.0.0.tgz",
+      "integrity": "sha1-6NDB4UwuBbZTSgKCVqyiECXEXd4=",
+      "dev": true
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-config-standard-scss": "^1.1.0",
     "stylelint-scss": "^3.17.2",
+    "us": "^2.0.0",
     "watchy": "^0.9.7"
   }
 }

--- a/script/make-states
+++ b/script/make-states
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { writeFileSync } = require('fs')
+const { STATES_AND_TERRITORIES } = require('us')
+
+const states = STATES_AND_TERRITORIES
+  .map(({ name, abbr }) => ({ label: name, value: abbr }))
+
+const json = JSON.stringify(states, null, 2)
+writeFileSync('data/states.json', json, 'utf8')

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -13,11 +13,8 @@ export default class StateSelect extends Select {
       template: '{{ item.label }}',
       data: {
         values: [
-          { label: ' ', value: '' },
-          ...states.map(({ name, code }) => ({
-            label: name,
-            value: code
-          }))
+          { value: '', label: ' ' },
+          ...states
         ]
       }
     }, ...extend)

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -9,6 +9,8 @@ export default class StateSelect extends Select {
       key: 'state',
       widget: 'html5',
       dataSrc: 'values',
+      lazyLoad: false,
+      template: '{{ item.label }}',
       data: {
         values: [
           { label: ' ', value: '' },


### PR DESCRIPTION
This updates our list of U.S. states in the `state` component to include territories (D.C., American Samoa, Guam, Puerto Rico, Virgin Islands. The list comes courtesy of the ["us" npm module](https://github.com/patsplat/javascript-us), and there's a [script](https://github.com/SFDigitalServices/formio-sfds/blob/0691aed058ae299d27223d6f9c395fb83521e911/script/make-states) that regenerates the JSON for our state component from the list, should it ever need to change:

```
script/make-states
```

I've also removed the unnecessary `<span>` elements from the option templates; added snapshot tests for the `state` and `zip` components; and added a snippet to the snapshot test suite that triggers the redrawing of `select` component values, which are not added in the initial render, and which causes the `<option>` elements to be included in the HTML snapshots.