### PR TITLE
Fix content and htmlelement component translations

### DIFF
--- a/__tests__/__snapshots__/snapshots.js.snap
+++ b/__tests__/__snapshots__/snapshots.js.snap
@@ -1257,10 +1257,6 @@ exports[`component snapshots component "content" scenario: basic matches the sna
         >
           Hello, world!
         </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
     </div>
     <div ref="messageContainer"
@@ -1295,10 +1291,6 @@ exports[`component snapshots component "content" scenario: required matches the 
              class
         >
           Hello, world!
-        </div>
-        <div ref="messageContainer"
-             class="messages"
-        >
         </div>
       </div>
     </div>
@@ -2370,10 +2362,6 @@ exports[`component snapshots component "htmlelement" scenario: basic matches the
         >
           Hello, world!
         </h1>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
     </div>
     <div ref="messageContainer"
@@ -2409,10 +2397,6 @@ exports[`component snapshots component "htmlelement" scenario: required matches 
         >
           Hello, world!
         </h1>
-        <div ref="messageContainer"
-             class="messages"
-        >
-        </div>
       </div>
     </div>
     <div ref="messageContainer"

--- a/__tests__/templates.js
+++ b/__tests__/templates.js
@@ -4,7 +4,7 @@ import '../dist/formio-sfds.standalone.js'
 
 describe('template tests', () => {
   describe('htmlelement component', () => {
-    const content = 'Hello, world!'
+    const expectedContent = 'Hello, world!'
     let form
     beforeAll(async () => {
       form = await createForm({
@@ -15,7 +15,12 @@ describe('template tests', () => {
             attrs: [
               { attr: 'id', value: 'foo' }
             ],
-            content
+            content: `
+              <div style="white-space: pre-wrap;">
+                  ${expectedContent}
+                  Your estimated total cost to reopen is
+                  \${{ 100 + (data.equipment || 0) }}.</div>
+            `
           }
         ]
       })
@@ -32,7 +37,12 @@ describe('template tests', () => {
     })
 
     it('renders content', async () => {
-      expect(form.element.querySelector('kbd').textContent).toContain(content)
+      expect(form.element.querySelector('kbd').textContent).toContain(expectedContent)
+    })
+
+    it('renders data in template strings (${{}})', () => {
+      expect(form.element.querySelector('kbd').textContent)
+        .toContain('$100')
     })
   })
 

--- a/__tests__/templates.js
+++ b/__tests__/templates.js
@@ -17,9 +17,9 @@ describe('template tests', () => {
             ],
             content: `
               <div style="white-space: pre-wrap;">
-                  ${expectedContent}
-                  Your estimated total cost to reopen is
-                  \${{ 100 + (data.equipment || 0) }}.</div>
+                ${expectedContent}
+                Your estimated total cost to reopen is \${{ 100 + (data.equipment || 0) }}.
+              </div>
             `
           }
         ]
@@ -40,25 +40,138 @@ describe('template tests', () => {
       expect(form.element.querySelector('kbd').textContent).toContain(expectedContent)
     })
 
-    it('renders data in template strings (${{}})', () => {
+    it('renders expressions in {{}} template strings', () => {
       expect(form.element.querySelector('kbd').textContent)
-        .toContain('$100')
+        .toContain('Your estimated total cost to reopen is $100.')
+    })
+  })
+
+  describe('htmlelement component', () => {
+    it('renders submission data in translated content strings', async () => {
+      const englishTemplate = 'My name is {{ data.name }}!'
+      const spanishTemplate = '¡Mi nombre es {{ data.name }}!'
+      // const translate = str => str.replace('{{ data.name }}', form.submission.data.name)
+      const form = await createForm({
+        components: [
+          {
+            type: 'hidden',
+            key: 'name'
+          },
+          {
+            type: 'htmlelement',
+            content: englishTemplate,
+            key: 'message'
+          }
+        ]
+      }, {
+        language: 'es',
+        i18n: {
+          es: {
+            'message.content': spanishTemplate
+          }
+        }
+      })
+
+      expect(form.language).toBe('es')
+
+      const data = {
+        name: 'Mud'
+      }
+
+      form.submission = { data }
+      await form.ready
+      await form.redraw()
+
+      const comp = form.components[1]
+      const expectedOutput = '¡Mi nombre es Mud!'
+      expect(comp.render()).toContain(expectedOutput)
+      expect(comp.renderContent()).toContain(expectedOutput)
+      expect(comp.rootValue).toEqual(data)
+      expect(comp.element.textContent.trim()).toContain(expectedOutput)
+
+      destroyForm(form)
     })
   })
 
   describe('content component', () => {
     it('renders content', async () => {
-      const content = 'This is the content!'
       const form = await createForm({
         components: [
           {
             type: 'content',
-            html: content
+            html: 'My name is Mud.',
+            refreshOnChange: true
           }
         ]
       })
 
-      expect(form.element.textContent).toContain(content)
+      expect(form.element.textContent).toContain('My name is Mud.')
+
+      destroyForm(form)
+    })
+
+    it('renders submission data in {{}} placeholders', async () => {
+      const form = await createForm({
+        components: [
+          {
+            type: 'textfield',
+            key: 'name',
+            label: 'Name'
+          },
+          {
+            type: 'content',
+            html: 'My name is {{ data.name }}!'
+          }
+        ]
+      })
+
+      await form.setSubmission({
+        data: {
+          name: 'Mud'
+        }
+      })
+
+      expect(form.element.textContent).toContain('My name is Mud!')
+
+      destroyForm(form)
+    })
+
+    it('renders submission data in translated content strings', async () => {
+      const englishTemplate = 'My name is {{ data.name }}!'
+      const spanishTemplate = '¡Mi nombre es {{ data.name }}!'
+      // const translate = str => str.replace('{{ data.name }}', form.submission.data.name)
+      const form = await createForm({
+        components: [
+          {
+            type: 'hidden',
+            key: 'name'
+          },
+          {
+            type: 'content',
+            html: englishTemplate,
+            key: 'message'
+          }
+        ]
+      }, {
+        language: 'es',
+        i18n: {
+          es: {
+            'message.html': spanishTemplate
+          }
+        }
+      })
+
+      expect(form.language).toBe('es')
+
+      const data = {
+        name: 'Mud'
+      }
+
+      await form.setSubmission({ data })
+
+      const expectedOutput = '¡Mi nombre es Mud!'
+      expect(form.components[1].render()).toContain(expectedOutput)
+      expect(form.element.textContent.trim()).toContain(expectedOutput)
 
       destroyForm(form)
     })

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -1,0 +1,18 @@
+const { content: ContentComponent } = window.Formio.Components.components
+
+export default class Content extends ContentComponent {
+  get content () {
+    const submission = this.root?.submission || {}
+    const html = this.t([`${this.component.key}.html`, this.component.html])
+    // console.warn('[%s] get content(): %s -> %s <-', this.component.type, this.component.html, html, this.rootValue)
+    const content = html
+      ? this.interpolate(html, {
+        metadata: submission.metadata || {},
+        submission: submission,
+        data: this.rootValue,
+        row: this.data
+      })
+      : ''
+    return content || ''
+  }
+}

--- a/src/components/htmlelement.js
+++ b/src/components/htmlelement.js
@@ -1,0 +1,17 @@
+const { htmlelement: FormioHTMLElementComponent } = window.Formio.Components.components
+
+export default class HTMLElementComponent extends FormioHTMLElementComponent {
+  get content () {
+    const submission = this.root?.submission || {}
+    const content = this.t([`${this.component.key}.content`, this.component.content])
+    // console.warn('[%s] get content(): %s -> %s <-', this.component.type, this.component.content, content, data)
+    return content
+      ? this.interpolate(content, {
+        metadata: submission.metadata || {},
+        submission,
+        data: this.rootValue,
+        row: this.data
+      })
+      : ''
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,14 +1,18 @@
 import address from './address'
-import review from './review'
 import columns from './columns'
+import content from './content'
+import htmlelement from './htmlelement'
+import review from './review'
 import signature from './signature'
 import state from './state'
 import zip from './zip'
 
 export default {
   address,
-  review,
   columns,
+  content,
+  htmlelement,
+  review,
   state,
   signature,
   zip

--- a/src/templates/component/form.ejs
+++ b/src/templates/component/form.ejs
@@ -6,7 +6,9 @@
 >
   {% if (ctx.visible) { %}
     {{ ctx.children }}
+    {% if (['content', 'htmlelement'].indexOf(ctx.component.type) === -1) { %}
     <div class="messages" ref="messageContainer"></div>
+    {% } %}
   {% } %}
 
   {% if (ctx.options.translate && ['panel', 'content', 'htmlelement'].indexOf(ctx.component.type) === -1) { %}

--- a/src/templates/html/form.ejs
+++ b/src/templates/html/form.ejs
@@ -3,4 +3,4 @@
   {% ctx.attrs.forEach(function(attr) { %}
     {{attr.attr}}="{{attr.value}}"
   {% }) %}
->{{ ctx.tk(key, ctx.content) }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}
+>{{ ctx.content }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}


### PR DESCRIPTION
This is a fix for EPR-1048 and long running issues with the way that the [content](https://help.form.io/userguide/form-building/layout-components#content) and [htmlelement](https://help.form.io/userguide/form-building/layout-components#html-element) components are translated. After some deep digging, I learned more about how formio.js renders the content in both of these components and figured out how to work around it in such a way that our translations work.

**TL;DR**: The `content` getter for both of these components' classes does the interpolation before the content hits our (shared) template, which is too late for us to translate it correctly. I wrote failing tests with a form schema that interpolate submission data into both components, then subclassed those component classes in our theme with a `content` getter that looks up the translation before interpolating. ✨ 

<details>
  <summary><h3>More details about the problem and fix if you're curious...</h3></summary>

Both of the components in question have a similar rendering process; the primary differences are:

* The HTML Element component's "content" field is `content` ((in the component schema, i.e. `component.content`), whereas for the Content component it's `html` 🙃 
* The HTML Element component does an additional [sanitization](https://github.com/formio/formio.js/wiki/Form-Sanitize-Config) step to strip out potentially dangerous markup. Oddly, the Content component can also render arbitrary HTML but _does not_ sanitize it 🙃 

**Anyway...** Both components read the component schema's "content" field directly in their `content` getters, and there are no hooks there for getting the translation before it's accessed. Then the interpolation happens in those getters and the interpolated text is passed to our (shared) template context, where it's passed through:

```js
this.tk('content', ctx.content)
// which is a shortcut for...
this.t(`${ctx.component.key}.content`, ctx.content)
// which boils down to...
this.t('key.content', 'Already interpolated string')
```

...which, if there's a translation registered for `key.content`, will evaluate to the translated string _without any data to interpolate_. So, I was faced with a choice:

1. Rewrite the `this.tk()` call in the shared template to re-implement the translation logic that should be in the `content` getter; or
2. Subclass the two components and override the `content` getters in them to do the right thing, and simplify the shared template to just output `ctx.content`

I went with option 2, and then I time-boxed option 1 to see if I could make it work, but it felt like a hack and I feel like it's better to keep as much code _out_ of the templates as possible, since it's not linted or tested in any way.

</details>