### PR TITLE
Don't run primer/publish if secrets.NPM_AUTH_TOKEN isn't set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - run: npm test
 
       - uses: primer/publish@v2.0.0
+        if: secrets.NPM_AUTH_TOKEN
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   build:
+    if: secrets.NPM_AUTH_TOKEN
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Dependabot PRs are failing because they don't have access to workflow secrets. This skips the publish step if `secrets.NPM_AUTH_TOKEN` isn't set. We can test the publishing workflow in release branches.

This is not a code change, so we can merge to `main` straight away without a release.