### PR TITLE
Fix <sfgov-icon> HTML

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -2652,7 +2652,7 @@ exports[`component snapshots component "radio" scenario: basic matches the snaps
                      value="1"
                      lang="en"
                      type="radio"
-                     name="data[radio][radio-basic-2]"
+                     name="data[radio][radio-basic-1-radio-basic-2]"
                      class="input-radio position-relative d-block mr-2 mb-0"
                      ref="input"
               >
@@ -2667,7 +2667,7 @@ exports[`component snapshots component "radio" scenario: basic matches the snaps
                      value="2"
                      lang="en"
                      type="radio"
-                     name="data[radio][radio-basic-2]"
+                     name="data[radio][radio-basic-1-radio-basic-2]"
                      class="input-radio position-relative d-block mr-2 mb-0"
                      ref="input"
               >
@@ -2682,7 +2682,7 @@ exports[`component snapshots component "radio" scenario: basic matches the snaps
                      value="3"
                      lang="en"
                      type="radio"
-                     name="data[radio][radio-basic-2]"
+                     name="data[radio][radio-basic-1-radio-basic-2]"
                      class="input-radio position-relative d-block mr-2 mb-0"
                      ref="input"
               >
@@ -2739,7 +2739,7 @@ exports[`component snapshots component "radio" scenario: required matches the sn
                      value="1"
                      lang="en"
                      type="radio"
-                     name="data[radio][radio-required-2]"
+                     name="data[radio][radio-required-1-radio-required-2]"
                      class="input-radio position-relative d-block mr-2 mb-0"
                      ref="input"
               >
@@ -2754,7 +2754,7 @@ exports[`component snapshots component "radio" scenario: required matches the sn
                      value="2"
                      lang="en"
                      type="radio"
-                     name="data[radio][radio-required-2]"
+                     name="data[radio][radio-required-1-radio-required-2]"
                      class="input-radio position-relative d-block mr-2 mb-0"
                      ref="input"
               >
@@ -2769,7 +2769,7 @@ exports[`component snapshots component "radio" scenario: required matches the sn
                      value="3"
                      lang="en"
                      type="radio"
-                     name="data[radio][radio-required-2]"
+                     name="data[radio][radio-required-1-radio-required-2]"
                      class="input-radio position-relative d-block mr-2 mb-0"
                      ref="input"
               >

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "formio-sfds",
-      "version": "9.2.7",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "choices.js": "^9.0.1",
         "dotmap": "^0.1.0",
         "flatpickr": "^4.6.3",
-        "formiojs": "4.13.2",
+        "formiojs": "4.14.8",
         "interpolate": "^0.1.0",
         "uri-template-lite": "^19.12.0",
         "whatwg-fetch": "^3.0.0"
@@ -1770,11 +1770,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1987,9 +1987,9 @@
       "dev": true
     },
     "node_modules/@formio/bootstrap3": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.11.4.tgz",
-      "integrity": "sha512-JTUjYxs/GF2tMGIeU56mH1LrZlUqnIz+MZXZDijh8Y6cjzo7uKc8qJOb+hVest54Dh6W1ejcru3pgVTfwqaFcw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.2.tgz",
+      "integrity": "sha512-Y1WD/U22HHKRl1MzUt65bXeFHYO9Wlt+wefRqXFrOhIgbmkfTjCx6e0n2b8t/IYz9FUMg+/GTKdqaBrTZgjrTA==",
       "dependencies": {
         "resize-observer-polyfill": "^1.5.1"
       }
@@ -2005,9 +2005,9 @@
       }
     },
     "node_modules/@formio/semantic": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.5.3.tgz",
-      "integrity": "sha512-dZ3L2565K5st8S93lwkx8VIdiZF3nnHi7qyfvzAF5AeIEl2YcXnRzp6Uvr2c5nD6Nk7F9V7tCzGFkJjz3WRPWA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.6.0.tgz",
+      "integrity": "sha512-RwMEVXkyz+B6RivflrrKIqvvnGR/eZDLQs74u67StcrzO6n3/5D2J8XqTQRSUzQzr5QV6Wq0eZ51z/+mGm6THw=="
     },
     "node_modules/@formio/vanilla-text-mask": {
       "version": "5.1.1",
@@ -3871,6 +3871,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -5101,6 +5110,14 @@
       "resolved": "https://registry.npmjs.org/browser-cookies/-/browser-cookies-1.2.0.tgz",
       "integrity": "sha1-/KP/ubamOq3E2MCZnGtX0Pp9KbU="
     },
