### PR TITLE
chore: add plugin for auto to deal with protected branch

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -4,5 +4,8 @@
   "canary": {
     "target": "pr-body",
     "force": true
-  }
+  },
+  "plugins": [
+    "protected-branch"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "whatwg-fetch": "^3.0.0"
       },
       "devDependencies": {
+        "@auto-it/protected-branch": "^11.0.1",
         "@babel/cli": "^7.10.1",
         "@babel/core": "^7.10.1",
         "@babel/plugin-proposal-optional-chaining": "^7.11.0",
@@ -447,6 +448,25 @@
       "engines": {
         "node": ">=10.x"
       }
+    },
+    "node_modules/@auto-it/protected-branch": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@auto-it/protected-branch/-/protected-branch-11.0.1.tgz",
+      "integrity": "sha512-1kBXv7koWNPpP3xwb5bbHXCLmaVnsAKOYgZ92zhgq2tyXyl6LwDUtUczT54SdbTlDz6vEy3NEOjmfF+IZgStcQ==",
+      "dev": true,
+      "dependencies": {
+        "@auto-it/core": "11.0.1",
+        "@octokit/rest": "^18.12.0",
+        "fp-ts": "^2.5.3",
+        "io-ts": "^2.1.2",
+        "tslib": "1.10.0"
+      }
+    },
+    "node_modules/@auto-it/protected-branch/node_modules/tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "node_modules/@auto-it/released": {
       "version": "11.0.1",
@@ -24175,6 +24195,27 @@
       "requires": {
         "parse-author": "^2.0.0",
         "parse-github-url": "1.0.2"
+      }
+    },
+    "@auto-it/protected-branch": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@auto-it/protected-branch/-/protected-branch-11.0.1.tgz",
+      "integrity": "sha512-1kBXv7koWNPpP3xwb5bbHXCLmaVnsAKOYgZ92zhgq2tyXyl6LwDUtUczT54SdbTlDz6vEy3NEOjmfF+IZgStcQ==",
+      "dev": true,
+      "requires": {
+        "@auto-it/core": "11.0.1",
+        "@octokit/rest": "^18.12.0",
+        "fp-ts": "^2.5.3",
+        "io-ts": "^2.1.2",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+          "dev": true
+        }
       }
     },
     "@auto-it/released": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
+    "@auto-it/protected-branch": "^11.0.1",
     "@babel/cli": "^7.10.1",
     "@babel/core": "^7.10.1",
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",


### PR DESCRIPTION
error when trying to create a tag for the release:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.   
```
protected branch needs a personal access token with admin level access.  to avoid using an admin token, we can configure auto to use a plugin from the authors.

[issue detail](https://github.com/intuit/auto/issues/2377)
[plugin](https://www.npmjs.com/package/@auto-it/protected-branch)