### PR TITLE
Shared components example, better "language" option support

### DIFF
--- a/__tests__/i18n.js
+++ b/__tests__/i18n.js
@@ -47,7 +47,7 @@ describe('form localization', () => {
       document.documentElement.removeAttribute('lang')
     })
 
-    it('allows "language" option to override DOM lang', async () => {
+    it('prioritizes "language" option over DOM lang', async () => {
       const lang = 'es'
       document.documentElement.setAttribute('lang', 'en')
       const form = await createForm({}, { language: lang })

--- a/__tests__/i18n.js
+++ b/__tests__/i18n.js
@@ -46,6 +46,15 @@ describe('form localization', () => {
       destroyForm(form)
       document.documentElement.removeAttribute('lang')
     })
+
+    it('allows "language" option to override DOM lang', async () => {
+      const lang = 'es'
+      document.documentElement.setAttribute('lang', 'en')
+      const form = await createForm({}, { language: lang })
+      expect(form.options.language).toEqual(lang)
+      destroyForm(form)
+      document.documentElement.removeAttribute('lang')
+    })
   })
 
   describe('"i18n" option', () => {

--- a/src/elements/sfgov-form.js
+++ b/src/elements/sfgov-form.js
@@ -1,7 +1,14 @@
 import { mergeObjects } from '../utils'
 import { fallbackCSS, tryParse } from './utils'
 
-const { Event, Formio } = window
+const {
+  customElements,
+  Event,
+  Formio,
+  FormioSFDS,
+  HTMLElement,
+  Promise
+} = window
 
 const defaultOptions = {
   display: 'form',
@@ -9,13 +16,13 @@ const defaultOptions = {
   language: 'en'
 }
 
-export default class SFGovForm extends window.HTMLElement {
+export default class SFGovForm extends HTMLElement {
   static get elementName () {
     return 'sfgov-form'
   }
 
   static register () {
-    window.customElements.define(SFGovForm.elementName, SFGovForm)
+    customElements.define(SFGovForm.elementName, SFGovForm)
   }
 
   constructor () {
@@ -32,7 +39,8 @@ export default class SFGovForm extends window.HTMLElement {
     return mergeObjects(
       {},
       defaultOptions,
-      optionString ? tryParse(optionString) : {},
+      FormioSFDS.options,
+      optionString && tryParse(optionString),
       this.otherOptions
     )
   }
@@ -56,8 +64,9 @@ export default class SFGovForm extends window.HTMLElement {
 
   connectedCallback () {
     const data = this.formData
-    const options = this.options
-    Formio.createForm(this, data, options)
+    const { options } = this
+
+    this.created = Formio.createForm(this, data, options)
       .then(async form => {
         this.form = form
         if (options.example?.submit) {

--- a/src/examples.js
+++ b/src/examples.js
@@ -1,4 +1,11 @@
 import { SFGovForm, SFGovFormData } from './elements'
 
+const { location, FormioSFDS } = window
+
+const params = new URLSearchParams(location.search)
+for (const [key, value] of params.entries()) {
+  FormioSFDS.options[key] = value
+}
+
 SFGovForm.register()
 SFGovFormData.register()

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -1,3 +1,7 @@
+- id: shared-components
+  title: Shared components
+  form: https://sfds.form.io/sharedcomponents
+
 - id: single-file
   title: Single file upload
   form:

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,21 @@ const framework = 'sfds'
 
 const plugin = {
   framework,
-  version,
   components,
+  options: {},
   templates: {
     [framework]: templates
   }
 }
+
+Object.defineProperty(plugin, 'version', {
+  // Formio complains about the "version" key if
+  // the property is enumerable :shrug:
+  enumerable: false,
+  get () {
+    return version
+  }
+})
 
 export default plugin
 export { patch }

--- a/src/patch.js
+++ b/src/patch.js
@@ -215,7 +215,6 @@ function patch (Formio) {
         }
       }
 
-      updateLanguage(form)
       forms.push(form)
 
       return form


### PR DESCRIPTION
Three things in this PR:

1. I added [an example](https://formio-sfds-git-shared-components-example.sfds.vercel.app/examples/shared-components) that loads our shared components resource directly from form.io
2. I added the ability to pass form options into examples via the query string so that we can test shared components (and other examples) with different options at runtime
3. I fixed a bug that was causing the DOM `lang` attribute to override the `language` form option, if provided. This was preventing [`?language=es`](https://formio-sfds-git-shared-components-example.sfds.vercel.app/examples/shared-components?language=es) (check the "Next" button text) from working in examples.

Fixes #161.