### PR TITLE
Language fixes + debugging improvements

### DIFF
--- a/api/preview.js
+++ b/api/preview.js
@@ -8,6 +8,32 @@ module.exports = async (req, res) => {
     const proxy = new Proxy(query)
     await proxy.fetch(query.url || path)
     proxy.transform(query)
+    proxy.appendScript(`
+      window.setLanguage = function (lang) {
+        for (var id in Formio.forms) {
+          var form = Formio.forms[id]
+          form.language = lang
+          form.redraw()
+        }
+      }
+
+      var links = document.querySelectorAll('a[data-sfgov-translate]')
+      Array.from(links).forEach(function (link) {
+        var lang = link
+          .getAttribute('data-sfgov-translate')
+          .split('|')
+          .pop()
+        link.addEventListener('click', function (event) {
+          window.setLanguage(lang)
+          event.preventDefault()
+        })
+      })
+
+      // disable the google translate links
+      // (do this last so that if we ever get rid of jQuery it won't
+      // short-circuit the rest of the function)
+      $('.gtranslate-link').off()
+    `)
     proxy.send(res)
   } catch (error) {
     res.statusCode = 500

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -178,7 +178,7 @@ export class Proxy {
   setFormioJSVersion (version) {
     const script = this.getScript('formiojs@')
     if (script) {
-      script.setAttribute('src', script.src.replace(/formiojs@[^/]+/, `formio-sfds@${version}`))
+      script.setAttribute('src', script.src.replace(/formiojs@[^/]+/, `formiojs@${version}`))
     } else {
       throw new Error('No <script> found with formiojs in the src attribute')
     }

--- a/src/i18n/load.js
+++ b/src/i18n/load.js
@@ -14,29 +14,31 @@ export function loadTranslations (url) {
     })
 }
 
-export function getEmbeddedTranslations (model) {
-  const bundles = {}
-  FormioUtils.eachComponent(model.components, ({ key, properties }) => {
-    if (!properties) return
-    for (const prop in properties) {
-      if (prop.includes(':')) {
-        const [lang, field] = prop.split(':')
-        const stringId = `${key}.${field}`
-        const value = properties[prop]
-        if (bundles[lang]) {
-          bundles[lang][stringId] = value
-        } else {
-          bundles[lang] = { [stringId]: value }
-        }
-      }
-    }
-  })
-  return bundles
-}
-
 export function loadEmbeddedTranslations (model, i18next) {
   const bundles = getEmbeddedTranslations(model)
   for (const lang in bundles) {
     i18next.addResourceBundle(lang, I18NEXT_DEFAULT_NAMESPACE, bundles[lang])
   }
+}
+
+export function getEmbeddedTranslations (model) {
+  const bundles = {}
+  FormioUtils.eachComponent(model.components, comp => {
+    const { key, properties } = comp
+    if (properties) {
+      for (const prop in properties) {
+        if (/^[-a-z]+:/i.test(prop)) {
+          const [lang, field] = prop.split(':')
+          const stringId = `${key}.${field}`
+          const value = properties[prop]
+          if (bundles[lang]) {
+            bundles[lang][stringId] = value
+          } else {
+            bundles[lang] = { [stringId]: value }
+          }
+        }
+      }
+    }
+  }, true)
+  return bundles
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import components from './components'
-import patch from './patch'
+import patch, { forms } from './patch'
 import templates from './templates'
 import { observeIcons } from './icons'
 import { version } from '../package.json'
@@ -10,6 +10,7 @@ const plugin = {
   framework,
   components,
   options: {},
+  forms,
   templates: {
     [framework]: templates
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10,20 +10,22 @@ const plugin = {
   framework,
   components,
   options: {},
-  forms,
   templates: {
     [framework]: templates
   }
 }
 
-Object.defineProperty(plugin, 'version', {
-  // Formio complains about the "version" key if
-  // the property is enumerable :shrug:
-  enumerable: false,
-  get () {
-    return version
-  }
-})
+const hiddenProps = {
+  forms,
+  version
+}
+
+for (const [prop, value] of Object.entries(hiddenProps)) {
+  Object.defineProperty(plugin, prop, {
+    enumerable: false,
+    get () { return value }
+  })
+}
 
 export default plugin
 export { patch }

--- a/src/patch.js
+++ b/src/patch.js
@@ -372,7 +372,7 @@ function disableConditionals (components) {
   FormioUtils.eachComponent(components, comp => {
     comp.properties.conditional = comp.conditional
     comp.conditional = {}
-  })
+  }, true)
 }
 
 function userIsTranslating (opts) {


### PR DESCRIPTION
A couple of bug fixes and preview/debugging enhancements in this PR:

1. Fixes #153 by explicitly disabling conditionals in all components (not just "layout") in the translate view
1. Applies the same fix to enable embedded translation support of all components, including content
1. Fixes a typo in the rewritten URL that was preventing us from testing different versions of `formiojs`
1. Adds JS in the preview proxy to hijack translation links to set the form language
1. Adds a `FormioSFDS.forms` getter to access only the upgraded forms as an array, which is useful for debugging form instances on sf.gov in the console