### PR TITLE
Translation fixes + tests

### DIFF
--- a/__tests__/translation.js
+++ b/__tests__/translation.js
@@ -6,19 +6,41 @@ import { createForm, destroyForm } from '../lib/test-helpers'
 // all of the EJS stuff happens.
 import '../dist/formio-sfds.standalone.js'
 
-describe('field translations', () => {
-  const components = [
-    {
-      key: 'name',
-      type: 'textfield',
-      label: 'Name',
-      description: 'Please enter your name'
-    }
-  ]
+describe('generic string translations', () => {
+  describe('translates validation error types', () => {
+    it('without custom translations', async () => {
+      const form = await createForm()
+      expect(form.t('required', { field: 'foo' })).toEqual('foo is required')
+      await (form.language = 'es')
+      expect(form.t('required', { field: 'foo' })).toEqual('foo es requerido')
+    })
 
+    it('with custom translations', async () => {
+      const form = await createForm({ }, {
+        i18n: {
+          en: { required: 'required: {{field}}' },
+          es: { foo: 'El foo' }
+        }
+      })
+      expect(form.t('required', { field: 'foo' })).toEqual('required: foo')
+      await (form.language = 'es')
+      expect(form.t('required', { field: 'foo' })).toEqual('foo es requerido')
+      expect(form.t('foo')).toEqual('El foo')
+    })
+  })
+})
+
+describe('field translations', () => {
   it('translates labels', async () => {
     const form = await createForm({
-      components
+      components: [
+        {
+          key: 'name',
+          type: 'textfield',
+          label: 'Name',
+          description: 'Please enter your name'
+        }
+      ]
     }, {
       language: 'es',
       i18n: {
@@ -33,6 +55,42 @@ describe('field translations', () => {
 
     const label = form.element.querySelector('label:not(.control-label--hidden)')
     expect(label.textContent.trim()).toEqual('Nombre')
+
+    destroyForm(form)
+  })
+
+  it('translates radio option labels', async () => {
+    const form = await createForm({
+      components: [
+        {
+          key: 'color',
+          type: 'radio',
+          values: [
+            { value: 'red', label: 'Red' },
+            { value: 'green', label: 'Green' },
+            { value: 'blue', label: 'Blue' }
+          ]
+        }
+      ]
+    }, {
+      language: 'es',
+      i18n: {
+        es: {
+          'color.values.red': 'Rojo',
+          'color.values.green': 'Verde'
+        }
+      }
+    })
+
+    expect(form.i18next.language).toEqual('es')
+    expect(form.t('color.values.red')).toEqual('Rojo')
+
+    const labels = form.element.querySelectorAll('fieldset label')
+    expect(labels).toHaveLength(3)
+    expect(labels[0].textContent.trim()).toEqual('Rojo')
+    expect(labels[1].textContent.trim()).toEqual('Verde')
+    // this one does not have a translation, but it should still render the English version
+    expect(labels[2].textContent.trim()).toEqual('Blue')
 
     destroyForm(form)
   })

--- a/src/templates/radio/form.ejs
+++ b/src/templates/radio/form.ejs
@@ -31,7 +31,7 @@
           id="{{ctx.id}}{{ctx.row}}-{{item.value}}">
       </span>
       <span class="flex-auto">
-        {{ ctx.t(item.label) }}
+        {{ ctx.t([`${ctx.component.key}.values.${item.value}`, item.label]) }}
       </span>
     </label>
   {% } %}


### PR DESCRIPTION
This PR adds some more test coverage to our template translation calls and adds missing translations to radio (and "selectboxes") component item labels. This was simply an oversight on my part, and I'd like to follow this up with tests that cover other component templates I might've missed.

#150 is related because I've noticed in _some_ cases (I'm still not sure which), the validation error message translations break and we end up with keys like `required` or `pattern` rather than the default translations. The generic string tests are meant to catch if we're overwriting our generic string translations from `src/i18n/*.json` when passing in custom translations, which appears not to be the case.