### PR TITLE
Create Vercel URL alias for pushed version tags

### DIFF
--- a/.github/workflows/alias.yml
+++ b/.github/workflows/alias.yml
@@ -1,0 +1,42 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  alias:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: create version alias
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # pre-install CLI tools
+          npm i --no-save fx vercel 
+
+          PREFIX=formio-sfds
+          PROD_URL="$PREFIX.vercel.app"
+          ROOT_URL=$(
+            curl -s "https://api.vercel.com/v11/now/deployments/get?url=$PROD_URL" \
+              -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
+              | npx fx .url
+          )
+
+          echo "prod URL: $PROD_URL"
+          echo "root URL: $ROOT_URL"
+
+          if [[ "$ROOT_URL" != "" ]];
+            VERSION="$(npm view . version)"
+            ALIAS="v${VERSION//./-}"
+            npx vercel --token="${{ secrets.VERCEL_TOKEN }}" \
+              alias set "$PREFIX-$ALIAS" "$ROOT_URL"
+          else
+            echo "no root URL found; skipping version alias"
+          fi

--- a/.github/workflows/alias.yml
+++ b/.github/workflows/alias.yml
@@ -3,20 +3,12 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      ref:
-        name: Git ref
-        description: Specify the git ref ("v<version>") or branch to alias
-        default: main
 
 jobs:
   alias:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.ref || github.event.ref }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12

--- a/.github/workflows/alias.yml
+++ b/.github/workflows/alias.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 

--- a/.github/workflows/alias.yml
+++ b/.github/workflows/alias.yml
@@ -1,42 +1,32 @@
 name: CI
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        name: Git ref
+        description: Specify the git ref ("v<version>") or branch to alias
+        default: main
 
 jobs:
   alias:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref || github.event.ref }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12
 
-      - name: create version alias
-        if: github.ref == 'refs/heads/main'
+      - name: install dependencies
         run: |
-          # pre-install CLI tools
           npm i --no-save fx vercel 
 
-          PREFIX=formio-sfds
-          PROD_URL="$PREFIX.vercel.app"
-          ROOT_URL=$(
-            curl -s "https://api.vercel.com/v11/now/deployments/get?url=$PROD_URL" \
-              -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
-              | npx fx .url
-          )
-
-          echo "prod URL: $PROD_URL"
-          echo "root URL: $ROOT_URL"
-
-          if [[ "$ROOT_URL" != "" ]];
-            VERSION="$(npm view . version)"
-            ALIAS="v${VERSION//./-}"
-            npx vercel --token="${{ secrets.VERCEL_TOKEN }}" \
-              alias set "$PREFIX-$ALIAS" "$ROOT_URL"
-          else
-            echo "no root URL found; skipping version alias"
-          fi
+      - name: create version alias
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          script/alias-version 

--- a/script/alias-version
+++ b/script/alias-version
@@ -5,6 +5,7 @@ PROD_URL=formio-sfds.vercel.app
 
 # make this work locally, too
 if [ -f .env ]; then
+  # shellcheck disable=SC1091
   source .env
 fi
 

--- a/script/alias-version
+++ b/script/alias-version
@@ -1,0 +1,24 @@
+#!/bin/bash
+VERSION="${1:-$(npm view . version)}"
+ALIAS="v${VERSION//./-}"
+PREFIX=formio-sfds
+SUFFIX=.vercel.app
+PROD_URL="${PREFIX}${SUFFIX}"
+
+ROOT_URL=$(
+  curl -s "https://api.vercel.com/v11/now/deployments/get?url=$PROD_URL" \
+    -H "Authorization: Bearer $VERCEL_TOKEN" \
+    | npx -q fx .url
+)
+
+echo "prod URL: $PROD_URL"
+echo "root URL: $ROOT_URL"
+
+if [[ "$ROOT_URL" != "" ]]; then
+  ALIAS_URL="${PREFIX}-${ALIAS}${SUFFIX}"
+  echo "aliasing:"
+  echo "  $ALIAS_URL → $ROOT_URL"
+  npx -q vercel --token="$VERCEL_TOKEN" alias set "$ALIAS_URL" "$ROOT_URL"
+else
+  echo "no root URL found; skipping version alias"
+fi

--- a/script/alias-version
+++ b/script/alias-version
@@ -3,6 +3,11 @@ VERSION="${1:-$(npm view . version)}"
 ALIAS="v${VERSION//./-}"
 PROD_URL=formio-sfds.vercel.app
 
+# make this work locally, too
+if [ -f .env ]; then
+  source .env
+fi
+
 ROOT_URL=$(
   curl -s "https://api.vercel.com/v11/now/deployments/get?url=$PROD_URL" \
     -H "Authorization: Bearer $VERCEL_TOKEN" \
@@ -16,7 +21,7 @@ if [[ "$ROOT_URL" != "" ]]; then
   ALIAS_URL="formio-sfds-${ALIAS}.vercel.app"
   echo "aliasing:"
   echo "  $ALIAS_URL → $ROOT_URL"
-  npx -q vercel --token="$VERCEL_TOKEN" alias set "$ALIAS_URL" "$ROOT_URL"
+  npx -q vercel --scope sfds --token="$VERCEL_TOKEN" alias set "$ROOT_URL" "$ALIAS_URL"
 else
   echo "no root URL found; skipping version alias"
 fi

--- a/script/alias-version
+++ b/script/alias-version
@@ -1,9 +1,7 @@
 #!/bin/bash
 VERSION="${1:-$(npm view . version)}"
 ALIAS="v${VERSION//./-}"
-PREFIX=formio-sfds
-SUFFIX=.vercel.app
-PROD_URL="${PREFIX}${SUFFIX}"
+PROD_URL=formio-sfds.vercel.app
 
 ROOT_URL=$(
   curl -s "https://api.vercel.com/v11/now/deployments/get?url=$PROD_URL" \
@@ -15,7 +13,7 @@ echo "prod URL: $PROD_URL"
 echo "root URL: $ROOT_URL"
 
 if [[ "$ROOT_URL" != "" ]]; then
-  ALIAS_URL="${PREFIX}-${ALIAS}${SUFFIX}"
+  ALIAS_URL="formio-sfds-${ALIAS}.vercel.app"
   echo "aliasing:"
   echo "  $ALIAS_URL → $ROOT_URL"
   npx -q vercel --token="$VERCEL_TOKEN" alias set "$ALIAS_URL" "$ROOT_URL"


### PR DESCRIPTION
This adds an "alias" workflow that creates a Vercel deployment URL alias whenever a tag beginning with `v` is created. For instance, when we tag the next major release with `v7.0.0`, the workflow should run and create an alias from `formio-sfds-v7-0-0.vercel.app` to the current production deployment.

The point of this is to make it easier to compare rendered examples in different versions of our theme.

In the future, these aliases could also power a dropdown on the site that allows you to see the examples and docs as of a specific version by changing the hostname of the current URL. I'm going to manually add aliases for a few recent versions by going down [the production deployments list](https://github.com/SFDigitalServices/formio-sfds/deployments/activity_log?environment=Production). I don't think there's any need to automate doing the retroactive aliases for versions earlier than, say, [6.3.0](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.3.0).