### PR TITLE
Force redraw forms on language change

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -252,10 +252,18 @@ function patchLanguageObserver () {
   return observer
 }
 
-function updateLanguage (form) {
+async function updateLanguage (form) {
   const closestLangElement = form.element.closest('[lang]:not([class*=sfgov-translate-lang-])')
   if (closestLangElement) {
-    form.language = closestLangElement.getAttribute('lang')
+    const lang = closestLangElement.getAttribute('lang')
+    const currentLang = form.language || form.i18next.language
+    if (currentLang === lang) {
+      await form.redraw()
+      return lang
+    } else {
+      await (form.language = lang)
+      return lang
+    }
   }
 }
 


### PR DESCRIPTION
Over in #154 I detailed why I think Filipino translations aren't working on some forms. This is a fix, which you can test by repeatedly reloading [this preview URL](https://formio-sfds.vercel.app/api/preview?url=https://sf.gov/fil/node/1432&version=0.0.0-a84c74e) and comparing how it (for me, at least) always displays the Filipino translations. ([The sf.gov URL](https://sf.gov/fil/node/1432) does not.)

The problem appears to be that the form isn't explicitly redrawn after translations are loaded. Now, I'm not 100% sure about _why_ this works, because our patched `Formio.createForm()` implementation [fetches the Phrase translations before patching the form model object](https://github.com/SFDigitalServices/formio-sfds/blob/941409f0a33d2361174299aff0a3faa038543f01/src/patch.js#L145-L167), which _should_ always force a redraw.

My guess is that translations are being loaded, the model is being patched, _then_ the language attribute is being changed by Google Translate, which triggers our `updateLanguage()` function, and this patch just adds another `redraw()` call that forces the form to apply the new translations. But the failure state is hard to simulate because it's based on a very specific order of operations. The only proof I have that it works is by reloading the preview page over and over again in a real browser. 😬 