### PR TITLE
Fix aria-invalid patch

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -438,8 +438,10 @@ function patchAriaInvalid (Formio) {
     setErrorClasses(elements, ...rest)
     for (const el of elements) {
       const input = this.performInputMapping(el)
-      const invalid = input.classList.contains('is-invalid')
-      input.setAttribute('aria-invalid', invalid)
+      if (input) {
+        const invalid = input.classList.contains('is-invalid')
+        input.setAttribute('aria-invalid', invalid)
+      }
     }
   })
 }


### PR DESCRIPTION
Apparently there are some inputs for which `this.performInputMapping(el)` doesn't return an input, because some forms are silently failing after [this line](https://github.com/SFDigitalServices/formio-sfds/blob/f254b1f6aabe9922cf0bc5e8dbc82970b489fb5c/src/patch.js#L440) returns `undefined`.