### PR TITLE
Enable translation of autocomplete strings

### DIFF
--- a/src/examples.yml
+++ b/src/examples.yml
@@ -30,6 +30,120 @@
         description: And this is the description
         tooltip: And this is the tooltip
 
+- id: language-picker
+  title: Language picker
+  form:
+    components:
+      - type: columns
+        columns:
+          - width: 1
+            components:
+              - type: button
+                label: English
+                action: custom
+                custom: 'form.language = "en"'
+          - width: 1
+            components:
+              - type: button
+                label: Español
+                action: custom
+                custom: 'form.language = "es"'
+          - width: 1
+            components:
+              - type: button
+                label: 中文
+                action: custom
+                custom: 'form.language = "zh"'
+          - width: 1
+            components:
+              - type: button
+                label: Filipino
+                action: custom
+                custom: 'form.language = "fil"'
+      - type: htmlelement
+        key: html
+        content: Chemical and hazardous materials
+        properties:
+          'es:content': Materiales químicos y peligrosos
+          'fil:content': Mga Kemikal at Mapanganib na Materyales
+          'zh:content': 化学物品与危险物质
+
+- id: autocomplete
+  title: Autocomplete
+  form:
+    components:
+      - type: select
+        key: job
+        label: Your job
+        tags:
+          - autocomplete
+        data:
+          values:
+            - label: Healthcare worker
+              value: healthCareWorker
+            - label: Emergency services
+              value: emergencyServices
+            - label: Food and agriculture
+              value: foodAndAgriculture
+            - label: Energy
+              value: energy
+            - label: Water and wastewater
+              value: waterAndWastewater
+
+      - type: select
+        key: words
+        label: Pick some words
+        tags:
+          - autocomplete
+        multiple: true
+        customOptions:
+          maxItemCount: 3
+        properties:
+          en:autocomplete.maxItemText: "Sorry, {{count}} tags max!"
+        description: |
+          This uses <code>multiple</code> and
+          <code>customOptions.maxItemCount</code> to limit the number of
+          choices, and the <code>autocomplete.maxItemText</code> translation
+          key to change the text that shows up when two are selected.
+        data:
+          values:
+            - label: green
+              value: green
+            - label: empathic
+              value: empathic
+            - label: never
+              value: never
+            - label: eleven
+              value: eleven
+            - label: dry
+              value: dry
+            - label: valuable
+              value: valuable
+            - label: fortify
+              value: fortify
+            - label: whatever
+              value: whatever
+            - label: leaven
+              value: leaven
+
+      - type: htmlelement
+        tag: div
+        content: |
+          <b>ProTip:</b> Add <a
+          href="?language=debug"><code>?language=debug</code></a> to the
+          query string to see the <code>autocomplete.*</code> translation keys
+          in context.
+
+  options:
+    i18n:
+      debug:
+        autocomplete.noResultsText: 'autocomplete.noResultsText'
+        autocomplete.itemSelectText: 'autocomplete.itemSelectText'
+        autocomplete.maxItemText: 'autocomplete.maxItemText'
+        autocomplete.noChoicesText: 'autocomplete.noChoicesText'
+        autocomplete.searchPlaceholderValue: 'autocomplete.searchPlaceholderValue'
+
+
 - id: radio
   title: Radio
   form:

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -30,44 +30,6 @@
         description: And this is the description
         tooltip: And this is the tooltip
 
-- id: language-picker
-  title: Language picker
-  form:
-    components:
-      - type: columns
-        columns:
-          - width: 1
-            components:
-              - type: button
-                label: English
-                action: custom
-                custom: 'form.language = "en"'
-          - width: 1
-            components:
-              - type: button
-                label: Español
-                action: custom
-                custom: 'form.language = "es"'
-          - width: 1
-            components:
-              - type: button
-                label: 中文
-                action: custom
-                custom: 'form.language = "zh"'
-          - width: 1
-            components:
-              - type: button
-                label: Filipino
-                action: custom
-                custom: 'form.language = "fil"'
-      - type: htmlelement
-        key: html
-        content: Chemical and hazardous materials
-        properties:
-          'es:content': Materiales químicos y peligrosos
-          'fil:content': Mga Kemikal at Mapanganib na Materyales
-          'zh:content': 化学物品与危险物质
-
 - id: autocomplete
   title: Autocomplete
   form:

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -108,5 +108,12 @@
   "words": "words",
   "year": "Year",
   "Year": "Year",
-  "Yes, delete it": "Yes, delete it"
+  "Yes, delete it": "Yes, delete it",
+  "autocomplete": {
+    "noResultsText": "No results found",
+    "itemSelectText": "",
+    "maxItemText": "Only {{count}} values can be added",
+    "noChoicesText": "No choices to choose from",
+    "searchPlaceholderValue": "Type to search"
+  }
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -167,7 +167,7 @@ function patch (Formio) {
 
       loadEmbeddedTranslations(model, form.i18next)
 
-      patchSelectMode(model)
+      patchSelectMode(model, form)
       form.form = model
 
       for (const [event, handler] of Object.entries(eventHandlers)) {
@@ -226,17 +226,49 @@ function patch (Formio) {
   })
 }
 