+    "node_modules/browser-md5-file": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browser-md5-file/-/browser-md5-file-1.1.1.tgz",
+      "integrity": "sha512-9h2UViTtZPhBa7oHvp5mb7MvJaX5OKEPUsplDwJ800OIV+In7BOR3RXOMB78obn2iQVIiS3WkVLhG7Zu1EMwbw==",
+      "dependencies": {
+        "spark-md5": "^2.0.2"
+      }
+    },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -5730,9 +5747,9 @@
       "dev": true
     },
     "node_modules/compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.4.tgz",
+      "integrity": "sha512-FemMreK9xNyL8gQevsdRMrvO4lFCkQP7qbuktn1q8ndcNk1+0mz7lgE7b/sNvbhVgY4w6tMN1FDp6aADjqw2rw=="
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
@@ -5848,9 +5865,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-      "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -6829,9 +6846,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.2.tgz",
-      "integrity": "sha512-jXJnvWloI+scD+N5uBikpUMsYXZb0LCAXxLFAOLS5duCzKfXLqBCpuINvFOiI4eJgTLggrngljT18HNoakHUsA=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.3.tgz",
+      "integrity": "sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -8218,20 +8235,9 @@
       }
     },
     "node_modules/fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -8427,53 +8433,68 @@
       }
     },
     "node_modules/formiojs": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.13.2.tgz",
-      "integrity": "sha512-HZeq5h2P2BPwhSDbENHM6TVjJCoHdhz53sGxORIRXkzt2/GTErjrh6CuejrflLYdWuS1YRy0qjYuxIS/2P40+A==",
+      "version": "4.14.8",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.8.tgz",
+      "integrity": "sha512-BZucLSxCGWhBe1FQATR6GgxfHtwxEZxp2ur29DjAjo6ErlUTnl2Zbmb1IjW8NNfw0jn81SfSKtxh/SRSY5Ut7A==",
       "dependencies": {
-        "@formio/bootstrap3": "^2.11.0",
+        "@formio/bootstrap3": "^2.12.2",
         "@formio/choices.js": "^9.0.1",
-        "@formio/semantic": "^2.5.1",
+        "@formio/semantic": "^2.6.0",
         "@formio/vanilla-text-mask": "^5.1.1",
-        "autocompleter": "^6.1.0",
+        "autocompleter": "^6.1.2",
         "browser-cookies": "^1.2.0",
-        "compare-versions": "^3.6.0",
-        "core-js": "^3.13.0",
+        "browser-md5-file": "^1.1.1",
+        "compare-versions": "^4.1.3",
+        "core-js": "^3.21.1",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.6",
-        "dompurify": "^2.2.8",
+        "dompurify": "^2.3.4",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^4.0.7",
         "fast-deep-equal": "^3.1.3",
-        "fast-json-patch": "^2.2.1",
+        "fast-json-patch": "^3.1.0",
         "fetch-ponyfill": "^7.1.0",
-        "i18next": "^20.3.0",
-        "idb": "^6.1.1",
+        "i18next": "^21.6.0",
+        "idb": "^6.1.5",
         "ismobilejs": "^1.1.1",
         "json-logic-js": "^2.0.0",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
-        "moment-timezone": "^0.5.33",
+        "moment": "^2.29.2",
+        "moment-timezone": "^0.5.34",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
         "resize-observer-polyfill": "^1.5.1",
-        "signature_pad": "^2.3.2",
+        "signature_pad": "^4.0.4",
         "string-hash": "^1.1.3",
         "text-mask-addons": "^3.8.0",
-        "tooltip.js": "^1.3.3",
+        "tippy.js": "^6.3.7",
         "uuid": "^8.3.2",
-        "vanilla-picker": "^2.11.2"
+        "vanilla-picker": "^2.12.1"
       }
     },
     "node_modules/formiojs/node_modules/i18next": {
-      "version": "20.6.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
-      "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
       "dependencies": {
-        "@babel/runtime": "^7.12.0"
+        "@babel/runtime": "^7.17.2"
       }
     },
     "node_modules/forwarded": {
@@ -9284,9 +9305,9 @@
       "dev": true
     },
     "node_modules/idb": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.3.tgz",
