### PR TITLE
New translate view, localization fixes, docs

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -1763,6 +1763,206 @@ exports[`component snapshots component "day" scenario: required matches the snap
 </div>
 `;
 
+exports[`component snapshots component "form" scenario: basic matches the snapshot 1`] = `
+<div id="form-form-basic"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div class="formio-form mb-4">
+    <div class="d-flex flex-column flex-md-row flex-md-auto flex-justify-between">
+      <div class="col-md-2">
+        <nav class="fg-light-slate"
+             id="wizard-form-basic-1-header"
+             aria-label="navigation"
+             role="navigation"
+        >
+          <ul class="nav-list mt-2 mb-0 mx-0 p-0">
+            <li aria-current="page"
+                class="mb-1 d-flex flex-items-start"
+            >
+              <span data-icon="square"
+                    class="fg-slate notranslate"
+              >
+                <svg viewbox="0 0 17 20"
+                     fill="currentColor"
+                     height="20"
+                >
+                  <rect x="5"
+                        y="5"
+                        width="7"
+                        height="7"
+                        rx="2"
+                  >
+                  </rect>
+                </svg>
+              </span>
+              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u">
+                Page 1 link title
+              </button>
+            </li>
+            <li class="mb-1 d-flex flex-items-start">
+              <span data-icon="square"
+                    class="fg-none notranslate"
+              >
+                <svg viewbox="0 0 17 20"
+                     fill="currentColor"
+                     height="20"
+                >
+                  <rect x="5"
+                        y="5"
+                        width="7"
+                        height="7"
+                        rx="2"
+                  >
+                  </rect>
+                </svg>
+              </span>
+              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-inherit fw-regular no-u">
+                Page 2
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div class="col-md-4">
+        <div class="mb-3">
+          <h1 class="d1 mb-4 mr-n2">
+            Page 1
+          </h1>
+          <div ref="wizard-form-basic-1"
+               class="components"
+          >
+          </div>
+        </div>
+        <div id="wizard-form-basic-1-nav"
+             class="d-flex flex-justify-between"
+        >
+          <button ref="wizard-form-basic-1-next"
+                  class="btn flex-justify-end"
+          >
+            <div class="d-flex flex-items-center">
+              <span>
+                Get started
+              </span>
+              <span class="d-flex flex-items-center ml-1 notranslate"
+                    data-icon="next"
+              >
+                <svg viewbox="0 0 20 20"
+                     fill="currentColor"
+                     height="20"
+                >
+                  <path d="M19.635 9.115L13.27 2.75A1.25 1.25 0 0011.5 4.5l4.23 4.23H1.25a1.25 1.25 0 100 2.5h14.5L11.5 15.5a1.252 1.252 0 001.77 1.77l6.365-6.385a1.255 1.255 0 000-1.77z">
+                  </path>
+                </svg>
+              </span>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component snapshots component "form" scenario: translate matches the snapshot 1`] = `
+<div id="form-form-translate"
+     class="d-flex flex-column-reverse mb-4"
+>
+  <div class="formio-form mb-4">
+    <div class="d-flex flex-column flex-md-row flex-md-auto flex-justify-between">
+      <div class="col-md-2">
+        <nav class="fg-light-slate"
+             id="wizard-form-translate-1-header"
+             aria-label="navigation"
+             role="navigation"
+        >
+          <ul class="nav-list mt-2 mb-0 mx-0 p-0">
+            <li aria-current="page"
+                class="mb-1 d-flex flex-items-start"
+            >
+              <span data-icon="square"
+                    class="fg-slate notranslate"
+              >
+                <svg viewbox="0 0 17 20"
+                     fill="currentColor"
+                     height="20"
+                >
+                  <rect x="5"
+                        y="5"
+                        width="7"
+                        height="7"
+                        rx="2"
+                  >
+                  </rect>
+                </svg>
+              </span>
+              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-slate fw-medium no-u">
+                Page 1 link title
+              </button>
+            </li>
+            <li class="mb-1 d-flex flex-items-start">
+              <span data-icon="square"
+                    class="fg-none notranslate"
+              >
+                <svg viewbox="0 0 17 20"
+                     fill="currentColor"
+                     height="20"
+                >
+                  <rect x="5"
+                        y="5"
+                        width="7"
+                        height="7"
+                        rx="2"
+                  >
+                  </rect>
+                </svg>
+              </span>
+              <button class="btn-link flex-auto align-left m-0 pl-1 py-0 fg-inherit fw-regular no-u">
+                Page 2
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div class="col-md-4">
+        <div class="mb-3">
+          <h1 class="d1 mb-4 mr-n2">
+            Page 1
+          </h1>
+          <div ref="wizard-form-translate-1"
+               class="components"
+          >
+          </div>
+        </div>
+        <div id="wizard-form-translate-1-nav"
+             class="d-flex flex-justify-between"
+        >
+          <button ref="wizard-form-translate-1-next"
+                  class="btn flex-justify-end"
+          >
+            <div class="d-flex flex-items-center">
+              <span>
+                Get started
+              </span>
+              <span class="d-flex flex-items-center ml-1 notranslate"
+                    data-icon="next"
+              >
+                <svg viewbox="0 0 20 20"
+                     fill="currentColor"
+                     height="20"
+                >
+                  <path d="M19.635 9.115L13.27 2.75A1.25 1.25 0 0011.5 4.5l4.23 4.23H1.25a1.25 1.25 0 100 2.5h14.5L11.5 15.5a1.252 1.252 0 001.77 1.77l6.365-6.385a1.255 1.255 0 000-1.77z">
+                  </path>
+                </svg>
+              </span>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`component snapshots component "htmlelement" scenario: basic matches the snapshot 1`] = `
 <div id="form-htmlelement-basic"
      class="d-flex flex-column-reverse mb-4"
