### PR TITLE
chore: specify fetch-depth because default 1 has no tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 30
+          fetch-depth: 0
           fetch-tags: true
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 30
           fetch-tags: true
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
`fetch-depth` for `checkout` action defaults to 1.  our last commit doesn't have a tag.  configuring for `fetch-depth:0` to attempt to get latest tag
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.0.1--canary.264.c7bf6d1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install formio-sfds@10.0.1--canary.264.c7bf6d1.0
  # or 
  yarn add formio-sfds@10.0.1--canary.264.c7bf6d1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