-      "integrity": "sha512-oIRDpVcs5KXpI1hRnTJUwkY63RB/7iqu9nSNuzXN8TLHjs7oO20IoPFbBTsqxIL5IjzIUDi+FXlVcK4zm26J8A=="
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
+      "integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -16036,16 +16057,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -18495,9 +18506,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -19738,9 +19749,9 @@
       "dev": true
     },
     "node_modules/signature_pad": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
-      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.1.4.tgz",
+      "integrity": "sha512-NKLm9uhRfEPl8cdbbyYAiPsoJ3slIo1AyKg3tzwy8OCX2zQc6jrccUlgMBTJPcUsZXNU8o6fy7iX33rtYSoQHQ=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -20056,6 +20067,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/spark-md5": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-2.0.2.tgz",
+      "integrity": "sha512-9WfT+FYBEvlrOOBEs484/zmbtSX4BlGjzXih1qIEWA1yhHbcqgcMHkiwXoWk2Sq1aJjLpcs6ZKV7JxrDNjIlNg=="
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -20981,6 +20997,14 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -21055,15 +21079,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tooltip.js": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.3.tgz",
-      "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
-      "deprecated": "Tooltip.js is not supported anymore, please migrate to tippy.js",
-      "dependencies": {
-        "popper.js": "^1.0.2"
       }
     },
     "node_modules/tosource": {
@@ -21713,9 +21728,9 @@
       }
     },
     "node_modules/vanilla-picker": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.11.2.tgz",
-      "integrity": "sha512-2cP7LlUnxHxwOf06ReUVtd2RFJMnJGaxN2s0p8wzBH3In5b00Le7fFZ9VrIoBE0svZkSq/BC/Pwq/k/9n+AA2g==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.1.tgz",
+      "integrity": "sha512-2qrEP9VYylKXbyzXKsbu2dferBTvqnlsr29XjHwFE+/MEp0VNj6oEUESLDtKZ7DWzGdSv1x/+ujqFZF+KsO3cg==",
       "dependencies": {
         "@sphinxxxx/color-conversion": "^2.2.2"
       }
@@ -23454,11 +23469,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
@@ -23620,9 +23635,9 @@
       }
     },
     "@formio/bootstrap3": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.11.4.tgz",
-      "integrity": "sha512-JTUjYxs/GF2tMGIeU56mH1LrZlUqnIz+MZXZDijh8Y6cjzo7uKc8qJOb+hVest54Dh6W1ejcru3pgVTfwqaFcw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.2.tgz",
+      "integrity": "sha512-Y1WD/U22HHKRl1MzUt65bXeFHYO9Wlt+wefRqXFrOhIgbmkfTjCx6e0n2b8t/IYz9FUMg+/GTKdqaBrTZgjrTA==",
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
       }
@@ -23638,9 +23653,9 @@
       }
     },
     "@formio/semantic": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.5.3.tgz",
-      "integrity": "sha512-dZ3L2565K5st8S93lwkx8VIdiZF3nnHi7qyfvzAF5AeIEl2YcXnRzp6Uvr2c5nD6Nk7F9V7tCzGFkJjz3WRPWA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.6.0.tgz",
+      "integrity": "sha512-RwMEVXkyz+B6RivflrrKIqvvnGR/eZDLQs74u67StcrzO6n3/5D2J8XqTQRSUzQzr5QV6Wq0eZ51z/+mGm6THw=="
     },
     "@formio/vanilla-text-mask": {
       "version": "5.1.1",
@@ -25093,6 +25108,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -26061,6 +26081,14 @@
       "resolved": "https://registry.npmjs.org/browser-cookies/-/browser-cookies-1.2.0.tgz",
       "integrity": "sha1-/KP/ubamOq3E2MCZnGtX0Pp9KbU="
     },