@@ -1978,35 +2178,8 @@ exports[`component snapshots component "panel" scenario: basic matches the snaps
                  id="panel-panel"
         >
           <h1 class="d1 mt-0 mb-4">
-            Panel
+            Panel title
           </h1>
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
-               id="panel-basic-3"
-          >
-            <label for="input-panel-basic-3"
-                   class
-            >
-              Your name
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[textField]"
-                       id="input-panel-basic-3"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
         </section>
         <div ref="messageContainer"
              class="messages"
@@ -2046,35 +2219,8 @@ exports[`component snapshots component "panel" scenario: required matches the sn
                  id="panel-panel"
         >
           <h1 class="d1 mt-0 mb-4">
-            Panel
+            Panel title
           </h1>
-          <div ref="component"
-               class="form-group has-feedback formio-component formio-component-textfield formio-component-textField"
-               id="panel-basic-3"
-          >
-            <label for="input-panel-basic-3"
-                   class
-            >
-              Your name
-            </label>
-            <div ref="element">
-              <div class="form-input">
-                <input value
-                       spellcheck="true"
-                       lang="en"
-                       class="form-control"
-                       type="text"
-                       name="data[textField]"
-                       id="input-panel-basic-3"
-                       ref="input"
-                >
-              </div>
-            </div>
-            <div ref="messageContainer"
-                 class="messages"
-            >
-            </div>
-          </div>
         </section>
         <div ref="messageContainer"
              class="messages"

--- a/__tests__/i18n.js
+++ b/__tests__/i18n.js
@@ -417,6 +417,42 @@ describe('i18n extraction', () => {
       })
     })
 
