### PR TITLE
Fix: remove v-align-top class from <tr> in datagrid component

### DIFF
--- a/src/templates/datagrid/form.ejs
+++ b/src/templates/datagrid/form.ejs
@@ -35,7 +35,7 @@
         class="datagrid-group-label">{{ctx.groups[index].label}}</td>
     </tr>
     {% } %}
-    <tr ref="{{ctx.datagridKey}}-row" class="v-align-top">
+    <tr ref="{{ctx.datagridKey}}-row">
       {% if (ctx.component.reorder) { %}
         <td>
           <button type="button" class="formio-drag-button btn btn-default fa fa-bars"></button>


### PR DESCRIPTION
Per [this Slack thread](https://sfdigitalservices.slack.com/archives/C0134AQ7TSR/p1651089908538079)