-function patchSelectMode (model) {
+function patchSelectMode (model, form) {
   const selects = FormioUtils.searchComponents(model.components, { type: 'select' })
-  for (const component of selects) {
+  const keyPrefix = 'autocomplete'
+
+  // forEach() instead of for...of gives us a closure,
+  // which is important because the component reference needs to
+  // persist for functions like searchPlaceholderValue()
+  selects.forEach(component => {
+    const compKey = component.key
     if (component.tags && component.tags.includes('autocomplete')) {
+      const t = (prop, ...rest) => {
+        const key = `autocomplete.${prop}`
+        const fallback = dot.get(defaultTranslations.en, key) || ''
+        return form.t([
+          `${compKey}.${key}`,
+          key,
+          fallback
+        ], ...rest)
+      }
+
       component.customOptions = Object.assign({
-        shouldSort: true
+        // shown when no results match the search input
+        noResultsText: t('noResultsText'),
+        // shown when no options are available (or loaded from an API)
+        noChoicesText: t('noChoicesText'),
+        // this overrides addItemText if provided
+        itemSelectText: t('itemSelectText'),
+        searchPlaceholderValue: t('searchPlaceholderValue'),
+        addItemText: component.customOptions.addItemText ? value => {
+          return t('addItemText', {
+            value: FormioUtils.sanitize(value, {
+              sanitizeConfig: component.customOptions?.sanitize
+            })
+          })
+        } : false,
+        maxItemText (count) {
+          return t('maxItemText', { count })
+        }
       }, component.customOptions)
     } else {
       component.widget = 'html5'
     }
-  }
+  })
 }
 
 function patchLanguageObserver () {

--- a/src/patch.js
+++ b/src/patch.js
@@ -254,7 +254,7 @@ function patchSelectMode (model, form) {
         // this overrides addItemText if provided
         itemSelectText: t('itemSelectText'),
         searchPlaceholderValue: t('searchPlaceholderValue'),
-        addItemText: component.customOptions.addItemText ? value => {
+        addItemText: component.customOptions?.addItemText ? value => {
           return t('addItemText', {
             value: FormioUtils.sanitize(value, {
               sanitizeConfig: component.customOptions?.sanitize


### PR DESCRIPTION
💣 ⚠️ **The `shouldSort: true` option default is gone in this PR**. You can add `{"shouldSort": true}` to the custom options of your component to sort the items alphabetically.

This PR enables translation of all the strings that can be configured via a `select` component's "custom options" JSON to control what shows up in [Choices.js](https://github.com/jshjohnson/Choices) under certain conditions. There is a new [autocomplete example](https://formio-sfds-k0tcfu99z.vercel.app/examples/autocomplete) that you can give [`?language=debug` in the query string](https://formio-sfds-k0tcfu99z.vercel.app/examples/autocomplete?language=debug) to see the keys in context.

| key | English | Choices option | notes
:--- | :--- | :--- | :---
| `autocomplete.searchPlaceholderValue` | "Type to search" | [searchPlaceholderValue](https://github.com/jshjohnson/Choices#searchplaceholdervalue) | The placeholder text of the search input
| `autocomplete.noResultsText` | "No results found" | [noResultsText](https://github.com/jshjohnson/Choices#noresultstext)
| `autocomplete.itemSelectText` | _none_ | [itemSelectText](https://github.com/jshjohnson/Choices#itemselecttext) | Displayed on the right side of the dropdown alongside the currently highlighted option
| `autocomplete.maxItemText` | "Only {{count}} values can be added" | [maxItemText](https://github.com/jshjohnson/Choices#maxitemtext) | The `{{count}}` placeholder is substituted with the [maxItemCount](https://github.com/jshjohnson/Choices#maxitemcount) option.
| `autocomplete.noChoicesText` | "No choices to choose from" | [noChoicesText](https://github.com/jshjohnson/Choices#nochoicestext) | This should only show up if we haven't provided any static options or have a dynamic select driven by an API that doesn't return any results.
| `autocomplete.addItemText` | _none_ | [addItemText](https://github.com/jshjohnson/Choices#additemtext) | ⚠️ I **think** that this option is only applicable when freeform values are allowed. If so, this shows up when you've typed a search string as a prompt, e.g. "Press Enter to add **{{value}}**", where `{{value}}` is substituted with the "backend" value of the option.

Each of the translation keys above can be prefixed with the component key and a `.` to customize the strings for that component only. For instance, `yourJob.autocomplete.searchPlaceholderValue` might have an English translation of "Type to search common jobs".