### PR TITLE
Guard against empty labels in strings API

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -86,16 +86,16 @@ function getStrings (form) {
     fieldGetter('suffix'),
     fieldGetter('values', (values, component, path) => {
       return Array.isArray(values) && values.map(({ label, value }) => {
-        return new UIString(label, component, `values.${value}`)
-      })
+        return label && new UIString(label, component, `values.${value}`)
+      }).filter(Boolean)
     }),
     fieldGetter('data', (data, component, path) => {
       const { dataSrc } = component
       const { values } = data
       if (Array.isArray(values) && (!dataSrc || dataSrc === 'values')) {
         return values.map(({ label, value }) => {
-          return new UIString(label, component, `values.${value}`)
-        })
+          return label && new UIString(label, component, `values.${value}`)
+        }).filter(Boolean)
       } else {
         console.info('Skipping data for component "%s" (dataSrc: "%s"), length: %d', component.key, dataSrc, values.length)
       }


### PR DESCRIPTION
This is a hotfix for our Phrase strings API to fix an issue that arose with the Prop H form. Empty labels are no longer included in the strings API output because they (likely) don't need to be translated, and we can always add them manually if they do need to be translated.

/cc @brianleesfgov 