### PR TITLE
Bug fix: prevent access errors in undefined form.form.properties

### DIFF
--- a/src/phrase.js
+++ b/src/phrase.js
@@ -85,7 +85,7 @@ module.exports = class Phrase {
     const { form } = this
     const props = Object.assign(
       {},
-      form.properties || form.form.properties,
+      form.properties || (form.form ? form.form.properties : {}),
       form.options
     )
     const {


### PR DESCRIPTION
I saw some errors that crashed the web app [in Papertrail](https://my.papertrailapp.com/groups/27212641/events?focus=1456596439307059209):

```
Apr 29 00:21:17 formio-sfds app/web.1 /app/src/phrase.js:88
Apr 29 00:21:17 formio-sfds app/web.1       form.properties || form.form.properties,
Apr 29 00:21:17 formio-sfds app/web.1                                    ^
Apr 29 00:21:17 formio-sfds app/web.1 TypeError: Cannot read properties of undefined (reading 'properties')
Apr 29 00:21:17 formio-sfds app/web.1     at Phrase.get props [as props] (/app/src/phrase.js:88:36)
Apr 29 00:21:17 formio-sfds app/web.1     at Phrase.getTranslationInfo (/app/src/phrase.js:100:13)
Apr 29 00:21:17 formio-sfds app/web.1     at module.exports (/app/api/wtf.js:82:27)
```

This should prevent that specific error from happening, but it's a bigger problem that this took the entire server down. Clearly we need better [error handling](https://expressjs.com/en/guide/error-handling.html) 😬 