### PR TITLE
Add lang option to proxy preview, etc.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,6 +1,7 @@
 import { URL } from 'url'
 import fetch from 'node-fetch'
 import { JSDOM } from 'jsdom'
+import packageJson from '../package.json'
 
 export const LIVE_URL = 'https://sf.gov'
 
@@ -37,24 +38,21 @@ export class Proxy {
 
   transform (query) {
     const {
-      version: formioSFDSVersion,
-      formioVersion,
+      version,
+      formioSFDSVersion = version,
+      formiojsVersion,
+      lang,
       env = 'live'
     } = query
 
-    const {
-      document,
-      url
-    } = this
+    const { document, url } = this
 
-    let {
-      source,
-      options
-    } = query
+    let { source, options } = query
 
     this.setFormioSFDSVersion(formioSFDSVersion)
-    if (formioVersion) {
-      this.setFormioJSVersion(formioVersion)
+
+    if (formiojsVersion) {
+      this.setFormioJSVersion(formiojsVersion)
     }
 
     const div = document.querySelector('[data-source]')
@@ -64,6 +62,11 @@ export class Proxy {
       } else {
         source = div.getAttribute('data-source')
       }
+
+      if (lang) {
+        div.setAttribute('lang', lang)
+      }
+
       if (options) {
         const optstr = options instanceof Object ? JSON.stringify(options) : options
         div.setAttribute('data-options', optstr)
@@ -89,10 +92,18 @@ export class Proxy {
                 ${env ? `(via <code>env=${env}</code>)` : ''}
               </dd>
 
-              <dt><b>Theme version</b></dt>
-              <dd class="mb-0 ml-2">${
-                formioSFDSVersion ? `version <code>${formioSFDSVersion}</code>` : 'not provided (injected <a id="formio-sfds-url">built JS</a>)'
-              }</dd>
+              <dt><b>Form.io JS versions </b></dt>
+              <dd class="mb-0 ml-2">
+                <a data-script-src="formiojs">
+                  <code>formiojs@${formiojsVersion || this.getScriptVersion('formiojs')}</code>
+                </a>
+              </dd>
+              <dd class="mb-0 ml-2">
+                <a data-script-src="formio-sfds">
+                  <code>formio-sfds@${formioSFDSVersion || this.getScriptVersion('formio-sfds') || packageJson.version}</code>
+                </a>
+                ${formioSFDSVersion ? '' : ' (local)'}
+              </dd>
 
               <dt><b>Form data source URL</b></dt>
               <dd class="mb-1 ml-2">${
@@ -109,14 +120,36 @@ export class Proxy {
       `.trim()
 
       div.parentNode.insertBefore(info, div)
+
+      this.appendScript(`
+        Array.from(document.querySelectorAll('[data-script-src]')).forEach(link => {
+          var pattern = link.getAttribute('data-script-src')
+          link.href = document.querySelector('script[src*=' + pattern + ']').src
+        })
+      `)
     } else {
       console.warn('no [data-source] form element found!')
     }
   }
 
+  appendScript (code) {
+    const script = this.document.createElement('script')
+    script.textContent = `(function () { ${code} })()`
+    this.document.body.appendChild(script)
+  }
+
   getScript (srcPattern) {
     const selector = `script[src*="${srcPattern}"]`
     return this.document.querySelector(selector)
+  }
+
+  getScriptVersion (srcPattern) {
+    const script = this.getScript(srcPattern)
+    if (script) {
+      const match = script.src.match(/@([^/]+)/)
+      return match ? match[1] : undefined
+    }
+    return undefined
   }
 
   setFormioSFDSVersion (version) {
@@ -135,7 +168,6 @@ export class Proxy {
           script.src = baseUrl + '/dist/formio-sfds.standalone.js'
           console.info('injected formio-sfds:', script.src)
           document.body.appendChild(script)
-          document.getElementById('formio-sfds-url').href = script.src
         `
       }
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,13 @@ import components from './components'
 import patch from './patch'
 import templates from './templates'
 import { observeIcons } from './icons'
+import { version } from '../package.json'
 
 const framework = 'sfds'
 
 const plugin = {
   framework,
+  version,
   components,
   templates: {
     [framework]: templates


### PR DESCRIPTION
A couple of updates to the proxy preview API:

1. You can now pass `lang=(es|zh|fil)` in the query string to set the form language. (The rest of the page appears in English, but we can address that separately.)
2. We now support `formioSFDSVersion` in the query string as a replacement for the more ambiguous `version` parameter.
3. The form preview details box now includes the versions of both formiojs and formio-sfds (this library):

    ![image](https://user-images.githubusercontent.com/113896/102393867-cb60f600-3f8d-11eb-95c6-5d0a3561a416.png)

Also, the browser export now includes the version from `package.json`, which you can access in a browser via `FormioSFDS.version`.