+    "browser-md5-file": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browser-md5-file/-/browser-md5-file-1.1.1.tgz",
+      "integrity": "sha512-9h2UViTtZPhBa7oHvp5mb7MvJaX5OKEPUsplDwJ800OIV+In7BOR3RXOMB78obn2iQVIiS3WkVLhG7Zu1EMwbw==",
+      "requires": {
+        "spark-md5": "^2.0.2"
+      }
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -26546,9 +26574,9 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.4.tgz",
+      "integrity": "sha512-FemMreK9xNyL8gQevsdRMrvO4lFCkQP7qbuktn1q8ndcNk1+0mz7lgE7b/sNvbhVgY4w6tMN1FDp6aADjqw2rw=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -26639,9 +26667,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-      "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw=="
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww=="
     },
     "core-js-compat": {
       "version": "3.17.3",
@@ -27416,9 +27444,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.2.tgz",
-      "integrity": "sha512-jXJnvWloI+scD+N5uBikpUMsYXZb0LCAXxLFAOLS5duCzKfXLqBCpuINvFOiI4eJgTLggrngljT18HNoakHUsA=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.3.tgz",
+      "integrity": "sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ=="
     },
     "domutils": {
       "version": "1.7.0",
@@ -28481,19 +28509,9 @@
       }
     },
     "fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "dependencies": {
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        }
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -28660,53 +28678,54 @@
       "dev": true
     },
     "formiojs": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.13.2.tgz",
-      "integrity": "sha512-HZeq5h2P2BPwhSDbENHM6TVjJCoHdhz53sGxORIRXkzt2/GTErjrh6CuejrflLYdWuS1YRy0qjYuxIS/2P40+A==",
+      "version": "4.14.8",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.8.tgz",
+      "integrity": "sha512-BZucLSxCGWhBe1FQATR6GgxfHtwxEZxp2ur29DjAjo6ErlUTnl2Zbmb1IjW8NNfw0jn81SfSKtxh/SRSY5Ut7A==",
       "requires": {
-        "@formio/bootstrap3": "^2.11.0",
+        "@formio/bootstrap3": "^2.12.2",
         "@formio/choices.js": "^9.0.1",
-        "@formio/semantic": "^2.5.1",
+        "@formio/semantic": "^2.6.0",
         "@formio/vanilla-text-mask": "^5.1.1",
-        "autocompleter": "^6.1.0",
+        "autocompleter": "^6.1.2",
         "browser-cookies": "^1.2.0",
-        "compare-versions": "^3.6.0",
-        "core-js": "^3.13.0",
+        "browser-md5-file": "^1.1.1",
+        "compare-versions": "^4.1.3",
+        "core-js": "^3.21.1",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.6",
-        "dompurify": "^2.2.8",
+        "dompurify": "^2.3.4",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^4.0.7",
         "fast-deep-equal": "^3.1.3",
-        "fast-json-patch": "^2.2.1",
+        "fast-json-patch": "^3.1.0",
         "fetch-ponyfill": "^7.1.0",
-        "i18next": "^20.3.0",
-        "idb": "^6.1.1",
+        "i18next": "^21.6.0",
+        "idb": "^6.1.5",
         "ismobilejs": "^1.1.1",
         "json-logic-js": "^2.0.0",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
-        "moment-timezone": "^0.5.33",
+        "moment": "^2.29.2",
+        "moment-timezone": "^0.5.34",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
         "resize-observer-polyfill": "^1.5.1",
-        "signature_pad": "^2.3.2",
+        "signature_pad": "^4.0.4",
         "string-hash": "^1.1.3",
         "text-mask-addons": "^3.8.0",
-        "tooltip.js": "^1.3.3",
+        "tippy.js": "^6.3.7",
         "uuid": "^8.3.2",
-        "vanilla-picker": "^2.11.2"
+        "vanilla-picker": "^2.12.1"
       },
       "dependencies": {
         "i18next": {
-          "version": "20.6.1",
-          "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
-          "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
+          "version": "21.10.0",
+          "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+          "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
           "requires": {
-            "@babel/runtime": "^7.12.0"
+            "@babel/runtime": "^7.17.2"
           }
         }
       }
