### PR TITLE
✍️ Signature style 

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,7 @@
 import address from './address'
 import review from './review'
 import columns from './columns'
+import signature from './signature'
 import state from './state'
 import zip from './zip'
 
@@ -9,5 +10,6 @@ export default {
   review,
   columns,
   state,
+  signature,
   zip
 }

--- a/src/components/signature.js
+++ b/src/components/signature.js
@@ -1,0 +1,28 @@
+const { signature: BaseSignature } = window.Formio.Components.components
+
+const overrides = {
+  height: {
+    initial: '150px',
+    override: '254px'
+  },
+  penColor: {
+    initial: 'black',
+    override: '#1c3e57' // Slate
+  },
+  backgroundColor: {
+    initial: 'rgb(245,245,235)',
+    override: 'transparent' // the template handles this
+  }
+}
+
+export default class Signature extends BaseSignature {
+  mergeSchema (component) {
+    const merged = super.mergeSchema(component)
+    for (const [key, { initial, override }] of Object.entries(overrides)) {
+      if (merged[key] === initial) {
+        merged[key] = override
+      }
+    }
+    return merged
+  }
+}

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -300,8 +300,7 @@
   form:
     components:
       - type: signature
-        label: Sign here
-        description: This is the description
+        description: This is the signature description
         validate:
           required: true
 

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -295,6 +295,16 @@
           - type: review
             label: ''
 
+- id: signature
+  title: Signature
+  form:
+    components:
+      - type: signature
+        label: Sign here
+        description: This is the description
+        validate:
+          required: true
+
 - id: day-default
   title: Day (default)
   form:

--- a/src/scss/forms/_inputs.scss
+++ b/src/scss/forms/_inputs.scss
@@ -111,29 +111,3 @@ input[type="radio"] {
     }
   }
 }
-
-.formio-component-signature {
-  border: solid $grey-2 border-width(1);
-}
-
-.signature-pad-footer {
-  position: relative;
-  border-top: dashed 2px $grey-3;
-  line-height: 48px;
-  background: white;
-  color: darken($grey-4, 20%);
-  text-align: center;
-  font-size: 21px;
-}
-
-.signature-refresh {
-  font-size: 18px;
-  position: absolute;
-  left: 20px;
-  color: darken($blue-2, 20%);
-
-  &:hover {
-    cursor: pointer;
-    color: darken($blue-2, 40%);
-  }
-}

--- a/src/templates/signature/form.ejs
+++ b/src/templates/signature/form.ejs
@@ -1,24 +1,25 @@
 {{ctx.element}}
-<div class="round-1 bg-grey-2 mb-2"
+<div class="round-1 bg-grey-2 mb-2 position-relative"
   style="
     width: {{ctx.component.width}};
     height: {{ctx.component.height}};
   "
   tabindex="{{ctx.component.tabindex || 0}}" ref="padBody">
-  <canvas class="signature-pad-canvas" width="{{ctx.component.width}}" height="{{ctx.component.height}}"
+  <canvas
+    width="{{ctx.component.width}}"
+    height="{{ctx.component.height}}"
     ref="canvas"></canvas>
-  <!--
-    {% if (ctx.required) { %}
-    <span class="form-control-feedback field-required-inline text-danger">
-      <i class="{{ctx.iconClass('asterisk')}}"></i>
-    </span>
-    {% } %}
-  -->
+  {% if (ctx.component.footer) { %}
+    <div
+      class="position-absolute px-3"
+      style="pointer-events: none; bottom: 0; left: 0; width: 100%;">
+      <div class="align-center py-1 border-top-1 border-slate">
+        {{ ctx.t(ctx.component.footer) }}
+      </div>
+    </div>
+  {% } %}
   <img style="width: 100%; display: none;" ref="signatureImage">
 </div>
-{% if (ctx.component.footer) { %}
-<div class="d-flex flex-justify-between">
+<div>
   <button class="btn bg-slate" ref="refresh">{{ ctx.t('Clear') }}</button>
-  {{ctx.t(ctx.component.footer)}}
 </div>
-{% } %}

--- a/src/templates/signature/form.ejs
+++ b/src/templates/signature/form.ejs
@@ -1,19 +1,24 @@
 {{ctx.element}}
-<div class="signature-pad-body"
-  style="width: {{ctx.component.width}};height: {{ctx.component.height}};padding:0;margin:0;"
+<div class="round-1 bg-grey-1 mb-2"
+  style="
+    width: {{ctx.component.width}};
+    height: {{ctx.component.height}};
+  "
   tabindex="{{ctx.component.tabindex || 0}}" ref="padBody">
   <canvas class="signature-pad-canvas" width="{{ctx.component.width}}" height="{{ctx.component.height}}"
     ref="canvas"></canvas>
-  {% if (ctx.required) { %}
-  <span class="form-control-feedback field-required-inline text-danger">
-    <i class="{{ctx.iconClass('asterisk')}}"></i>
-  </span>
-  {% } %}
+  <!--
+    {% if (ctx.required) { %}
+    <span class="form-control-feedback field-required-inline text-danger">
+      <i class="{{ctx.iconClass('asterisk')}}"></i>
+    </span>
+    {% } %}
+  -->
   <img style="width: 100%; display: none;" ref="signatureImage">
 </div>
 {% if (ctx.component.footer) { %}
-<div class="signature-pad-footer">
-  <a class="signature-refresh" ref="refresh">clear</a>
+<div class="d-flex flex-justify-between">
+  <button class="btn bg-slate" ref="refresh">{{ ctx.t('Clear') }}</button>
   {{ctx.t(ctx.component.footer)}}
 </div>
 {% } %}

--- a/src/templates/signature/form.ejs
+++ b/src/templates/signature/form.ejs
@@ -1,5 +1,5 @@
 {{ctx.element}}
-<div class="round-1 bg-grey-1 mb-2"
+<div class="round-1 bg-grey-2 mb-2"
   style="
     width: {{ctx.component.width}};
     height: {{ctx.component.height}};


### PR DESCRIPTION
This PR adds a `signature` component class and templates to match [this Figma comp](https://www.figma.com/file/Q2z3e3lwNDHbXJQzw2CJ0oNp/Form-components?node-id=1411%3A753). Below is a visual comparison, and you can test it live [on the review app](https://formio-sfds-pr-186.herokuapp.com/examples/signature/).

Figma (as of 6/2 @ 2:30) | This PR (as of f28d918)
:--- | :---
![image](https://user-images.githubusercontent.com/113896/120554224-556f1080-c3ae-11eb-9853-858cd24c5272.png) | ![image](https://user-images.githubusercontent.com/113896/120564567-0fbb4380-c3c0-11eb-9086-4074a37f678d.png)

The one funky thing to note about how I implemented this is that the slate line and "Sign above" text (form.io calls it the "footer") have `pointer-events: none` so that mouse and touch events go directly to the canvas below. The `pointer-events` CSS property was originally meant only for SVG, but was eventually supported on HTML elements by [most browsers](https://caniuse.com/pointer-events).

[Slack discussion](https://sfdigitalservices.slack.com/archives/C0134AQ7TSR/p1622669629055700) for reference.