### PR TITLE
Fix select component option translation

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -141,8 +141,8 @@ exports[`component snapshots component "address" scenario: basic matches the sna
                             required
                             ref="selectContainer"
                     >
-                      <option value
-                              selected="selected"
+                      <option selected
+                              value
                       >
                       </option>
                       <option value="AL">
@@ -512,8 +512,8 @@ exports[`component snapshots component "address" scenario: required matches the 
                             required
                             ref="selectContainer"
                     >
-                      <option value
-                              selected="selected"
+                      <option selected
+                              value
                       >
                       </option>
                       <option value="AL">
@@ -2825,8 +2825,8 @@ exports[`component snapshots component "select" scenario: basic matches the snap
                 id="input-select-basic-2"
                 ref="selectContainer"
         >
-          <option value
-                  selected="selected"
+          <option selected
+                  value
           >
           </option>
           <option value="a">
@@ -2896,8 +2896,8 @@ exports[`component snapshots component "select" scenario: required matches the s
                 required
                 ref="selectContainer"
         >
-          <option value
-                  selected="selected"
+          <option selected
+                  value
           >
           </option>
           <option value="a">
@@ -3139,8 +3139,8 @@ exports[`component snapshots component "state" scenario: basic matches the snaps
                 id="input-state-basic-2"
                 ref="selectContainer"
         >
-          <option value
-                  selected="selected"
+          <option selected
+                  value
           >
           </option>
           <option value="AL">
@@ -3363,8 +3363,8 @@ exports[`component snapshots component "state" scenario: required matches the sn
                 required
                 ref="selectContainer"
         >
-          <option value
-                  selected="selected"
+          <option selected
+                  value
           >
           </option>
           <option value="AL">

--- a/src/examples.yml
+++ b/src/examples.yml
@@ -34,6 +34,28 @@
             - label: B
               value: b
 
+- id: select-translation
+  title: Select with translations
+  options:
+    language: es
+    i18n:
+      es:
+        choices.label: ¿Qué dirección?
+        choices.values.up: Arriba
+        choices.values.down: Abajo
+  form:
+    components:
+      - type: select
+        widget: html5
+        key: choices
+        label: Which direction?
+        data:
+          values:
+            - label: Up
+              value: up
+            - label: Down
+              value: down
+
 - id: checkbox
   title: Checkbox
   form:

--- a/src/templates/selectOption/form.ejs
+++ b/src/templates/selectOption/form.ejs
@@ -1,8 +1,9 @@
-<option {{ ctx.selected ? 'selected="selected"' : '' }}
-  value="{{ctx.useId ? ctx.id : ctx.option.value}}"
-  {% for (var attr in ctx.attrs) { %}
-  {{attr}}="{{ctx.attrs[attr]}}"
+<option
+  value="{{ ctx.useId ? ctx.id : ctx.option.value }}"
+  {% if (ctx.selected) { %} selected {% } %}
+  {% for (const attr in ctx.attrs) { %}
+    {{ attr }}="{{ ctx.attrs[attr] }}"
   {% } %}
-  >
-  {{ctx.t(ctx.option.label)}}
+>
+  {{ ctx.t([`${ctx.component.key}.values.${ctx.option.value}`, ctx.option.label]) }}
 </option>


### PR DESCRIPTION
Option label translations weren't working properly. Now they should, and there are tests!