### PR TITLE
fix(i18n): add "Back" and "Next" translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,6 +1,7 @@
 {
   "april": "Abril",
   "august": "Agosto",
+  "Back": "Atrás",
   "browse": "explorar",
   "Browse": "Explorar",
   "Cancel": "Cancelar",
@@ -19,7 +20,7 @@
   "may": "Mayo",
   "month": "Mes",
   "Month": "Mes",
-  "next": "Siguiente",
+  "Next": "Siguiente",
   "november": "Noviembre",
   "october": "Octubre",
   "previous": "Previo",

--- a/src/i18n/tl.json
+++ b/src/i18n/tl.json
@@ -1,10 +1,11 @@
 {
+  "Back": "Back",
   "Browse": "Mag-browse",
   "Drop files to attach, or": "I-drop ang mga file para i-attach, o",
   "File Name": "Pangalan ng File",
   "File name": "Pangalan ng File",
   "Get started": "Magsimula",
-  "next": "Susunod",
+  "Next": "Susunod",
   "Size": "Laki",
   "Submit": "I-padala dito."
 }

--- a/src/i18n/tl.json
+++ b/src/i18n/tl.json
@@ -1,5 +1,5 @@
 {
-  "Back": "Back",
+  "Back": "Bumalik",
   "Browse": "Mag-browse",
   "Drop files to attach, or": "I-drop ang mga file para i-attach, o",
   "File Name": "Pangalan ng File",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -1,4 +1,5 @@
 {
+  "Back": "返回",
   "Browse": "瀏覽",
   "Cancel": "取消",
   "characters": "字",
@@ -15,7 +16,7 @@
   "march": "三月",
   "may": "五月",
   "minWords": "{{field}} 至少要有{{length}}個字",
-  "next": "繼續",
+  "Next": "繼續",
   "or": "或",
   "required": "{{field}} 必填",
   "Size": "大小",


### PR DESCRIPTION
I'm adding built-in translations for "Back" and "Next":

| English | Spanish | Chinese | Filipino
| :--- | :--- | :--- | :---
| Back | Atrás | 返回 | Bumalik
| Next | Siguiente | 繼續 | Susunod
