### PR TITLE
Scope [data-toggle-container] observer to .formio-sfds

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -484,7 +484,7 @@ function userIsTranslating (opts) {
 }
 
 function toggleComponent () {
-  observe('[data-toggle-container]', {
+  observe(`.${WRAPPER_CLASS} [data-toggle-container]`, {
     add (el) {
       const ariaControl = el.querySelector('[aria-controls]')
 


### PR DESCRIPTION
I noticed when debugging some Ghost Inspector [failures](https://app.ghostinspector.com/results/6144c3bfc34f55630be871d1) on [this page](https://pr-929-sfgov.pantheonsite.io/step-by-step/gi-test-step-step-4) that there were some JS errors in the console:

```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
    at add (patch.js:487)
    at It (index.esm.js:156)
    at St (index.esm.js:72)
    at Ut.Vt (index.esm.js:592)
    at Array.n (index.esm.js:13)
    at MutationObserver.kt (index.esm.js:47)
```

which is happening [here](https://github.com/SFDigitalServices/formio-sfds/blob/1eccba6e2677dcc652ea778cd42ed0276a0e1384/src/patch.js#L487):

```js
function toggleComponent () {
  observe('[data-toggle-container]', {
    add (el) {
      const ariaControl = el.querySelector('[aria-controls]')
      //        ⬇ ariaControl is undefined here, so this throws
      ariaControl.addEventListener('click', event => {
```

The problem isn't a broken toggle container; it's that this observer is running on an element outside of a form.io form. The fix is to scope that `[data-toggle-container]` selector to the forms, which are always wrapped in an element with the `formio-sfds` class.

I'm going to make this a draft and test the canary release over in https://github.com/SFDigitalServices/sfgov/pull/929 to see if this has any effect on the failing test.