### PR TITLE
Add "what the form" view

### DIFF
--- a/__tests__/phrase.js
+++ b/__tests__/phrase.js
@@ -102,7 +102,7 @@ describe('Phrase helpers', () => {
         }
       }))
 
-      await phrase.loadTranslations()
+      await phrase.load(loadTranslations)
 
       expect(phrase.reverseLookup.has('Hello')).toBe(true)
       expect(phrase.t('Hello')).toEqual('[[__phrase_greeting__]]')

--- a/api/wtf.js
+++ b/api/wtf.js
@@ -1,0 +1,122 @@
+import fetch from 'node-fetch'
+import { URL } from 'url'
+import { join } from 'path'
+import nunjucks from 'nunjucks'
+import Phrase from '../src/phrase'
+import { Proxy } from '../lib/proxy'
+
+const templates = nunjucks.configure(join(__dirname, '../views'), {
+  autoescape: false
+})
+
+module.exports = async (req, res) => {
+  const { query } = req
+  const { url } = query
+
+  const data = {
+    input: query,
+    sfgov: {},
+    formio: {},
+    formiojs: {},
+    theme: {},
+    translation: {}
+  }
+
+  if (url) {
+    const parsed = new URL(url)
+
+    if (isSFGovURL(parsed)) {
+      data.sfgov.url = url
+
+      const proxy = new Proxy({ base: url })
+      const { document } = await proxy.fetch(parsed.path)
+      const element = document.querySelector('[data-source]')
+      if (element) {
+        data.formio.url = element.getAttribute('data-source')
+        const form = await fetch(data.formio.url).then(res => res.json())
+        data.formio.form = form
+
+        if (element.hasAttribute('data-options')) {
+          const options = JSON.parse(element.getAttribute('data-options'))
+          data.formio.options = options
+
+          if (typeof options.i18n === 'string') {
+            data.translation.url = options.i18n
+            const match = options.i18n.match(/google\/([^@])/)
+            data.translation.source = {
+              title: 'Google Sheets',
+              url: `https://docs.google.com/spreadsheets/d/${match[1]}/edit`
+            }
+          }
+        }
+      }
+
+      const formioScript = proxy.getScript('formiojs')
+      if (formioScript) {
+        data.formiojs.url = formioScript.src
+        data.formiojs.version = getUnpkgVersion(formioScript.src)
+      }
+
+      const themeScript = proxy.getScript('formio-sfds')
+      if (themeScript) {
+        data.theme.url = themeScript.src
+        data.theme.version = getUnpkgVersion(themeScript.src)
+      }
+    } else if (isFormioPortalURL(parsed)) {
+      const parts = parsed.hash.replace(/^#\//, '').split('/')
+      if (parts[0] === 'project' && parts[2] === 'form' && parts[3]) {
+        const formId = parts[3]
+        const [form] = await fetch(`http://sfds.form.io/form?_id__eq=${formId}`).then(res => res.json())
+        if (form) {
+          data.formio.form = form
+          data.formio.url = `https://sfds.form.io/${form.path}`
+        } else {
+          data.error = `Unable to find form with ID: "${formId}"`
+        }
+      }
+    } else if (isDataSourceURL(parsed)) {
+      data.formio.url = url
+      data.formio.form = await fetch(url).then(res => res.json())
+    }
+
+    const { form } = data.formio
+    if (form) {
+      const phrase = new Phrase(form)
+      const info = phrase.getTranslationInfo()
+      if (info && info.url) {
+        data.translation.url = info.url
+        data.translation.source = {
+          title: `Phrase project ${info.projectId}`,
+          url: '' // TODO
+        }
+      }
+    }
+  } else {
+    data.error = 'Please enter a URL from sf.gov or form.io'
+  }
+
+  res.setHeader('Content-Type', 'text/html')
+  const content = templates.render('wtf.html', data)
+  res.send(content)
+}
+
+function isSFGovURL (url) {
+  return url.hostname === 'sf.gov' || (
+    url.hostname.includes('sfgov') &&
+    url.hostname.endsWith('.pantheonsite.io')
+  )
+}
+
+function isFormioPortalURL (url) {
+  return url.hostname === 'portal.form.io'
+}
+
+function isDataSourceURL (url) {
+  return url.hostname.endsWith('.form.io') &&
+    url.hostname.includes('sfds')
+}
+
+function getUnpkgVersion (url) {
+  const match = url.match(/@([^/]+)/)
+  return match ? match[1] : undefined
+}

--- a/api/wtf.js
+++ b/api/wtf.js
@@ -14,6 +14,17 @@ const templates = nunjucks.configure(join(__dirname, '../views'), {
   autoescape: false
 })
 
+const languageNames = {
+  en: 'English',
+  es: 'Spanish',
+  zh: 'Chinese',
+  'zh-hant': 'Chinese (Traditional)',
+  'zh-hans': 'Chinese (Simplified)',
+  'zh-tw': 'Chinese (Taiwan)',
+  fil: 'Filipino',
+  tl: 'Tagalog'
+}
+
 module.exports = async (req, res) => {
   const { query } = req
   const { url } = query
@@ -145,6 +156,23 @@ async function getSFgovData (url, data) {
   data.sfgov.url = url
   data.sfgov.title = document.title.replace(/\s*\|\s*San Francisco\s*$/, '')
 
+  const { lang } = document.documentElement
+  data.lang = {
+    code: lang,
+    name: languageNames[lang.toLowerCase()],
+    links: Array.from(document.querySelectorAll('link[rel="alternate"]'), link => {
+      const code = link.hreflang
+      return {
+        href: link.href,
+        lang: {
+          code,
+          name: languageNames[code]
+        }
+      }
+    })
+      .filter(link => link.lang.code !== lang)
+  }
+
   const element = document.querySelector('[data-source]')
   if (element) {
     data.formio.url = element.getAttribute('data-source')
@@ -182,5 +210,5 @@ async function getSFgovData (url, data) {
 async function getSFGovPages (options) {
   const { data } = await fetch(`${FORMS_API_URL}/api/sfgov`)
     .then(res => res.json())
-  return data && data.forms || []
+  return (data && data.forms) || []
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -127,7 +127,7 @@ function patch (Formio) {
       let { googleTranslate } = opts
 
       try {
-        const loaded = await phrase.loadTranslations()
+        const loaded = await phrase.load(loadTranslations)
         if (loaded) {
           googleTranslate = false
 

--- a/src/phrase.js
+++ b/src/phrase.js
@@ -1,5 +1,4 @@
 import interpolate from 'interpolate'
-import loadTranslations from './i18n/load'
 
 const I18NEXT_DEFAULT_NAMESPACE = 'translation' // ???
 const I18N_SERVICE_URL = process.env.I18N_SERVICE_URL || 'https://translate.sf.gov'
@@ -84,7 +83,11 @@ export default class Phrase {
 
   get props () {
     const { form } = this
-    const props = Object.assign({}, form.form.properties, form.options)
+    const props = Object.assign(
+      {},
+      form.properties || form.form.properties,
+      form.options
+    )
     const {
       phraseProjectId,
       phraseProjectVersion,
@@ -122,7 +125,7 @@ export default class Phrase {
     return undefined
   }
 
-  async loadTranslations () {
+  async load (loadTranslations) {
     const { form, reverseLookup } = this
     const { i18next, options: { debug = debugDefault } } = form
     const info = this.getTranslationInfo()

--- a/views/wtf.html
+++ b/views/wtf.html
@@ -127,9 +127,15 @@
                 <a href="{{ translation.url }}">data API</a>
               )
             {% else %}
-              ⚠️  <b>This form has not been translated.</b>
-              Please <a href="/docs/localization/#translate-a-form">see the docs</a>
-              to start the translation process.
+              <div>
+                ⚠️  <b>This form has not been translated.</b>
+                Please <a href="/docs/localization/#translate-a-form">see
+                the docs</a> to start the translation process.
+              </div>
+              <div class="mt-1">
+                Download the strings for this form by holding <kbd>option</kbd>
+                when clicking <a href="/api/strings?formUrl={{ formio.url }}">this JSON link</a>.
+              </div>
             {% endif %}
           </dd>
 

--- a/views/wtf.html
+++ b/views/wtf.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>What the form | formio-sfds</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="/dist/common.css">
+  </head>
+  <body>
+    <div class="formio-sfds">
+      <div class="container p-2">
+        <h1 class="h3 mb-4">
+          <a href="/">formio-sfds@{{ pkg.version }}</a> /
+          What the form
+        </h1>
+        <form class="mb-2">
+          <h2>
+            <label for="url-input">Enter a URL</label>
+          </h2>
+          <div>
+            <input type="text" id="url-input" name="url" value="{{ input.url }}">
+          </div>
+        </form>
+
+        {% if error %}
+          <div class="bg-red-1 p-2 border-1 border-red-3 round-1">
+            {{ error }}
+          </div>
+        {% else %}
+          <dl>
+            {% if sfgov.url %}
+              <dt>SFgov URL</dt>
+              <dd>
+                <a href="{{ sfgov.url }}">{{ sfgov.url }}</a>
+              </dd>
+            {% endif %}
+
+            {% if formio.form %}
+              <dt>Form.io form</dt>
+              <dd>
+                <a href="{{ formio.url }}">{{ formio.form.title }}</a>
+                {% set formio_url -%}
+                  https://portal.form.io/#/project/{{ formio.form.project }}/form/{{ formio.form._id }}
+                {%- endset %}
+                (
+                  <a href="{{ formio_url }}/edit">edit</a> |
+                  <a href="{{ formio_url }}/settings">settings</a> |
+                  <a href="{{ formio_url }}/submission">submissions</a>
+                )
+              </dd>
+            {% elif formio.url %}
+              <dt>Form.io data source URL</dt>
+              <dd>
+                <a href="{{ formio.url }}">{{ formio.url }}</a>
+              </dd>
+            {% endif %}
+
+            {% if formio.options %}
+              <dt>Form.io render options</dt>
+              <dd>
+                <pre>{{ formio.options | dump(2) }}</pre>
+              </dd>
+            {% endif %}
+
+            {% if translation.url %}
+              <dt>Translation</dt>
+              <dd>
+                {% if translation.source %}
+                  <a href="{{ translation.source.url }}">{{ translation.source.title }}</a>
+                → {% endif %}<a href="{{ translation.url }}">API data</a>
+              </dd>
+            {% endif %}
+
+            {% if formiojs.version %}
+              <dt>formio.js version</dt>
+              <dd>
+                <a href="https://unpkg.com/formiojs@{{ formiojs.version }}/">
+                  <code>{{ formiojs.version }}</code>
+                </a>
+                (<a href="https://github.com/formio/formio.js/blob/v{{ formiojs.version }}/Changelog.md#readme">
+                  changelog
+                </a>)
+              </dd>
+            {% endif %}
+            {% if theme.version %}
+              <dt>formio-sfds theme version</dt>
+              <dd>
+                <a href="https://unpkg.com/formio-sfds@{{ theme.version }}/">
+                  <code>{{ theme.version }}</code>
+                </a>
+                (<a href="https://github.com/SFDigitalServices/formio-sfds/releases/tag/v{{ theme.version }}">
+                  release notes
+                </a>)
+              </dd>
+            {% endif %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.min.js"></script>
+    <script src="/dist/formio-sfds.standalone.js"></script>
+  </body>
+</html>

--- a/views/wtf.html
+++ b/views/wtf.html
@@ -30,7 +30,7 @@
           </div>
           {% if pages %}
             <div class="mt-1">
-              <label for="page-select">...or select an existing form:</label>
+              <label for="page-select">...or choose a live form:</label>
               <select id="page-select">
                 <option></option>
                 {% for page in pages %}

--- a/views/wtf.html
+++ b/views/wtf.html
@@ -1,12 +1,24 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>What the form | formio-sfds</title>
+    <title>WTF | formio-sfds</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/dist/common.css">
+    <link rel="stylesheet" href="//unpkg.com/highlight.js@10.3.2/styles/github.css">
     <style>
-      dt { font-weight: bold; }
+      dt {
+        font-weight: bold;
+      }
+
+      pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      .hljs {
+        padding: 0;
+      }
     </style>
   </head>
   <body>
@@ -14,11 +26,12 @@
       <div class="container p-2">
         <h1 class="h3 mb-4">
           <a href="/">formio-sfds@{{ pkg.version }}</a> /
-          What the form
+          WTF
         </h1>
+        <h2 class="d-1">What the form</h2>
         <form class="mb-4">
           <h2>
-            <label for="url-input">Enter a URL</label>
+            <label for="url-input">Enter a URL:</label>
           </h2>
           <div class="d-flex flex-align-start">
             <div class="flex-auto mr-2">
@@ -28,9 +41,12 @@
               <button class="btn" type="submit">Go!</button>
             </div>
           </div>
+          <div class="small fg-light-slate mt-1">
+            Form page URLs on sf.gov (or Pantheon sites) and form.io URLs (including edit links) <em>should</em> work.
+          </div>
           {% if pages %}
             <div class="mt-1">
-              <label for="page-select">...or choose a live form:</label>
+              <label for="page-select">or choose a live form:</label>
               <select id="page-select">
                 <option></option>
                 {% for page in pages %}
@@ -39,6 +55,9 @@
                   </option>
                 {% endfor %}
               </select>
+              <div class="small fg-light-slate mt-1">
+                Selecting a page will populate the URL field above and submit the form automatically.
+              </div>
             </div>
           {% endif %}
         </form>
@@ -59,10 +78,19 @@
 
         <dl>
           {% if sfgov.url %}
-            <dt>SF.gov page</dt>
+            <dt>SF.gov form page</dt>
             <dd class="mb-2">
-              {{ sfgov.title }}:<br>
+              {{ sfgov.title }}<br>
               <a href="{{ sfgov.url }}">{{ sfgov.url }}</a>
+              ( <a href="{{ sfgov.url }}/edit">edit</a> )<br>
+              Document language: {{ lang.name | default('English') }} ( <code>{{ lang.code | default('en') }}</code> )
+              {% if lang.links %}
+                <br>View in other languages:
+                {% for link in lang.links %}
+                  <a href="?url={{ link.href }}">{{ link.lang.name }}</a>
+                  {% if not loop.last %} | {% endif %}
+                {% endfor %}
+              {% endif %}
             </dd>
           {% endif %}
 
@@ -70,9 +98,7 @@
             <dt>Form.io form</dt>
             <dd class="mb-2">
               <a href="{{ formio.url }}">{{ formio.form.title }}</a>
-              {% set formio_url -%}
-                https://portal.form.io/#/project/{{ formio.form.project }}/form/{{ formio.form._id }}
-              {%- endset %}
+              {% set formio_url %}https://portal.form.io/#/project/{{ formio.form.project }}/form/{{ formio.form._id }}{% endset %}
               (
                 <a href="{{ formio_url }}/edit">edit</a> |
                 <a href="{{ formio_url }}/settings">settings</a> |
@@ -86,16 +112,9 @@
             </dd>
           {% endif %}
 
-          {% if formio.options %}
-            <dt>Form.io render options</dt>
-            <dd class="mb-2">
-              <pre class="my-0">{{ formio.options | dump(2) }}</pre>
-            </dd>
-          {% endif %}
-
-          {% if translation.url %}
-            <dt>Translation</dt>
-            <dd class="mb-2">
+          <dt class="{% if not translation.url %}fg-red-4{% endif %}">Translation</dt>
+          <dd class="mb-2">
+            {% if translation.url %}
               {% if translation.source %}
                 {% if translation.source.url %}
                   <a href="{{ translation.source.url }}">{{ translation.source.title }}</a>
@@ -107,8 +126,12 @@
                 <a href="/api/strings?formUrl={{ formio.url }}">get strings</a> |
                 <a href="{{ translation.url }}">data API</a>
               )
-            </dd>
-          {% endif %}
+            {% else %}
+              ⚠️  <b>This form has not been translated.</b>
+              Please <a href="/docs/localization/#translate-a-form">see the docs</a>
+              to start the translation process.
+            {% endif %}
+          </dd>
 
           {% if formiojs.version %}
             <dt>formio.js version</dt>
@@ -116,9 +139,9 @@
               <a href="https://unpkg.com/formiojs@{{ formiojs.version }}/">
                 <code>{{ formiojs.version }}</code>
               </a>
-              (<a href="https://github.com/formio/formio.js/blob/v{{ formiojs.version }}/Changelog.md#readme">
+              ( <a href="https://github.com/formio/formio.js/blob/v{{ formiojs.version }}/Changelog.md#readme">
                 changelog
-              </a>)
+              </a> )
             </dd>
           {% endif %}
           {% if theme.version %}
@@ -127,9 +150,9 @@
               <a href="https://unpkg.com/formio-sfds@{{ theme.version }}/">
                 <code>{{ theme.version }}</code>
               </a>
-              (<a href="https://github.com/SFDigitalServices/formio-sfds/releases/tag/v{{ theme.version }}">
+              ( <a href="https://github.com/SFDigitalServices/formio-sfds/releases/tag/v{{ theme.version }}">
                 release notes
-              </a>)
+              </a> )
               <form action="/api/preview">
                 Preview this page with formio-sfds version:
                 <input type="text" name="version" value="latest" class="d-inline-block mx-1" style="width: 8em;">
@@ -138,14 +161,29 @@
               </form>
             </dd>
           {% endif %}
+
+          {% if formio.options %}
+            <dt>Form.io render options</dt>
+            <dd class="mb-2">
+              <pre class="my-0"><code class="language-json bg-none">{{ formio.options | dump(2) }}</code></pre>
+            </dd>
+          {% endif %}
         </dl>
+
+        <details>
+          <summary>Response HTML</summary>
+          <pre class="border-1 border-bright-blue p-2 m-0 round-bottom-1"><code class="language-html bg-none">{{ body | e }}</code></pre>
+        </details>
 
       </div>
     </div>
 
-    <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.min.js"></script>
+    <script src="//unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.min.js"></script>
     <script src="/dist/formio-sfds.standalone.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.2/highlight.min.js"></script>
     <script>
+      hljs.initHighlightingOnLoad()
+
       var select = document.getElementById('page-select')
       if (select) {
         select.addEventListener('change', e => {

--- a/views/wtf.html
+++ b/views/wtf.html
@@ -5,6 +5,9 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/dist/common.css">
+    <style>
+      dt { font-weight: bold; }
+    </style>
   </head>
   <body>
     <div class="formio-sfds">
@@ -18,7 +21,8 @@
             <label for="url-input">Enter a URL</label>
           </h2>
           <div>
-            <input type="text" id="url-input" name="url" value="{{ query.url }}">
+            <input type="text" id="url-input" name="url" value="{{ query.url }}" class="mb-1">
+            <button class="btn" type="submit">Go!</button>
           </div>
         </form>
 
@@ -39,15 +43,15 @@
         <dl>
           {% if sfgov.url %}
             <dt>SF.gov page</dt>
-            <dd>
-              {% if sfgov.title %}<b>{{ sfgov.title }}</b>{% endif %}
+            <dd class="mb-2">
+              {{ sfgov.title }}:<br>
               <a href="{{ sfgov.url }}">{{ sfgov.url }}</a>
             </dd>
           {% endif %}
 
           {% if formio.form %}
             <dt>Form.io form</dt>
-            <dd>
+            <dd class="mb-2">
               <a href="{{ formio.url }}">{{ formio.form.title }}</a>
               {% set formio_url -%}
                 https://portal.form.io/#/project/{{ formio.form.project }}/form/{{ formio.form._id }}
@@ -60,30 +64,38 @@
             </dd>
           {% elif formio.url %}
             <dt>Form.io data source URL</dt>
-            <dd>
+            <dd class="mb-2">
               <a href="{{ formio.url }}">{{ formio.url }}</a>
             </dd>
           {% endif %}
 
           {% if formio.options %}
             <dt>Form.io render options</dt>
-            <dd>
-              <pre>{{ formio.options | dump(2) }}</pre>
+            <dd class="mb-2">
+              <pre class="my-0">{{ formio.options | dump(2) }}</pre>
             </dd>
           {% endif %}
 
           {% if translation.url %}
             <dt>Translation</dt>
-            <dd>
+            <dd class="mb-2">
               {% if translation.source %}
-                <a href="{{ translation.source.url }}">{{ translation.source.title }}</a>
-              → {% endif %}<a href="{{ translation.url }}">API data</a>
+                {% if translation.source.url %}
+                  <a href="{{ translation.source.url }}">{{ translation.source.title }}</a>
+                {% else %}
+                  {{ translation.source.title }}
+                {% endif %}
+              {% endif %}
+              (
+                <a href="/api/strings?formUrl={{ formio.url }}">get strings</a> |
+                <a href="{{ translation.url }}">data API</a>
+              )
             </dd>
           {% endif %}
 
           {% if formiojs.version %}
             <dt>formio.js version</dt>
-            <dd>
+            <dd class="mb-2">
               <a href="https://unpkg.com/formiojs@{{ formiojs.version }}/">
                 <code>{{ formiojs.version }}</code>
               </a>
@@ -94,13 +106,19 @@
           {% endif %}
           {% if theme.version %}
             <dt>formio-sfds theme version</dt>
-            <dd>
+            <dd class="mb-2">
               <a href="https://unpkg.com/formio-sfds@{{ theme.version }}/">
                 <code>{{ theme.version }}</code>
               </a>
               (<a href="https://github.com/SFDigitalServices/formio-sfds/releases/tag/v{{ theme.version }}">
                 release notes
               </a>)
+              <form action="/api/preview">
+                Preview this page with formio-sfds version:
+                <input type="text" name="version" value="latest" class="d-inline" style="width: 5em;">
+                <input type="hidden" name="url" value="{{ sfgov.url }}">
+                <button type="submit" class="btn">Go!</button>
+              </form>
             </dd>
           {% endif %}
         </dl>

--- a/views/wtf.html
+++ b/views/wtf.html
@@ -16,18 +16,35 @@
           <a href="/">formio-sfds@{{ pkg.version }}</a> /
           What the form
         </h1>
-        <form class="mb-2">
+        <form class="mb-4">
           <h2>
             <label for="url-input">Enter a URL</label>
           </h2>
-          <div>
-            <input type="text" id="url-input" name="url" value="{{ query.url }}" class="mb-1">
-            <button class="btn" type="submit">Go!</button>
+          <div class="d-flex flex-align-start">
+            <div class="flex-auto mr-2">
+              <input type="text" id="url-input" name="url" value="{{ query.url }}">
+            </div>
+            <div>
+              <button class="btn" type="submit">Go!</button>
+            </div>
           </div>
+          {% if pages %}
+            <div class="mt-1">
+              <label for="page-select">...or select an existing form:</label>
+              <select id="page-select">
+                <option></option>
+                {% for page in pages %}
+                  <option value="{{ page.url }}">
+                  {{ page.title }} ({{ page.url }})
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          {% endif %}
         </form>
 
         {% if error %}
-          <div class="bg-red-1 p-2 border-1 border-red-3 round-1">
+          <div class="bg-red-1 p-2 border-1 border-red-3 round-1 mb-2">
             {{ error }}
           </div>
         {% endif %}
@@ -115,7 +132,7 @@
               </a>)
               <form action="/api/preview">
                 Preview this page with formio-sfds version:
-                <input type="text" name="version" value="latest" class="d-inline" style="width: 5em;">
+                <input type="text" name="version" value="latest" class="d-inline-block mx-1" style="width: 8em;">
                 <input type="hidden" name="url" value="{{ sfgov.url }}">
                 <button type="submit" class="btn">Go!</button>
               </form>
@@ -128,5 +145,16 @@
 
     <script src="https://unpkg.com/formiojs@{{ pkg.dependencies.formiojs }}/dist/formio.full.min.js"></script>
     <script src="/dist/formio-sfds.standalone.js"></script>
+    <script>
+      var select = document.getElementById('page-select')
+      if (select) {
+        select.addEventListener('change', e => {
+          if (select.value) {
+            select.form.querySelector('[name=url]').value = select.value
+            select.form.submit()
+          }
+        })
+      }
+    </script>
   </body>
 </html>

--- a/views/wtf.html
+++ b/views/wtf.html
@@ -18,7 +18,7 @@
             <label for="url-input">Enter a URL</label>
           </h2>
           <div>
-            <input type="text" id="url-input" name="url" value="{{ input.url }}">
+            <input type="text" id="url-input" name="url" value="{{ query.url }}">
           </div>
         </form>
 
@@ -26,75 +26,85 @@
           <div class="bg-red-1 p-2 border-1 border-red-3 round-1">
             {{ error }}
           </div>
-        {% else %}
-          <dl>
-            {% if sfgov.url %}
-              <dt>SFgov URL</dt>
-              <dd>
-                <a href="{{ sfgov.url }}">{{ sfgov.url }}</a>
-              </dd>
-            {% endif %}
-
-            {% if formio.form %}
-              <dt>Form.io form</dt>
-              <dd>
-                <a href="{{ formio.url }}">{{ formio.form.title }}</a>
-                {% set formio_url -%}
-                  https://portal.form.io/#/project/{{ formio.form.project }}/form/{{ formio.form._id }}
-                {%- endset %}
-                (
-                  <a href="{{ formio_url }}/edit">edit</a> |
-                  <a href="{{ formio_url }}/settings">settings</a> |
-                  <a href="{{ formio_url }}/submission">submissions</a>
-                )
-              </dd>
-            {% elif formio.url %}
-              <dt>Form.io data source URL</dt>
-              <dd>
-                <a href="{{ formio.url }}">{{ formio.url }}</a>
-              </dd>
-            {% endif %}
-
-            {% if formio.options %}
-              <dt>Form.io render options</dt>
-              <dd>
-                <pre>{{ formio.options | dump(2) }}</pre>
-              </dd>
-            {% endif %}
-
-            {% if translation.url %}
-              <dt>Translation</dt>
-              <dd>
-                {% if translation.source %}
-                  <a href="{{ translation.source.url }}">{{ translation.source.title }}</a>
-                → {% endif %}<a href="{{ translation.url }}">API data</a>
-              </dd>
-            {% endif %}
-
-            {% if formiojs.version %}
-              <dt>formio.js version</dt>
-              <dd>
-                <a href="https://unpkg.com/formiojs@{{ formiojs.version }}/">
-                  <code>{{ formiojs.version }}</code>
-                </a>
-                (<a href="https://github.com/formio/formio.js/blob/v{{ formiojs.version }}/Changelog.md#readme">
-                  changelog
-                </a>)
-              </dd>
-            {% endif %}
-            {% if theme.version %}
-              <dt>formio-sfds theme version</dt>
-              <dd>
-                <a href="https://unpkg.com/formio-sfds@{{ theme.version }}/">
-                  <code>{{ theme.version }}</code>
-                </a>
-                (<a href="https://github.com/SFDigitalServices/formio-sfds/releases/tag/v{{ theme.version }}">
-                  release notes
-                </a>)
-              </dd>
-            {% endif %}
-          </dl>
         {% endif %}
+
+        {% if warnings.length %}
+          <ul class="bg-yellow-1 p-2 border-1 border-yellow-3 round-1 list-style-none">
+            {% for warning in warnings %}
+              <li>{{ warning }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+
+        <dl>
+          {% if sfgov.url %}
+            <dt>SF.gov page</dt>
+            <dd>
+              {% if sfgov.title %}<b>{{ sfgov.title }}</b>{% endif %}
+              <a href="{{ sfgov.url }}">{{ sfgov.url }}</a>
+            </dd>
+          {% endif %}
+
+          {% if formio.form %}
+            <dt>Form.io form</dt>
+            <dd>
+              <a href="{{ formio.url }}">{{ formio.form.title }}</a>
+              {% set formio_url -%}
+                https://portal.form.io/#/project/{{ formio.form.project }}/form/{{ formio.form._id }}
+              {%- endset %}
+              (
+                <a href="{{ formio_url }}/edit">edit</a> |
+                <a href="{{ formio_url }}/settings">settings</a> |
+                <a href="{{ formio_url }}/submission">submissions</a>
+              )
+            </dd>
+          {% elif formio.url %}
+            <dt>Form.io data source URL</dt>
+            <dd>
+              <a href="{{ formio.url }}">{{ formio.url }}</a>
+            </dd>
+          {% endif %}
+
+          {% if formio.options %}
+            <dt>Form.io render options</dt>
+            <dd>
+              <pre>{{ formio.options | dump(2) }}</pre>
+            </dd>
+          {% endif %}
+
+          {% if translation.url %}
+            <dt>Translation</dt>
+            <dd>
+              {% if translation.source %}
+                <a href="{{ translation.source.url }}">{{ translation.source.title }}</a>
+              → {% endif %}<a href="{{ translation.url }}">API data</a>
+            </dd>
+          {% endif %}
+
+          {% if formiojs.version %}
+            <dt>formio.js version</dt>
+            <dd>
+              <a href="https://unpkg.com/formiojs@{{ formiojs.version }}/">
+                <code>{{ formiojs.version }}</code>
+              </a>
+              (<a href="https://github.com/formio/formio.js/blob/v{{ formiojs.version }}/Changelog.md#readme">
+                changelog
+              </a>)
+            </dd>
+          {% endif %}
+          {% if theme.version %}
+            <dt>formio-sfds theme version</dt>
+            <dd>
+              <a href="https://unpkg.com/formio-sfds@{{ theme.version }}/">
+                <code>{{ theme.version }}</code>
+              </a>
+              (<a href="https://github.com/SFDigitalServices/formio-sfds/releases/tag/v{{ theme.version }}">
+                release notes
+              </a>)
+            </dd>
+          {% endif %}
+        </dl>
+
       </div>
     </div>
 


### PR DESCRIPTION
This adds a new "what the form" view that, given one of the below URL archetypes, attempts to provide as much information about the form, any options passed, and translations, as possible:

1. Any `sf.gov` or `*sfgov*.pantheonsite.io` URL will parse out the data source URL and options from the HTML
2. Any `portal.form.io` URL will attempt to get the project and form ID from the hash (`#/project/:projectId/form/:formId`), query the "Live" stage form.io API for a form with that ID via `sfds.form.io/form?_id__eq={formId}` (check out [the form.io API docs for more info](https://apidocs.form.io/#46ee13a4-b4b6-4d6d-b34a-8cc4a398140d))
3. Any other `*sfds*.form.io` URL will be treated as a JSON data source URL

I've added support to look up pages on sf.gov by form data source URL (using an API published from our private forms repo) so that any of these should work and show the same results:

* [SF.gov URL](https://formio-sfds-git-wtf.sfds.vercel.app/api/wtf?url=https%3A%2F%2Fsf.gov%2Fnode%2F1339)
* [Data source URL](https://formio-sfds-git-wtf.sfds.vercel.app/api/wtf?url=https%3A%2F%2Fsfds.form.io%2Fdemographicsforcannabisgrant)
* [Form.io portal URL](https://formio-sfds-git-wtf.sfds.vercel.app/api/wtf?url=https%3A%2F%2Fportal.form.io%2F%23%2Fproject%2F5e6febe6392a752112cf954a%2Fform%2F5f6cf9d2d78840a11d00fa88%2Fsubmission)