### PR TITLE
Release tweaks

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -12,7 +12,7 @@ const PATCHED = `sfds-patch-${Date.now()}`
 
 const hasProperty = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 
-const debugDefault = process.env.NODE_ENV !== 'test'
+const debugDefault = process.env.NODE_ENV !== 'production'
 
 const libraryHooks = {}
 

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -5,8 +5,6 @@ $common-styles: (
   "https://sf.gov/core/themes/stable/css/system/components/js.module.css",
   "https://sf.gov/modules/contrib/extlink/extlink.css",
   "https://sf.gov/modules/contrib/paragraphs/css/paragraphs.unpublished.css",
-  "https://sf.gov/libraries/sfgov-pattern-lab/dist/css/components.css",
-  "https://sf.gov/libraries/sf-design-system/css/all.css",
   "https://sf.gov/themes/custom/sfgovpl/dist/css/critical.css",
   "https://sf.gov/themes/custom/sfgovpl/dist/css/drupal.css",
   "https://fonts.googleapis.com/css?family=Rubik:300,400,500,700",


### PR DESCRIPTION
A couple of random knob twiddles for #164:

1. The `debug` option now defaults to `false` in production. In other words, you should see a lot less console logging from our theme in production unless you pass `"debug": true` in the form render options.
2. The "common" CSS bundle used to render the Vercel site (i.e. _not_ on sf.gov) no longer includes the design system stylesheets that were removed from sf.gov a long time ago.