+    describe('properties.displayTitle -> displayTitle mapping', () => {
+      it('maps component.properites.displayTitle to "displayTitle" for panels', () => {
+        const strings = getStrings({
+          components: [
+            {
+              type: 'panel',
+              key: 'page1',
+              properties: {
+                displayTitle: 'Display title'
+              }
+            }
+          ]
+        })
+
+        expect(strings).toHaveLength(1)
+        expect(strings[0].key).toBe('page1.displayTitle')
+        expect(strings[0].value).toBe('Display title')
+      })
+
+      it('does *not* map component.properites.displayTitle for non-panels', () => {
+        const strings = getStrings({
+          components: [
+            {
+              type: 'textfield',
+              key: 'name',
+              properties: {
+                displayTitle: 'Name'
+              }
+            }
+          ]
+        })
+
+        expect(strings).toHaveLength(0)
+      })
+    })
+
     describe('interpolations', () => {
       it('finds $t() interpolations', () => {
         const strings = getStrings({

--- a/__tests__/phrase.js
+++ b/__tests__/phrase.js
@@ -70,8 +70,8 @@ describe('Phrase helpers', () => {
       expect(phrase.formatKey(['foo', 'Foo!'])).toEqual('[[__phrase_foo__]]')
     })
 
-    it('returns an empty string (" ") if given an array with an empty last value', () => {
-      expect(phrase.formatKey(['foo', ''])).toEqual(' ')
+    it('returns an empty string if given an array with an empty last value', () => {
+      expect(phrase.formatKey(['foo', ''])).toEqual('')
     })
 
     it('respects the "context" option', () => {

--- a/__tests__/snapshots.js
+++ b/__tests__/snapshots.js
@@ -46,8 +46,26 @@ const components = [
   { type: 'textfield' },
   {
     type: 'panel',
+    title: 'Panel title',
+    components: []
+  },
+  {
+    type: 'form',
+    display: 'wizard',
     components: [
-      { type: 'textfield', label: 'Your name' }
+      {
+        type: 'panel',
+        title: 'Page 1',
+        properties: {
+          displayTitle: 'Page 1 link title'
+        },
+        components: []
+      },
+      {
+        type: 'panel',
+        title: 'Page 2',
+        components: []
+      }
     ]
   },
   { type: 'state' },
@@ -58,8 +76,17 @@ describe('component snapshots', () => {
   const scenarios = {
     basic: {},
     required: {
-      validate: {
-        required: true
+      filter: model => model.type !== 'form',
+      component: {
+        validate: {
+          required: true
+        }
+      }
+    },
+    translate: {
+      filter: model => model.type === 'form',
+      options: {
+        translate: true
       }
     }
   }
@@ -69,24 +96,36 @@ describe('component snapshots', () => {
   for (const comp of components) {
     describe(`component "${comp.type}"`, () => {
       for (const [name, props] of Object.entries(scenarios)) {
+        const model = comp.type === 'form'
+          ? Object.assign(
+            {},
+            comp,
+            props.form
+          )
+          : {
+            components: [
+              Object.assign(
+                {
+                  label: `This is the ${comp.type} label`,
+                  description: `This is the ${comp.type} description`
+                },
+                comp,
+                props.component
+              )
+            ]
+          }
+
+        if (typeof props.filter === 'function' && !props.filter(model, props)) {
+          // console.info('Skipping scenario "%s" for component "%s"', name, comp.type)
+          continue
+        }
+
         describe(`scenario: ${name}`, () => {
           it('matches the snapshot', async () => {
             let i = 0
             FormioUtils.getRandomComponentId = () => `${comp.type}-${name}-${i++}`
 
-            const form = await createForm({
-              components: [
-                Object.assign(
-                  {
-                    label: `This is the ${comp.type} label`,
-                    description: `This is the ${comp.type} description`
-                  },
-                  comp,
-                  props
-                )
-              ]
-            })
-
+            const form = await createForm(model, props.options)
             const select = form.element.querySelector('select:empty')
             if (select) {
               select.focus()

--- a/__tests__/snapshots.js
+++ b/__tests__/snapshots.js
@@ -25,7 +25,7 @@ const components = [
   { type: 'day' },
   { type: 'datetime' },
   { type: 'htmlelement', tag: 'h1', content: 'Hello, world!' },
-  { type: 'content', content: 'Hello, world!' },
+  { type: 'content', html: 'Hello, world!' },
   { type: 'number' },
   {
     type: 'radio',

--- a/api/preview.js
+++ b/api/preview.js
@@ -1,130 +1,16 @@
-const fetch = require('node-fetch')
-const { JSDOM } = require('jsdom')
+import { Proxy } from '../lib/proxy'
 
-const LIVE_URL = 'https://sf.gov'
+module.exports = async (req, res) => {
+  const { query } = req
+  const { path = '/feedback' } = query
 
-const envUrls = {
-  test: 'https://test-sfgov.pantheonsite.io'
-}
-
-module.exports = (req, res) => {
-  const {
-    version,
-    env,
-    path = '/feedback'
-  } = req.query
-
-  let {
-    form: source,
-    options
-  } = req.query
-
-  res.setHeader('Content-Type', 'text/html')
-
-  const baseUrl = (env ? envUrls[env] : null) || LIVE_URL
-  const fetchUrl = `${baseUrl}${path}`
-
-  let start = Date.now()
-
-  fetch(fetchUrl)
-    .then(fetched => fetched.text())
-    .then(body => {
-      res.setHeader('x-proxy-fetch-time', `${Date.now() - start} ms`)
-      start = Date.now()
-
-      const dom = new JSDOM(body)
-      const { document } = dom.window
-
-      const script = document.querySelector('script[src*=formio-sfds]')
-      if (script) {
-        if (version) {
-          script.setAttribute('src', script.src.replace(/formio-sfds@[^/]+/, `formio-sfds@${version}`))
-        } else {
-          script.removeAttribute('src')
-          script.textContent = `
-            var script = document.createElement('script')
-            var baseUrl = [
-              location.protocol, '//', location.hostname,
-              location.port ? ':' + location.port : ''
-            ].join('')
-            script.src = baseUrl + '/dist/formio-sfds.standalone.js'
-            console.info('injected formio-sfds:', script.src)
-            document.body.appendChild(script)
-            document.getElementById('formio-sfds-url').href = script.src
-          `
-        }
-      } else {
-        console.warn(
-          'no formio-sfds <script> found in:',
-          Array.from(document.querySelectorAll('script')).map(el => el.src)
-        )
-      }
-
-      const div = document.querySelector('[data-source]')
-      if (div) {
-        if (source) {
-          div.setAttribute('data-source', source)
-        } else {
-          source = div.getAttribute('data-source')
-        }
-        if (options) {
-          div.setAttribute('data-options', options)
-        } else {
-          options = div.getAttribute('data-options')
-        }
-        const header = document.createElement('div')
-        header.classList.add('formio-sfds')
-        header.innerHTML = `
-          <details>
-            <summary class="m-0">⚠️ This is a form preview</summary>
-            <div class="bg-blue-1 p-2 border-1 border-bright-blue round-bottom-1">
-              <p class="mt-0 mb-1">
-                <b>You are viewing this form in a simulated sf.gov environment.</b>
-                The form should function as expected, and styles should reflect
-                what you will see when this version of <code>formio-sfds</code>
-                is used on sf.gov. Some additional information is listed below.
-              </p>
-              <dl class="m-0">
-                <dt><b>Fetched URL</b></dt>
-                <dd class="mb-1 ml-2">
-                  <a href="${fetchUrl}"><code>${fetchUrl}</code></a>
-                  ${env ? `(via <code>env=${env}</code>)` : ''}
-                </dd>
-
-                <dt><b>Theme version</b></dt>
-                <dd class="mb-0 ml-2">${
-                  version ? `version <code>${version}</code>` : 'not provided (injected <a id="formio-sfds-url">built JS</a>)'
-                }</dd>
-
-                <dt><b>Form data source URL</b></dt>
-                <dd class="mb-1 ml-2">${
-                  source ? `<a href="${source}"><code>${source}</code></a>` : 'not provided'
-                }</dd>
-
-                <dt><b>Form options</b></dt>
-                <dd class="mb-1 ml-2">${
-                  options ? `<pre>${JSON.stringify(JSON.parse(options), null, 2)}</pre>` : 'none provided'
-                }</dd>
-              </ul>
-            </div>
-          </details>
-        `.trim()
-        div.parentNode.insertBefore(header, div)
-      } else {
-        console.warn('no [data-source] form element found!')
-      }
-
-      const base = document.createElement('base')
-      base.setAttribute('href', baseUrl)
-      document.head.insertBefore(base, document.head.firstChild)
-
-      const html = dom.serialize()
-      res.setHeader('x-proxy-render-time', `${Date.now() - start} ms`)
-      res.setHeader('Content-Length', Buffer.byteLength(html))
-      res.end(html, 'utf8')
-    })
-    .catch(error => {
-      res.statusCode = 500
-      res.end(`Sorry, there was an error: <pre>${error.message}</pre>`)
-    })
+  try {
+    const proxy = new Proxy(query)
+    await proxy.fetch(query.url || path)
+    proxy.transform(query)
+    proxy.send(res)
+  } catch (error) {
+    res.statusCode = 500
+    res.end(`Sorry, there was an error: <pre>${error.message}</pre>`)
+  }
 }

--- a/api/strings.js
+++ b/api/strings.js
@@ -9,7 +9,7 @@ const formatters = {
 }
 
 module.exports = (req, res) => {
-  const { formUrl, format = 'debug', ...params } = req.query
+  const { formUrl, format = 'nested', ...params } = req.query
   if (!formUrl) {
     res.json({
       status: 502,

--- a/api/translate.js
+++ b/api/translate.js
@@ -8,8 +8,9 @@ module.exports = async (req, res) => {
   try {
     options = Object.assign(
       {
-        translate: true,
         disableConditionals: true,
+        renderMode: 'flat',
+        translate: true,
         unlockNavigation: true
       },
       options ? JSON.parse(options) : null

--- a/api/translate.js
+++ b/api/translate.js
@@ -1,0 +1,35 @@
+import { Proxy } from '../lib/proxy'
+
+module.exports = async (req, res) => {
+  const { query } = req
+  const { path = '/feedback' } = query
+  let { options } = query
+
+  try {
+    options = Object.assign(
+      {
+        translate: true,
+        disableConditionals: true,
+        unlockNavigation: true
+      },
+      options ? JSON.parse(options) : null
+    )
+    query.options = JSON.stringify(options)
+
+    const proxy = new Proxy(query)
+    const { document } = await proxy.fetch(query.url || path)
+
+    document.head.appendChild(
+      proxy.element('script', {}, `
+        window.drupalSettings = { user: { uid: 1 } }
+      `)
+    )
+
+    proxy.transform(query)
+
+    proxy.send(res)
+  } catch (error) {
+    res.statusCode = 500
+    res.end(`Sorry, there was an error: <pre>${error.message}</pre>`)
+  }
+}

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,30 +1,66 @@
-## Localization
+# Localization
 We use [Phrase] to manage translations of both "generic" form strings and
 content specific to each form. There are a couple of different workflows to be
 aware of:
 
-### Translate generic strings (content)
+- [Translate generic strings](#translate-generic-strings-content)
+- [Update generic string translations](#update-generic-string-translations-engineering)
+- [Translate a specific form](#translate-a-form)
+
+## Translate generic strings (content)
 1. Translate the strings in the [generic strings Phrase project](https://app.phrase.com/accounts/city-county-of-san-francisco/projects/form-io-generic-strings)
 1. Ask somebody with access to this repo to pull the new translations (see below)
 
-### Update generic string translations (engineering)
+## Update generic string translations (engineering)
+1. Install the [Phrase CLI tools](https://phrase.com/cli/)
 1. Check out this repo
-1. Set `PHRASE_ACCESS_TOKEN` in your local environment
+1. Set `PHRASE_ACCESS_TOKEN` in your local environment (i.e. in `.env`)
 1. Run `script/phrase pull` to get the new strings
-1. If `git diff src/i18n` shows a diff, then commit the changes and make a new release
+1. If `git diff src/i18n` shows a diff, then commit the changes and [publish a new release](../develop.md#publishing)
 
-### Translate a form
-This workflow is done almost entirely in either [Phrase] or the [Phrase
-in-context editor]:
 
-1. Set the `phraseProjectId` custom property of your form on form.io to your
-   Phrase project ID
+## Translate a form
+Before you can translate a form, you'll need to do some one-time setup in both Phrase and the form.io portal:
+
+### Phrase setup
+1. Create a new Phrase project in the [SF Digital Services workspace](https://app.phrase.com/accounts/city-county-of-san-francisco/spaces)
+1. Open the <kbd>More ⌄</kbd> menu in the project navigation and select <kbd>Project Settings</kbd>
+
+    <img src="https://user-images.githubusercontent.com/113896/97355318-fbc0c980-1853-11eb-8559-a527798562de.png" height="400" alt="image of the More and Project Settings navigation">
+
+1. Select the <kbd>API</kbd> menu item on the left, and copy the Project ID:
+
+    ![image of the Project ID field](https://user-images.githubusercontent.com/113896/97355530-44788280-1854-11eb-8db4-2d0534d9897d.png)
+
+### Form.io setup
+1. Edit your form in the [form.io portal](https://portal.form.io), and 
+1. Click the gear icon in the form navigation to edit its settings:
+
+    ![image of the gear icon in form.io project settings](https://user-images.githubusercontent.com/113896/97355914-dbddd580-1854-11eb-89bb-fde9cc30cebe.png)
+
+1. In the <kbd>Custom Properties</kbd> section, add a new entry with `phraseProjectId` in the "Key" field and the Phrase project ID that you copied in the "Value" field:
+
+    ![image of the custom properties in form.io](https://user-images.githubusercontent.com/113896/88114083-fa527780-cb67-11ea-98a1-b85273db617a.png)
+   
 1. Visit `https://formio-sfds.vercel.app/api/strings?formUrl=<URL>`, where
    `<URL>` is your form.io data source URL
 1. Save the JSON to your computer
-1. Upload the JSON to your Phrase project
-1. Log in to sf.gov
-1. Visit the form on sf.gov and add `?translate=true` at the end of the URL
+1. Upload the JSON to your Phrase project:
+
+  - Under the <kbd>More ⌄</kbd> menu, select <kbd>Upload file</kbd>
+  - Click <kbd>Choose file</kbd> and find the JSON file that you just saved
+  - Choose `i18next (.json)` from the <kbd>Format</kbd> menu
+  - Under <kbd>Language</kbd>, type `en` in the field under <kbd>Use existing language</kbd>
+
+      <img src="https://user-images.githubusercontent.com/113896/97367482-6da20e80-1866-11eb-9b0a-5e6b86e5aabe.png" width="350">
+
+  - Click the <kbd>Upload</kbd> button
+  - Confirm that strings were loaded and click on <kbd>Translate imported keys</kbd> to view them:
+
+      ![image](https://user-images.githubusercontent.com/113896/97367809-00db4400-1867-11eb-8115-dca7ca108504.png)
+
+1. Visit `https://formio-sfds.vercel.app/api/translate?url=<URL>`, where
+   `<URL>` is the URL of your form _on sf.gov_
 1. When the form loads, you should see a modal dialog to log in to Phrase
 
 Once you've logged in, you should see a blue bar across the bottom and pencil
@@ -33,8 +69,15 @@ icon markers above each piece of translatable form content:
 ![Phrase in-context editor screenshot](https://user-images.githubusercontent.com/113896/88839471-f3db8580-d18f-11ea-8121-e0ce158ca274.png)
 
 Each batch of translations can be bundled together in a "release" by adding or
-updating the form's `phraseProjectVersion` custom property, ideally using
-[semantic versioning conventions](https://semver.org).
+updating the form's `phraseProjectVersion` custom property (in the same place
+that you added `phraseProjectId` above). Please use [semantic versioning
+conventions](https://semver.org) to track the types of changes:
+
+* Patch versions (`1.0.0` → `1.0.1`) for translation updates and other "fixes", like spelling
+* Minor versions (`1.0.1` → `1.1.0`) when new keys and/or translations are added
+* Major versions (`1.0.0` → `2.0.0`) when keys are deleted
+
+When in doubt, drop into **#topic-translations** and ask for help! 💪
 
 [Phrase]: https://phrase.com
 [Phrase in-context editor]: https://help.phrase.com/help/set-up-in-context-editor

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -81,8 +81,18 @@ function getStrings (form) {
       }
     }),
     fieldGetter('description'),
-    fieldGetter('content'),
-    fieldGetter('html'),
+    // NB: "html" components have a "content" field
+    fieldGetter('html', (value, component, path) => {
+      if (component.type === 'content' && value) {
+        return [new UIString(value, component, path)]
+      }
+    }),
+    // NB: "content" components have an "html" field
+    fieldGetter('content', (value, component, path) => {
+      if (component.type === 'html' && value) {
+        return [new UIString(value, component, path)]
+      }
+    }),
     fieldGetter('suffix'),
     fieldGetter('values', (values, component, path) => {
       return Array.isArray(values) && values.map(({ label, value }) => {

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -141,11 +141,8 @@ function getStrings (form) {
         ? [new UIString(customError, component, path)]
         : []
     }),
-    fieldGetter('properties.backTitle', (title, component) => {
-      return title
-        ? [new UIString(title, component, 'form.backTitle')]
-        : []
-    })
+    fieldGetterAlias('properties.displayTitle', 'displayTitle', 'panel'),
+    fieldGetterAlias('properties.backTitle', 'form.backTitle')
   ]
 
   const all = []
@@ -179,6 +176,19 @@ function getStrings (form) {
         const value = dot.get(component, path)
         return value ? [new UIString(value, component, path)] : []
       }
+    }
+  }
+
+  function fieldGetterAlias (path, key, filter = () => true) {
+    if (typeof filter === 'string') {
+      const type = filter
+      filter = component => component.type === type
+    }
+    return component => {
+      const value = dot.get(component, path)
+      return value && filter(component, value)
+        ? [new UIString(value, component, key)]
+        : []
     }
   }
 }

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -150,6 +150,11 @@ function getStrings (form) {
       return customError
         ? [new UIString(customError, component, path)]
         : []
+    }),
+    fieldGetter('properties.backTitle', (title, component) => {
+      return title
+        ? [new UIString(title, component, 'form.backTitle')]
+        : []
     })
   ]
 

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -81,18 +81,8 @@ function getStrings (form) {
       }
     }),
     fieldGetter('description'),
-    // NB: "html" components have a "content" field
-    fieldGetter('html', (value, component, path) => {
-      if (component.type === 'content' && value) {
-        return [new UIString(value, component, path)]
-      }
-    }),
-    // NB: "content" components have an "html" field
-    fieldGetter('content', (value, component, path) => {
-      if (component.type === 'html' && value) {
-        return [new UIString(value, component, path)]
-      }
-    }),
+    fieldGetter('html'),
+    fieldGetter('content'),
     fieldGetter('suffix'),
     fieldGetter('values', (values, component, path) => {
       return Array.isArray(values) && values.map(({ label, value }) => {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,0 +1,177 @@
+import { URL } from 'url'
+import fetch from 'node-fetch'
+import { JSDOM } from 'jsdom'
+
+export const LIVE_URL = 'https://sf.gov'
+
+export const environments = {
+  live: LIVE_URL,
+  test: 'https://test-sfgov.pantheonsite.io'
+}
+
+export class Proxy {
+  constructor (options) {
+    const { env = 'live', base } = options || {}
+    this.base = base || environments[env] || LIVE_URL
+    this.options = options
+  }
+
+  fetch (uri) {
+    const url = /^https?:/.test(uri)
+      ? uri
+      : new URL(uri, this.base)
+    console.warn('fetching:', url)
+    return fetch(url)
+      .then(async res => {
+        this.url = url
+        this.body = await res.text()
+        this.dom = new JSDOM(this.body)
+        this.document = this.dom.window.document
+        const base = this.document.createElement('base')
+        base.setAttribute('href', String(this.base))
+        this.document.head.insertBefore(base, this.document.head.firstChild)
+        return this
+      })
+  }
+
+  transform (query) {
+    const {
+      version: formioSFDSVersion,
+      formioVersion,
+      env = 'live'
+    } = query
+
+    const {
+      document,
+      url
+    } = this
+
+    let {
+      source,
+      options
+    } = query
+
+    this.setFormioSFDSVersion(formioSFDSVersion)
+    if (formioVersion) {
+      this.setFormioJSVersion(formioVersion)
+    }
+
+    const div = document.querySelector('[data-source]')
+    if (div) {
+      if (source) {
+        div.setAttribute('data-source', source)
+      } else {
+        source = div.getAttribute('data-source')
+      }
+      if (options) {
+        const optstr = options instanceof Object ? JSON.stringify(options) : options
+        div.setAttribute('data-options', optstr)
+      } else {
+        options = div.getAttribute('data-options')
+      }
+
+      const info = this.element('div', { class: 'formio-sfds' })
+      info.innerHTML = `
+        <details class="my-4">
+          <summary class="m-0">⚠️ This is a form preview</summary>
+          <div class="bg-blue-1 p-2 border-1 border-bright-blue round-bottom-1">
+            <p class="mt-0 mb-1">
+              <b>You are viewing this form in a simulated sf.gov environment.</b>
+              The form should function as expected, and styles should reflect
+              what you will see when this version of <code>formio-sfds</code>
+              is used on sf.gov. Some additional information is listed below.
+            </p>
+            <dl class="m-0">
+              <dt><b>Fetched URL</b></dt>
+              <dd class="mb-1 ml-2">
+                <a href="${url}"><code>${url}</code></a>
+                ${env ? `(via <code>env=${env}</code>)` : ''}
+              </dd>
+
+              <dt><b>Theme version</b></dt>
+              <dd class="mb-0 ml-2">${
+                formioSFDSVersion ? `version <code>${formioSFDSVersion}</code>` : 'not provided (injected <a id="formio-sfds-url">built JS</a>)'
+              }</dd>
+
+              <dt><b>Form data source URL</b></dt>
+              <dd class="mb-1 ml-2">${
+                source ? `<a href="${source}"><code>${source}</code></a>` : 'not provided'
+              }</dd>
+
+              <dt><b>Form options</b></dt>
+              <dd class="mb-1 ml-2">${
+                options ? `<pre>${JSON.stringify(JSON.parse(options), null, 2)}</pre>` : 'none provided'
+              }</dd>
+            </ul>
+          </div>
+        </details>
+      `.trim()
+
+      div.parentNode.insertBefore(info, div)
+    } else {
+      console.warn('no [data-source] form element found!')
+    }
+  }
+
+  getScript (srcPattern) {
+    const selector = `script[src*="${srcPattern}"]`
+    return this.document.querySelector(selector)
+  }
+
+  setFormioSFDSVersion (version) {
+    const script = this.getScript('formio-sfds@')
+    if (script) {
+      if (version) {
+        script.setAttribute('src', script.src.replace(/formio-sfds@[^/]+/, `formio-sfds@${version}`))
+      } else {
+        script.removeAttribute('src')
+        script.textContent = `
+          var script = document.createElement('script')
+          var baseUrl = [
+            location.protocol, '//', location.hostname,
+            location.port ? ':' + location.port : ''
+          ].join('')
+          script.src = baseUrl + '/dist/formio-sfds.standalone.js'
+          console.info('injected formio-sfds:', script.src)
+          document.body.appendChild(script)
+          document.getElementById('formio-sfds-url').href = script.src
+        `
+      }
+    } else {
+      throw new Error('No <script> found with formio-sfds in the src attribute')
+    }
+  }
+
+  setFormioJSVersion (version) {
+    const script = this.getScript('formiojs@')
+    if (script) {
+      script.setAttribute('src', script.src.replace(/formiojs@[^/]+/, `formio-sfds@${version}`))
+    } else {
+      throw new Error('No <script> found with formiojs in the src attribute')
+    }
+  }
+
+  element (name, attrs = {}, children = []) {
+    const el = this.document.createElement(name)
+    if (attrs) {
+      for (const [key, value] of Object.entries(attrs)) {
+        el.setAttribute(key, value)
+      }
+    }
+    if (typeof children === 'string') {
+      el.innerHTML = children
+    } else if (Array.isArray(children)) {
+      for (const child of children) {
+        el.appendChild(child)
+      }
+    }
+    return el
+  }
+
+  send (res) {
+    const html = this.dom.serialize()
+    res.setHeader('Content-Type', 'text/html')
+    res.setHeader('Content-Length', Buffer.byteLength(html))
+    res.end(html, 'utf8')
+  }
+}

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -23,6 +23,7 @@ export class Proxy {
     console.warn('fetching:', url)
     return fetch(url)
       .then(async res => {
+        this.response = res
         this.url = url
         this.body = await res.text()
         this.dom = new JSDOM(this.body)

--- a/src/patch.js
+++ b/src/patch.js
@@ -117,7 +117,9 @@ function patch (Formio) {
         return form
       }
 
-      if (debug) console.log('SFDS form created!')
+      if (debug) {
+        // console.log('SFDS form created!')
+      }
 
       const phrase = new Phrase(form)
       form.phrase = phrase

--- a/src/patch.js
+++ b/src/patch.js
@@ -129,7 +129,7 @@ function patch (Formio) {
         if (loaded) {
           googleTranslate = false
 
-          if (loaded.projectId && userIsTranslating()) {
+          if (loaded.projectId && userIsTranslating(opts)) {
             phrase.enableEditor()
           } else if (debug) {
             console.warn('loaded Phrase translations, but not the in-context editor', loaded, window.drupalSettings, window.location.search)
@@ -353,7 +353,10 @@ function scrollToTop () {
   window.scroll(0, 0)
 }
 
-function userIsTranslating () {
+function userIsTranslating (opts) {
+  if (opts?.translate === true) {
+    return true
+  }
   const uid = window.drupalSettings?.user?.uid
   if (uid && uid !== '0') {
     const translate = new URLSearchParams(window.location.search).get('translate')

--- a/src/patch.js
+++ b/src/patch.js
@@ -166,6 +166,9 @@ function patch (Formio) {
       // Note: we create a shallow copy of the form model so the .form setter
       // will treat it as changed. (form.io showed us this trick!)
       const model = { ...form.form }
+      if (opts.disableConditionals) {
+        disableConditionals(model.components)
+      }
       patchSelectMode(model)
       form.form = model
 
@@ -351,6 +354,13 @@ function getFlatpickrLocale (code) {
 
 function scrollToTop () {
   window.scroll(0, 0)
+}
+
+function disableConditionals (components) {
+  util.eachComponent(components, comp => {
+    comp.properties.conditional = comp.conditional
+    comp.conditional = {}
+  })
 }
 
 function userIsTranslating (opts) {

--- a/src/phrase.js
+++ b/src/phrase.js
@@ -55,17 +55,15 @@ export default class Phrase {
     }
   }
 
-  formatKey (keyOrKeys, options = {}) {
-    const multiple = Array.isArray(keyOrKeys) && keyOrKeys.length > 1
-    const english = multiple ? keyOrKeys[keyOrKeys.length - 1] : ''
-    if (multiple && !english) {
-      // we need to return a "truthy" string here, otherwise form.io
-      // will use the key provided as a fallback
-      return ' '
+  formatKey (keys, options = {}) {
+    const multiple = Array.isArray(keys) && keys.length > 1
+    const fallback = multiple ? keys[keys.length - 1] : ''
+    if (multiple && !fallback) {
+      return ''
     }
 
     const { prefix, suffix } = this.config
-    let key = multiple ? keyOrKeys[0] : keyOrKeys
+    let key = multiple ? keys[0] : keys
     const { context, contextSeparator = '._.' } = options || {}
     if (context) {
       key = `${key}${contextSeparator}${context}`
@@ -73,18 +71,15 @@ export default class Phrase {
     return `${prefix}phrase_${key}${suffix}`
   }
 
-  t (keyOrKeys, options) {
-    const { form: { i18next }, reverseLookup } = this
+  t (keys, options) {
+    const value = Array.isArray(keys) ? keys[keys.length - 1] : keys
 
-    if (Array.isArray(keyOrKeys)) {
-      const key = keyOrKeys.find(k => i18next.exists(k)) || keyOrKeys[0]
-      return this.formatKey(key, options)
-    } else if (reverseLookup.has(keyOrKeys)) {
-      const key = reverseLookup.get(keyOrKeys)
+    if (value && this.reverseLookup.has(value)) {
+      const key = this.reverseLookup.get(value)
       return this.formatKey(key, options)
     }
 
-    return this.formatKey(keyOrKeys, options)
+    return this.formatKey(keys, options)
   }
 
   get props () {

--- a/src/templates/component/form.ejs
+++ b/src/templates/component/form.ejs
@@ -8,4 +8,20 @@
     {{ ctx.children }}
     <div class="messages" ref="messageContainer"></div>
   {% } %}
+
+  {% if (ctx.options.translate && ctx.component.type !== 'panel') { %}
+    {% const validateCustom = ctx.tk('validate.custom') %}
+    {% if (validateCustom) { %}
+      <div class="fg-red-4 mt-2">
+        <b>Custom validation message:</b> {{ validateCustom }}
+      </div>
+    {% } %}
+
+    {% const customError = ctx.tk('customError') %}
+    {% if (customError) { %}
+      <div class="fg-red-4">
+        <b>Custom error message:</b> {{ customError }}
+      </div>
+    {% } %}
+  {% } %}
 </div>

--- a/src/templates/component/form.ejs
+++ b/src/templates/component/form.ejs
@@ -9,8 +9,8 @@
     <div class="messages" ref="messageContainer"></div>
   {% } %}
 
-  {% if (ctx.options.translate && ctx.component.type !== 'panel') { %}
-    {% const validateCustom = ctx.tk('validate.custom') %}
+  {% if (ctx.options.translate && ['panel', 'content', 'htmlelement'].indexOf(ctx.component.type) === -1) { %}
+    {% const validateCustom = ctx.tk('validate.custom', ctx.component.validate.custom) %}
     {% if (validateCustom) { %}
       <div class="fg-red-4 mt-2">
         <b>Custom validation message:</b> {{ validateCustom }}

--- a/src/templates/html/form.ejs
+++ b/src/templates/html/form.ejs
@@ -1,4 +1,4 @@
-{% const key = ctx.component.type === 'html' ? 'content' : 'html' %}
+{% const key = ctx.component.type === 'content' ? 'html' : 'content' %}
 <{{ctx.tag}} class="{{ ctx.component.className }}" ref="html"
   {% ctx.attrs.forEach(function(attr) { %}
     {{attr.attr}}="{{attr.value}}"

--- a/src/templates/html/form.ejs
+++ b/src/templates/html/form.ejs
@@ -1,5 +1,6 @@
+{% const key = ctx.component.type === 'html' ? 'content' : 'html' %}
 <{{ctx.tag}} class="{{ ctx.component.className }}" ref="html"
   {% ctx.attrs.forEach(function(attr) { %}
     {{attr.attr}}="{{attr.value}}"
   {% }) %}
->{{ ctx.tk('content', ctx.content) }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}
+>{{ ctx.tk(key, ctx.content) }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}

--- a/src/templates/panel/form.ejs
+++ b/src/templates/panel/form.ejs
@@ -1,4 +1,13 @@
 <section id="panel-{{ ctx.component.key }}" class="border-1 border-grey-2 p-2 round-1 mb-4">
+  {% if (ctx.options.translate) { %}
+    {% const displayTitle = ctx.tk('displayTitle', ctx.component.properties.displayTitle) %}
+    {% if (displayTitle) { %}
+      <h2 class="h5 m-0">
+        <b class="fg-light-slate">Link title:</b>
+        {{ displayTitle }}
+      </h2>
+    {% } %}
+  {% } %}
   <h1 class="d1 mt-0 mb-4">
     {{ ctx.tk('title') }}
   </h1>

--- a/src/templates/wizard/form.ejs
+++ b/src/templates/wizard/form.ejs
@@ -3,14 +3,14 @@
   <div class="d-flex flex-column flex-md-row flex-md-auto flex-justify-between">
     <div class="col-md-2">
       {% if (!panel.properties.hideSidebar || panel.properties.hideSidebar !== "true") { %}
-      {{ ctx.wizardHeader }}
+        {{ ctx.wizardHeader }}
       {% } %}
     </div>
     <div class="col-md-4">
       <div class="mb-3">
         {% if (panel) { %}
           <h1 class="d1 mb-4 mr-n2">
-            {{ ctx.t(panel.properties.displayTitle || panel.title) }}
+            {{ ctx.t([`${panel.key}.title`, panel.title]) }}
           </h1>
         {% } %}
         <div class="components" ref="{{ ctx.wizardKey }}">

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -3,7 +3,7 @@
 
   {% if (properties.backURL) { %}
     <a class="back-link fg-black fw-medium" href="{{ properties.backURL }}">
-      {{ ctx.t(properties.backTitle || 'Back', { context: 'nav' }) }}
+      {{ ctx.t(['form.backTitle', properties.backTitle || 'Back']) }}
     </a>
   {% } %}
 

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -24,7 +24,13 @@
               ref="{{ ctx.wizardKey }}-link"
             {% } %}
           >
-            {{ ctx.t([`${panel.key}.title`, panel.title]) }}
+            {{
+              ctx.t([
+                `${panel.key}.displayTitle`,
+                `${panel.key}.title`,
+                panel.properties.displayTitle || panel.title
+              ])
+            }}
           </button>
         </li>
       {%

--- a/src/templates/wizardHeader/form.ejs
+++ b/src/templates/wizardHeader/form.ejs
@@ -24,7 +24,7 @@
               ref="{{ ctx.wizardKey }}-link"
             {% } %}
           >
-            {{ ctx.t(panel.properties.displayTitle || panel.title, { context: 'nav' }) }}
+            {{ ctx.t([`${panel.key}.title`, panel.title]) }}
           </button>
         </li>
       {%

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,18 @@
     {
       "source": "/examples/:example",
       "destination": "/dist/examples/:example.html"
+    },
+    {
+      "source": "/preview",
+      "destination": "/api/preview"
+    },
+    {
+      "source": "/strings",
+      "destination": "/api/strings"
+    },
+    {
+      "source": "/translate",
+      "destination": "/api/translate"
     }
   ],
   "build": {

--- a/vercel.json
+++ b/vercel.json
@@ -11,18 +11,6 @@
     {
       "source": "/examples/:example",
       "destination": "/dist/examples/:example.html"
-    },
-    {
-      "source": "/preview",
-      "destination": "/api/preview"
-    },
-    {
-      "source": "/strings",
-      "destination": "/api/strings"
-    },
-    {
-      "source": "/translate",
-      "destination": "/api/translate"
     }
   ],
   "build": {


### PR DESCRIPTION
This is a big update to the localization docs that adds a lot more detail describing the process for getting from form to Phrase and back again. The code changes support this process:

1. Panel (form page) titles are properly localized round-trip now, so you can translate their titles in the left-hand nav.
1. The `form.backTitle` string key is used to localize the "Back" text that shows up if you provide `properties.backURL` in your form.
1. The `translate` form option short-circuits checks for `window.drupalSettings` so that the in-context editor can be enabled on any page that loads a form with that option hard-coded.
1. The HTTP proxy used in the preview API endpoint has been ripped out so that we can reuse it in a new translation view.
1. The new `/api/translate` endpoint renders a proxied sf.gov page with the `translate: true` and `unlockNavigation: true` form options set, which enables the in-context editor and allows navigation between form pages without validation.
1. The vercel config now adds rewrites for `/api/preview`, `/api/strings`, and `/api/translate` to URLs without the `/api` prefix so that they're easier to remember.

### New view for translators
The new translation view lives at `/api/translate?url=<URL>`, where `<URL>` is the URL of your _published_ form on sf.gov (or test-sfgov). For instance, [this is the translate view](https://formio-sfds-git-translate-view.sfds.vercel.app/api/translate?url=https://sf.gov/node/1339) for the [Cannabis social equity applicant questionnaire](https://sf.gov/node/1339), once you've signed in with Phrase:

![image](https://user-images.githubusercontent.com/113896/97494868-2bd79d80-1924-11eb-948a-d0a007f149d5.png)

There are a couple of important things going on here:

1. The "wizard" view is disabled so that translators can see the whole form at once.
2. Form conditionals are disabled so that all fields are visible.
3. Some templates have additional output specific to the translation view:
    * Panel components (pages in a wizard form) display an additional "Link title" heading that allows you to translate the text of the link that shows up in the side navigation of the wizard view:

        ![image](https://user-images.githubusercontent.com/113896/97495173-9688d900-1924-11eb-8f9d-13fe2bb78e94.png)

        These translations live in the `{key}.displayTitle` string in Phrase, and are only shown if the `displayTitle` custom property is set in the form.io editor.

    * All components except panel and content types display the text of custom validation and error messages in red if they're _not_ empty in the form.io editor.