@@ -29324,9 +29343,9 @@
       "dev": true
     },
     "idb": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.3.tgz",
-      "integrity": "sha512-oIRDpVcs5KXpI1hRnTJUwkY63RB/7iqu9nSNuzXN8TLHjs7oO20IoPFbBTsqxIL5IjzIUDi+FXlVcK4zm26J8A=="
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
+      "integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -34428,11 +34447,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -36355,9 +36369,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -37324,9 +37338,9 @@
       "dev": true
     },
     "signature_pad": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
-      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.1.4.tgz",
+      "integrity": "sha512-NKLm9uhRfEPl8cdbbyYAiPsoJ3slIo1AyKg3tzwy8OCX2zQc6jrccUlgMBTJPcUsZXNU8o6fy7iX33rtYSoQHQ=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -37584,6 +37598,11 @@
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
       "dev": true
+    },
+    "spark-md5": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-2.0.2.tgz",
+      "integrity": "sha512-9WfT+FYBEvlrOOBEs484/zmbtSX4BlGjzXih1qIEWA1yhHbcqgcMHkiwXoWk2Sq1aJjLpcs6ZKV7JxrDNjIlNg=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -38297,6 +38316,14 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "requires": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -38356,14 +38383,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
-    },
-    "tooltip.js": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.3.tgz",
-      "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
-      "requires": {
-        "popper.js": "^1.0.2"
-      }
     },
     "tosource": {
       "version": "1.0.0",
@@ -38855,9 +38874,9 @@
       }
     },
     "vanilla-picker": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.11.2.tgz",
-      "integrity": "sha512-2cP7LlUnxHxwOf06ReUVtd2RFJMnJGaxN2s0p8wzBH3In5b00Le7fFZ9VrIoBE0svZkSq/BC/Pwq/k/9n+AA2g==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.1.tgz",
+      "integrity": "sha512-2qrEP9VYylKXbyzXKsbu2dferBTvqnlsr29XjHwFE+/MEp0VNj6oEUESLDtKZ7DWzGdSv1x/+ujqFZF+KsO3cg==",
       "requires": {
         "@sphinxxxx/color-conversion": "^2.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "choices.js": "^9.0.1",
     "dotmap": "^0.1.0",
     "flatpickr": "^4.6.3",
-    "formiojs": "4.13.2",
+    "formiojs": "4.14.8",
     "interpolate": "^0.1.0",
     "uri-template-lite": "^19.12.0",
     "whatwg-fetch": "^3.0.0"

--- a/src/patch.js
+++ b/src/patch.js
@@ -108,7 +108,14 @@ function patch (Formio) {
     language = inputLanguageMap[language] || language
 
     // default to the inferred language, merge the provided options
-    const opts = { language, ...options }
+    const opts = {
+      language,
+      ...options,
+      sanitizeConfig: {
+        addTags: ['sfgov-icon', ...options.sanitizeConfig?.addTags || []],
+        addAttr: ['symbol', ...options.sanitizeConfig?.addAttr || []]
+      }
+    }
 
     opts.i18n = await resolveTranslations(opts.i18n, debug)
 


### PR DESCRIPTION
@josh-chou discovered that using `<sfgov-icon>` in form HTML prevents the forms from rendering. I looked into it, and there are two problems:

1. The version of `formiojs` we were using has a bug (either in its own code or in the code of its HTML sanitizer, [dompurify]) that throws on elements with a `-` in them. Upgrading to `4.14.8` fixes this.
2. I've added a default `sanitizeConfig` form option adding `sfgov-icon` and the `symbol` attribute, as suggested in [the formio.js docs](https://github.com/formio/formio.js/wiki/Form-Sanitize-Config):

    ```js
    sanitizeConfig: {
      addTag: ['sfgov-icon'],
      addAttr: ['symbol']
    }
    ```

[dompurify]: https://github.com/cure53/DOMPurify