### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: Release
 on:
   workflow_dispatch:
     inputs:
@@ -16,7 +17,7 @@ jobs:
         with:
           node-version: 12
       - run: |
-          script/version "${{ github.event.inputs.version }}"
+          npm version "${{ github.event.inputs.version }}"
           echo "RELEASE_VERSION=$(npm view . version)" >> $GITHUB_ENV
       - uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
This adds a title to the release workflow from #135 and has it run `npm version {{version}}` rather than `script/version`, which should sidestep the need to configure git with name and email.

Sorry for the noise! The workflow only runs from the `main` branch, so I have to open a PR for every change. 😬 